### PR TITLE
IPS-1185: Update step function canary interval

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1509,8 +1509,8 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: !Ref StepFunctionDeploymentPreference
-        Interval: 1
-        Percentage: 10
+        Interval: !If [IsProduction, 10, 5]
+        Percentage: !If [IsProduction, 10, 50]
         Alarms: !If
           - UseCanaryDeploymentAlarms
           - - !Ref JourneyEngineStepFunctionExecutionFailedCanaryAlarm


### PR DESCRIPTION
### What changed

- Update deployment strategy

### Why did it change

- To have different strategies in different envs
- To reflect change from `LINEAR` to `CANARY` in https://github.com/govuk-one-login/identity-common-infra/pull/630/files

<img width="500" alt="image" src="https://github.com/user-attachments/assets/c61d7e3e-7512-4ca4-9ca8-50176befda61" />

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1185](https://govukverify.atlassian.net/browse/IPS-1185)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1185]: https://govukverify.atlassian.net/browse/IPS-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ