### PR TITLE
PYIC-7832: Update journey map with new page

### DIFF
--- a/api-tests/features/cimit/enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/enhanced-verification-mitigation-dcmaw.feature
@@ -22,7 +22,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-suggest-other-options' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
 
   Rule: Same session journeys
 

--- a/api-tests/features/cimit/enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/enhanced-verification-mitigation-f2f.feature
@@ -20,7 +20,7 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-suggest-other-options' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
 
   Rule: Same session journeys
 

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -36,7 +36,7 @@ Feature: Disabled CRI journeys
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response with context 'dropout'
       When I submit an 'appTriage' event
       Then I get a 'pyi-technical' page response
 

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -36,7 +36,7 @@ Feature: Disabled CRI journeys
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-cri-escape' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-technical' page response
 
@@ -72,7 +72,7 @@ Feature: Disabled CRI journeys
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-suggest-other-options' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-technical' page response
 

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -87,7 +87,7 @@ Feature: Authoritative source checks with driving licence CRI
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-suggest-other-options' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
@@ -122,7 +122,7 @@ Feature: Authoritative source checks with driving licence CRI
     When I submit 'kenneth-score-0' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-cri-escape' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -157,7 +157,7 @@ Feature: Authoritative source checks with driving licence CRI
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-suggest-other-options' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
@@ -184,7 +184,7 @@ Feature: Authoritative source checks with driving licence CRI
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-suggest-other-options' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -122,7 +122,7 @@ Feature: Authoritative source checks with driving licence CRI
     When I submit 'kenneth-score-0' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response with context 'dropout'
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub

--- a/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
@@ -268,7 +268,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-suggest-other-options' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI

--- a/api-tests/features/inherited-identity/extended-scenarios.feature
+++ b/api-tests/features/inherited-identity/extended-scenarios.feature
@@ -20,7 +20,7 @@ Feature: Inherited identity extended scenarios
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-suggest-other-options' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
 
     # New journey with inherited identity - user still needs to mitigate the CI
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl250-passport'

--- a/api-tests/features/p1-journeys.feature
+++ b/api-tests/features/p1-journeys.feature
@@ -288,7 +288,7 @@ Feature: P1 journey
     When I submit 'kenneth-score-0' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response with context 'dropout'
 
   Scenario: P1 unsuccessful KBV questions for low confidence users with photo ID
     Given I activate the 'p1Journeys' feature set

--- a/api-tests/features/p1-journeys.feature
+++ b/api-tests/features/p1-journeys.feature
@@ -288,7 +288,7 @@ Feature: P1 journey
     When I submit 'kenneth-score-0' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'pyi-cri-escape' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
 
   Scenario: P1 unsuccessful KBV questions for low confidence users with photo ID
     Given I activate the 'p1Journeys' feature set
@@ -311,4 +311,4 @@ Feature: P1 journey
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'pyi-suggest-other-options' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -121,7 +121,7 @@ Feature: P2 Web document journey
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
     When I submit a 'end' event
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response with context 'dropout'
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -288,7 +288,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response with context 'dropout'
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -301,7 +301,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response with context 'dropout'
       When I submit an 'f2f' event
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
@@ -320,7 +320,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response with context 'dropout'
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -121,7 +121,7 @@ Feature: P2 Web document journey
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
     When I submit a 'end' event
-    Then I get a 'pyi-cri-escape' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -288,7 +288,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-cri-escape' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -301,7 +301,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-cri-escape' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response
       When I submit an 'f2f' event
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
@@ -320,7 +320,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-cri-escape' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -54,7 +54,7 @@ Feature: Return exit codes
     When I submit 'kenneth-score-0' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response with context 'dropout'
     When I submit a 'f2f' event
     Then I get a 'f2f' CRI response
     When I call the CRI stub with attributes and get an 'access_denied' OAuth error

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -54,7 +54,7 @@ Feature: Return exit codes
     When I submit 'kenneth-score-0' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-cri-escape' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
     When I submit a 'f2f' event
     Then I get a 'f2f' CRI response
     When I call the CRI stub with attributes and get an 'access_denied' OAuth error
@@ -131,7 +131,7 @@ Feature: Return exit codes
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-suggest-other-options' page response
+    Then I get a 'photo-id-security-questions-find-another-way' page response
     When I submit an 'f2f' event
     Then I get a 'f2f' CRI response
     When I call the CRI stub with attributes and get an 'access_denied' OAuth error

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -22,7 +22,7 @@ Feature: TICF failed/error journeys
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-suggest-other-options' page response
+      Then I get a 'photo-id-security-questions-find-another-way' page response
 
     Scenario: TICF failed enhanced-verification journey - PYI_NO_MATCH
       When I submit a 'appTriage' event

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -283,10 +283,10 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  PYI_CRI_ESCAPE:
+  PYI_KBV_DROPOUT_PHOTO_ID:
     response:
       type: page
-      pageId: pyi-cri-escape
+      pageId: photo-id-security-questions-find-another-way
     events:
       appTriage:
         targetState: APP_DOC_CHECK_PYI_ESCAPE
@@ -301,40 +301,18 @@ states:
       f2f:
         targetJourney: F2F_HAND_OFF
         targetState: START
-
-  PYI_CRI_ESCAPE_NO_F2F:
-    response:
-      type: page
-      pageId: pyi-cri-escape-no-f2f
-    events:
-      appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
+          f2f:
             targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
 
   # Common pages
   KBV_PHOTO_ID:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
-        targetState: PYI_CRI_ESCAPE
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
+        targetState: PYI_KBV_DROPOUT_PHOTO_ID
       end:
-        targetState: PYI_CRI_ESCAPE
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
+        targetState: PYI_KBV_DROPOUT_PHOTO_ID
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START
@@ -342,18 +320,11 @@ states:
           processCandidateIdentity:
             targetState: PROCESS_NEW_IDENTITY
       enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        targetState: PYI_KBV_DROPOUT_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
 
   # DCMAW journey (J1)
   POST_APP_DOC_CHECK_SUCCESS_PAGE:
@@ -455,14 +426,8 @@ states:
     exitEvents:
       fail-with-no-ci:
         targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
       end:
         targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START
@@ -471,13 +436,6 @@ states:
             targetState: PROCESS_NEW_IDENTITY
       enhanced-verification:
         targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
@@ -658,24 +616,6 @@ states:
         targetState: INELIGIBLE
 
   # Mitigation journey (02)
-  MITIGATION_02_OPTIONS:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options-no-f2f
-    events:
-      appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
 
   STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
     nestedJourney: STRATEGIC_APP_TRIAGE
@@ -741,25 +681,6 @@ states:
         checkFeatureFlag:
           processCandidateIdentity:
             targetState: PROCESS_INCOMPLETE_IDENTITY
-
-  MITIGATION_02_OPTIONS_WITH_F2F:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-      appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
 
   PYI_POST_OFFICE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -287,6 +287,7 @@ states:
     response:
       type: page
       pageId: photo-id-security-questions-find-another-way
+      context: dropout
     events:
       appTriage:
         targetState: APP_DOC_CHECK_PYI_ESCAPE
@@ -306,6 +307,44 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
+  PYI_CRI_ESCAPE:
+    response:
+      type: page
+      pageId: pyi-cri-escape
+    events:
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+
+  PYI_CRI_ESCAPE_NO_F2F:
+    response:
+      type: page
+      pageId: pyi-cri-escape-no-f2f
+    events:
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
   # Common pages
   KBV_PHOTO_ID:
     nestedJourney: KBVS
@@ -321,7 +360,7 @@ states:
           processCandidateIdentity:
             targetState: PROCESS_NEW_IDENTITY
       enhanced-verification:
-        targetState: PYI_KBV_DROPOUT_PHOTO_ID
+        targetState: MITIGATION_KBV_FAIL_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
@@ -450,6 +489,10 @@ states:
       f2f:
         targetJourney: F2F_HAND_OFF
         targetState: START
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       appTriage:
         targetState: APP_DOC_CHECK_PYI_ESCAPE
         targetEntryEvent: next
@@ -500,6 +543,10 @@ states:
       f2f:
         targetJourney: F2F_HAND_OFF
         targetState: START
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       appTriage:
         targetState: APP_DOC_CHECK_PYI_ESCAPE
         targetEntryEvent: next
@@ -617,6 +664,24 @@ states:
         targetState: INELIGIBLE
 
   # Mitigation journey (02)
+  MITIGATION_02_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options-no-f2f
+    events:
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
 
   STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
     nestedJourney: STRATEGIC_APP_TRIAGE
@@ -682,6 +747,48 @@ states:
         checkFeatureFlag:
           processCandidateIdentity:
             targetState: PROCESS_INCOMPLETE_IDENTITY
+
+  MITIGATION_02_OPTIONS_WITH_F2F:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  MITIGATION_KBV_FAIL_PHOTO_ID:
+    response:
+      type: page
+      pageId: photo-id-security-questions-find-another-way
+    events:
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
 
   PYI_POST_OFFICE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -303,6 +303,7 @@ states:
         targetState: START
         checkIfDisabled:
           f2f:
+            targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
   # Common pages

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -336,6 +336,7 @@ states:
         targetState: START
         checkIfDisabled:
           f2f:
+            targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
   # Common pages

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -316,10 +316,10 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  PYI_CRI_ESCAPE:
+  PYI_KBV_DROPOUT_PHOTO_ID:
     response:
       type: page
-      pageId: pyi-cri-escape
+      pageId: photo-id-security-questions-find-another-way
     events:
       appTriage:
         targetState: APP_DOC_CHECK_PYI_ESCAPE
@@ -334,40 +334,18 @@ states:
       f2f:
         targetJourney: F2F_HAND_OFF
         targetState: START
-
-  PYI_CRI_ESCAPE_NO_F2F:
-    response:
-      type: page
-      pageId: pyi-cri-escape-no-f2f
-    events:
-      appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
+          f2f:
             targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
 
   # Common pages
   KBV_PHOTO_ID:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
-        targetState: PYI_CRI_ESCAPE
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
+        targetState: PYI_KBV_DROPOUT_PHOTO_ID
       end:
-        targetState: PYI_CRI_ESCAPE
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
+        targetState: PYI_KBV_DROPOUT_PHOTO_ID
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START
@@ -375,18 +353,11 @@ states:
           processCandidateIdentity:
             targetState: PROCESS_NEW_IDENTITY
       enhanced-verification:
-        targetState: MITIGATION_02_OPTIONS_WITH_F2F
+        targetState: PYI_KBV_DROPOUT_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: enhanced-verification
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
 
   # DCMAW journey (J1)
   POST_APP_DOC_CHECK_SUCCESS_PAGE:
@@ -502,14 +473,8 @@ states:
     exitEvents:
       fail-with-no-ci:
         targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
       end:
         targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_CRI_ESCAPE_NO_F2F
       next:
         targetJourney: EVALUATE_SCORES
         targetState: START
@@ -518,13 +483,6 @@ states:
             targetState: PROCESS_NEW_IDENTITY
       enhanced-verification:
         targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
-        checkIfDisabled:
-          f2f:
-            targetState: MITIGATION_02_OPTIONS
-            auditEvents:
-              - IPV_MITIGATION_START
-            auditContext:
-              mitigationType: enhanced-verification
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
@@ -718,24 +676,6 @@ states:
         targetState: INELIGIBLE
 
   # Mitigation journey (02)
-  MITIGATION_02_OPTIONS:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options-no-f2f
-    events:
-      appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
 
   STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
     nestedJourney: STRATEGIC_APP_TRIAGE
@@ -801,25 +741,6 @@ states:
         checkFeatureFlag:
           processCandidateIdentity:
             targetState: PROCESS_INCOMPLETE_IDENTITY
-
-  MITIGATION_02_OPTIONS_WITH_F2F:
-    response:
-      type: page
-      pageId: pyi-suggest-other-options
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START
-      appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmaw:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
 
   PYI_POST_OFFICE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -320,6 +320,7 @@ states:
     response:
       type: page
       pageId: photo-id-security-questions-find-another-way
+      context: dropout
     events:
       appTriage:
         targetState: APP_DOC_CHECK_PYI_ESCAPE
@@ -339,6 +340,44 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
+  PYI_CRI_ESCAPE:
+    response:
+      type: page
+      pageId: pyi-cri-escape
+    events:
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+
+  PYI_CRI_ESCAPE_NO_F2F:
+    response:
+      type: page
+      pageId: pyi-cri-escape-no-f2f
+    events:
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
   # Common pages
   KBV_PHOTO_ID:
     nestedJourney: KBVS
@@ -354,7 +393,7 @@ states:
           processCandidateIdentity:
             targetState: PROCESS_NEW_IDENTITY
       enhanced-verification:
-        targetState: PYI_KBV_DROPOUT_PHOTO_ID
+        targetState: MITIGATION_KBV_FAIL_PHOTO_ID
         auditEvents:
           - IPV_MITIGATION_START
         auditContext:
@@ -497,6 +536,10 @@ states:
       f2f:
         targetJourney: F2F_HAND_OFF
         targetState: START
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       appTriage:
         targetState: APP_DOC_CHECK_PYI_ESCAPE
         targetEntryEvent: next
@@ -560,6 +603,10 @@ states:
       f2f:
         targetJourney: F2F_HAND_OFF
         targetState: START
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       appTriage:
         targetState: APP_DOC_CHECK_PYI_ESCAPE
         targetEntryEvent: next
@@ -677,6 +724,24 @@ states:
         targetState: INELIGIBLE
 
   # Mitigation journey (02)
+  MITIGATION_02_OPTIONS:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options-no-f2f
+    events:
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
 
   STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
     nestedJourney: STRATEGIC_APP_TRIAGE
@@ -742,6 +807,48 @@ states:
         checkFeatureFlag:
           processCandidateIdentity:
             targetState: PROCESS_INCOMPLETE_IDENTITY
+
+  MITIGATION_02_OPTIONS_WITH_F2F:
+    response:
+      type: page
+      pageId: pyi-suggest-other-options
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  MITIGATION_KBV_FAIL_PHOTO_ID:
+    response:
+      type: page
+      pageId: photo-id-security-questions-find-another-way
+    events:
+      appTriage:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
 
   PYI_POST_OFFICE:
     response:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

pyi-cri-escape and pyi-suggest-other-options templates will now be combined into a single dynamic template with URL 

photo-id-security-questions-find-another-way This also remove the no-F2F versions of this page and route to error in the case F2F is disabled

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7832](https://govukverify.atlassian.net/browse/PYIC-7832)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7832]: https://govukverify.atlassian.net/browse/PYIC-7832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ