### PR TITLE
BAU: Use local mode for AWS EMF when running tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,13 @@ subprojects {
 	configurations.all {
 		exclude group: 'software.amazon.awssdk', module: 'apache-client'
 	}
+
+	tasks.withType(Test) {
+		// Configures environment variables to avoid errors in AWS X-Ray and EMF loggers
+		environment "LAMBDA_TASK_ROOT", "handler"
+		environment 'AWS_EMF_ENVIRONMENT', 'Local'
+		environment 'AWS_XRAY_CONTEXT_MISSING', 'IGNORE_ERROR'
+	}
 }
 
 allprojects {

--- a/lambdas/build-client-oauth-response/build.gradle
+++ b/lambdas/build-client-oauth-response/build.gradle
@@ -25,8 +25,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/build-cri-oauth-request/build.gradle
+++ b/lambdas/build-cri-oauth-request/build.gradle
@@ -32,8 +32,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/build-proven-user-identity-details/build.gradle
+++ b/lambdas/build-proven-user-identity-details/build.gradle
@@ -29,8 +29,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -30,8 +30,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 	exclude 'uk/gov/di/ipv/core/builduseridentity/pact/**'

--- a/lambdas/call-dcmaw-async-cri/build.gradle
+++ b/lambdas/call-dcmaw-async-cri/build.gradle
@@ -31,8 +31,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 	exclude 'uk/gov/di/ipv/core/calldcmawasynccri/pact/**'

--- a/lambdas/call-ticf-cri/build.gradle
+++ b/lambdas/call-ticf-cri/build.gradle
@@ -30,8 +30,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 	exclude 'uk/gov/di/ipv/core/callticfcri/pact/**'

--- a/lambdas/check-coi/build.gradle
+++ b/lambdas/check-coi/build.gradle
@@ -28,8 +28,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -36,8 +36,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/check-gpg45-score/build.gradle
+++ b/lambdas/check-gpg45-score/build.gradle
@@ -29,8 +29,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/check-mobile-app-vc-receipt/build.gradle
+++ b/lambdas/check-mobile-app-vc-receipt/build.gradle
@@ -35,8 +35,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 	exclude 'uk/gov/di/ipv/core/checkmobileappvcreceipt/pact/**'

--- a/lambdas/check-reverification-identity/build.gradle
+++ b/lambdas/check-reverification-identity/build.gradle
@@ -28,8 +28,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -30,8 +30,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -35,8 +35,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -32,8 +32,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 	exclude 'uk/gov/di/ipv/core/issueclientaccesstoken/pact/**'

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -33,8 +33,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/process-candidate-identity/build.gradle
+++ b/lambdas/process-candidate-identity/build.gradle
@@ -32,8 +32,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -37,8 +37,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 	exclude 'uk/gov/di/ipv/core/processcricallback/pact/**'

--- a/lambdas/process-journey-event/build.gradle
+++ b/lambdas/process-journey-event/build.gradle
@@ -30,8 +30,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/process-mobile-app-callback/build.gradle
+++ b/lambdas/process-mobile-app-callback/build.gradle
@@ -29,8 +29,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 	exclude 'uk/gov/di/ipv/core/processmobileappcallback/pact/**'

--- a/lambdas/reset-session-identity/build.gradle
+++ b/lambdas/reset-session-identity/build.gradle
@@ -28,8 +28,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/store-identity/build.gradle
+++ b/lambdas/store-identity/build.gradle
@@ -27,8 +27,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/lambdas/user-reverification/build.gradle
+++ b/lambdas/user-reverification/build.gradle
@@ -29,8 +29,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 	exclude 'uk/gov/di/ipv/core/userreverification/pact/**'

--- a/libs/cri-api-service/build.gradle
+++ b/libs/cri-api-service/build.gradle
@@ -45,8 +45,6 @@ tasks.named('jar') {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/libs/evcs-service/build.gradle
+++ b/libs/evcs-service/build.gradle
@@ -49,8 +49,6 @@ tasks.named('jar') {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/libs/oauth-key-service/build.gradle
+++ b/libs/oauth-key-service/build.gradle
@@ -44,8 +44,6 @@ tasks.named('jar') {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/libs/ticf-cri-service/build.gradle
+++ b/libs/ticf-cri-service/build.gradle
@@ -32,8 +32,6 @@ java {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -49,8 +49,6 @@ tasks.named('jar') {
 }
 
 test {
-	// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-	environment "LAMBDA_TASK_ROOT", "handler"
 	useJUnitPlatform ()
 	finalizedBy jacocoTestReport
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added common environment variables for all test processes, to configure the AWS X-Ray and EMF libraries to work appropriately for local running.

### Why did it change

The test output has a lot of noise where the powertools libs fail to write logs (as they are not running in an AWS environment).
