### PR TITLE
PYIC-7931: Add old+new address to CoI end audit event

### DIFF
--- a/api-tests/data/audit-events/reprove-identity-journey.json
+++ b/api-tests/data/audit-events/reprove-identity-journey.json
@@ -232,6 +232,32 @@
           "value": "1965-07-08"
         }
       ],
+      "oldAddress": [
+        {
+          "addressCountry": "GB",
+          "uprn": 100120012077,
+          "buildingName": "",
+          "streetName": "HADLEY ROAD",
+          "postalCode": "BA2 5AA",
+          "buildingNumber": "8",
+          "addressLocality": "BATH",
+          "validFrom": "1000-01-01",
+          "subBuildingName": ""
+        }
+      ],
+      "newAddress": [
+        {
+          "addressCountry": "GB",
+          "uprn": 100120012077,
+          "buildingName": "",
+          "streetName": "HADLEY ROAD",
+          "postalCode": "BA2 5AA",
+          "buildingNumber": "8",
+          "addressLocality": "BATH",
+          "validFrom": "1000-01-01",
+          "subBuildingName": ""
+        }
+      ],
       "device_information": {}
     }
   },

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -397,6 +397,32 @@
           "value": "1965-07-08"
         }
       ],
+      "oldAddress": [
+        {
+          "addressCountry": "GB",
+          "uprn": 100120012077,
+          "buildingName": "",
+          "streetName": "HADLEY ROAD",
+          "postalCode": "BA2 5AA",
+          "buildingNumber": "8",
+          "addressLocality": "BATH",
+          "validFrom": "1000-01-01",
+          "subBuildingName": ""
+        }
+      ],
+      "newAddress": [
+        {
+          "addressCountry": "GB",
+          "uprn": 100120012047,
+          "buildingName": "",
+          "streetName": "King Road",
+          "postalCode": "BS9 6NR",
+          "buildingNumber": "28",
+          "addressLocality": "BRISTOL",
+          "validFrom": "1000-01-01",
+          "subBuildingName": ""
+        }
+      ],
       "device_information": {}
     }
   },

--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -42,9 +42,11 @@ import uk.gov.di.ipv.core.library.service.EvcsService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
+import uk.gov.di.model.PostalAddress;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.Boolean.TRUE;
@@ -261,14 +263,22 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
             List<VerifiableCredential> sessionVcs,
             String deviceInformation)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException {
+
         var oldIdentityClaim = userIdentityService.findIdentityClaim(oldVcs);
         var sessionIdentityClaim = userIdentityService.findIdentityClaim(sessionVcs);
+
+        Optional<List<PostalAddress>> oldAddressClaim =
+                userIdentityService.generateAddressClaim(oldVcs);
+        Optional<List<PostalAddress>> sessionAddressClaim =
+                userIdentityService.generateAddressClaim(sessionVcs);
 
         return new AuditRestrictedCheckCoi(
                 oldIdentityClaim.map(IdentityClaim::getName).orElse(null),
                 sessionIdentityClaim.map(IdentityClaim::getName).orElse(null),
                 oldIdentityClaim.map(IdentityClaim::getBirthDate).orElse(null),
                 sessionIdentityClaim.map(IdentityClaim::getBirthDate).orElse(null),
+                oldAddressClaim.orElse(null),
+                sessionAddressClaim.orElse(null),
                 new DeviceInformation(deviceInformation));
     }
 

--- a/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
+++ b/lambdas/check-coi/src/test/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.testhelpers.unit.LogCollector;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.model.NamePart;
+import uk.gov.di.model.PostalAddress;
 
 import java.util.List;
 import java.util.Map;
@@ -126,6 +127,13 @@ class CheckCoiHandlerTest {
         void setup() throws Exception {
             when(mockUserIdentityService.findIdentityClaim(any()))
                     .thenReturn(getMockIdentityClaim());
+
+            PostalAddress address = new PostalAddress();
+            address.setAddressCountry("AnyCountry");
+            address.setAddressLocality("AnyTown");
+            address.setAddressRegion("AnyRegion");
+            when(mockUserIdentityService.generateAddressClaim(any()))
+                    .thenReturn(Optional.of(List.of(address)));
         }
 
         private Optional<IdentityClaim> getMockIdentityClaim() {
@@ -141,7 +149,7 @@ class CheckCoiHandlerTest {
         @DisplayName("Successful checks")
         class SuccessfulChecks {
             @Test
-            void shouldReturnPassedForSuccessfulNamesAndDobCheck() throws Exception {
+            void shouldReturnPassedForSuccessfulNamesAndDobAndAddressCheck() throws Exception {
                 when(mockUserIdentityService.areNamesAndDobCorrelated(
                                 List.of(M1A_ADDRESS_VC, M1A_EXPERIAN_FRAUD_VC)))
                         .thenReturn(true);
@@ -179,6 +187,8 @@ class CheckCoiHandlerTest {
                 assertTrue(restrictedAuditData.has("oldName"));
                 assertTrue(restrictedAuditData.has("newBirthDate"));
                 assertTrue(restrictedAuditData.has("oldBirthDate"));
+                assertTrue(restrictedAuditData.has("oldAddress"));
+                assertTrue(restrictedAuditData.has("newAddress"));
                 assertTrue(restrictedAuditData.has("device_information"));
             }
 
@@ -221,6 +231,8 @@ class CheckCoiHandlerTest {
                 assertTrue(restrictedAuditData.has("oldName"));
                 assertTrue(restrictedAuditData.has("newBirthDate"));
                 assertTrue(restrictedAuditData.has("oldBirthDate"));
+                assertTrue(restrictedAuditData.has("oldAddress"));
+                assertTrue(restrictedAuditData.has("newAddress"));
                 assertTrue(restrictedAuditData.has("device_information"));
             }
 
@@ -262,6 +274,8 @@ class CheckCoiHandlerTest {
                 assertTrue(restrictedAuditData.has("oldName"));
                 assertTrue(restrictedAuditData.has("newBirthDate"));
                 assertTrue(restrictedAuditData.has("oldBirthDate"));
+                assertTrue(restrictedAuditData.has("oldAddress"));
+                assertTrue(restrictedAuditData.has("newAddress"));
                 assertTrue(restrictedAuditData.has("device_information"));
             }
 
@@ -307,6 +321,8 @@ class CheckCoiHandlerTest {
                 assertTrue(restrictedAuditData.has("oldName"));
                 assertTrue(restrictedAuditData.has("newBirthDate"));
                 assertTrue(restrictedAuditData.has("oldBirthDate"));
+                assertTrue(restrictedAuditData.has("oldAddress"));
+                assertTrue(restrictedAuditData.has("newAddress"));
                 assertTrue(restrictedAuditData.has("device_information"));
             }
 
@@ -351,6 +367,8 @@ class CheckCoiHandlerTest {
                 assertFalse(restrictedAuditData.has("oldName"));
                 assertFalse(restrictedAuditData.has("newBirthDate"));
                 assertFalse(restrictedAuditData.has("oldBirthDate"));
+                assertTrue(restrictedAuditData.has("oldAddress"));
+                assertTrue(restrictedAuditData.has("newAddress"));
                 assertTrue(restrictedAuditData.has("device_information"));
             }
         }
@@ -397,6 +415,8 @@ class CheckCoiHandlerTest {
                 assertTrue(restrictedAuditData.has("oldName"));
                 assertTrue(restrictedAuditData.has("newBirthDate"));
                 assertTrue(restrictedAuditData.has("oldBirthDate"));
+                assertTrue(restrictedAuditData.has("oldAddress"));
+                assertTrue(restrictedAuditData.has("newAddress"));
                 assertTrue(restrictedAuditData.has("device_information"));
             }
 
@@ -475,6 +495,8 @@ class CheckCoiHandlerTest {
                 assertTrue(restrictedAuditData.has("oldName"));
                 assertTrue(restrictedAuditData.has("newBirthDate"));
                 assertTrue(restrictedAuditData.has("oldBirthDate"));
+                assertTrue(restrictedAuditData.has("oldAddress"));
+                assertTrue(restrictedAuditData.has("newAddress"));
                 assertTrue(restrictedAuditData.has("device_information"));
             }
         }

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiService.java
@@ -30,8 +30,10 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.EvcsService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
+import uk.gov.di.model.PostalAddress;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.Boolean.TRUE;
@@ -181,14 +183,22 @@ public class CheckCoiService {
             List<VerifiableCredential> sessionVcs,
             String deviceInformation)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException {
+
         var oldIdentityClaim = userIdentityService.findIdentityClaim(oldVcs);
         var sessionIdentityClaim = userIdentityService.findIdentityClaim(sessionVcs);
+
+        Optional<List<PostalAddress>> oldAddressClaim =
+                userIdentityService.generateAddressClaim(oldVcs);
+        Optional<List<PostalAddress>> sessionAddressClaim =
+                userIdentityService.generateAddressClaim(sessionVcs);
 
         return new AuditRestrictedCheckCoi(
                 oldIdentityClaim.map(IdentityClaim::getName).orElse(null),
                 sessionIdentityClaim.map(IdentityClaim::getName).orElse(null),
                 oldIdentityClaim.map(IdentityClaim::getBirthDate).orElse(null),
                 sessionIdentityClaim.map(IdentityClaim::getBirthDate).orElse(null),
+                oldAddressClaim.orElse(null),
+                sessionAddressClaim.orElse(null),
                 new DeviceInformation(deviceInformation));
     }
 }

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.model.NamePart;
+import uk.gov.di.model.PostalAddress;
 
 import java.util.List;
 import java.util.Optional;
@@ -76,10 +77,17 @@ class CheckCoiServiceTest {
                 .thenReturn("some-component-id");
 
         when(mockUserIdentityService.findIdentityClaim(any())).thenReturn(getMockIdentityClaim());
+
+        PostalAddress address = new PostalAddress();
+        address.setAddressCountry("AnyCountry");
+        address.setAddressLocality("AnyTown");
+        address.setAddressRegion("AnyRegion");
+        when(mockUserIdentityService.generateAddressClaim(any()))
+                .thenReturn(Optional.of(List.of(address)));
     }
 
     @Test
-    void shouldReturnTrueForSuccessfulNamesAndDobCheck() throws Exception {
+    void shouldReturnTrueForSuccessfulNamesAndDobAndAddressCheck() throws Exception {
         // Arrange
         when(mockUserIdentityService.areNamesAndDobCorrelated(any())).thenReturn(true);
 
@@ -121,12 +129,13 @@ class CheckCoiServiceTest {
         assertEquals(
                 new AuditExtensionCoiCheck(STANDARD, true),
                 auditEventsCaptured.get(1).getExtensions());
-
         var restrictedAuditData = getRestrictedAuditDataNodeFromEvent(auditEventsCaptured.get(1));
         assertTrue(restrictedAuditData.has("newName"));
         assertTrue(restrictedAuditData.has("oldName"));
         assertTrue(restrictedAuditData.has("newBirthDate"));
         assertTrue(restrictedAuditData.has("oldBirthDate"));
+        assertTrue(restrictedAuditData.has("oldAddress"));
+        assertTrue(restrictedAuditData.has("newAddress"));
         assertTrue(restrictedAuditData.has("device_information"));
     }
 
@@ -273,6 +282,8 @@ class CheckCoiServiceTest {
         assertFalse(restrictedAuditData.has("oldName"));
         assertFalse(restrictedAuditData.has("newBirthDate"));
         assertFalse(restrictedAuditData.has("oldBirthDate"));
+        assertTrue(restrictedAuditData.has("oldAddress"));
+        assertTrue(restrictedAuditData.has("newAddress"));
         assertTrue(restrictedAuditData.has("device_information"));
     }
 
@@ -325,6 +336,8 @@ class CheckCoiServiceTest {
         assertTrue(restrictedAuditData.has("oldName"));
         assertTrue(restrictedAuditData.has("newBirthDate"));
         assertTrue(restrictedAuditData.has("oldBirthDate"));
+        assertTrue(restrictedAuditData.has("oldAddress"));
+        assertTrue(restrictedAuditData.has("newAddress"));
         assertTrue(restrictedAuditData.has("device_information"));
     }
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/restricted/AuditRestrictedCheckCoi.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.model.BirthDate;
 import uk.gov.di.model.Name;
+import uk.gov.di.model.PostalAddress;
 
 import java.util.List;
 
@@ -14,6 +15,8 @@ public record AuditRestrictedCheckCoi(
         @JsonInclude(JsonInclude.Include.NON_NULL) List<Name> newName,
         @JsonInclude(JsonInclude.Include.NON_NULL) List<BirthDate> oldBirthDate,
         @JsonInclude(JsonInclude.Include.NON_NULL) List<BirthDate> newBirthDate,
+        @JsonInclude(JsonInclude.Include.NON_NULL) List<PostalAddress> oldAddress,
+        @JsonInclude(JsonInclude.Include.NON_NULL) List<PostalAddress> newAddress,
         @JsonProperty(value = "device_information", required = true)
                 DeviceInformation deviceInformation)
         implements AuditRestrictedWithDeviceInformation {}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add old+new address (in the same JSON format as stored on the VC) to the restricted extensions alongside name and DOB

### Why did it change

Fraud have an audit requirement to be able to track changes users are making to their addresses and, in the context of intl' addresses, changing from a UK to a non-UK address and vice versa. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7931](https://govukverify.atlassian.net/browse/PYIC-7931)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-7931]: https://govukverify.atlassian.net/browse/PYIC-7931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ