### PR TITLE
PYIC-7926: audit events api tests

### DIFF
--- a/api-tests/data/audit-events/alternate-doc-mitigation-journey.json
+++ b/api-tests/data/audit-events/alternate-doc-mitigation-journey.json
@@ -67,7 +67,7 @@
       ],
       "successful": false,
       "isUkIssued": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/alternate-doc-mitigation-journey.json
+++ b/api-tests/data/audit-events/alternate-doc-mitigation-journey.json
@@ -1,0 +1,104 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "NEW_P2_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CRI_AUTH_RESPONSE_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "error_code": "access_denied",
+      "error_description": "No error description provided"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://driving-license-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 0,
+          "ci": ["NEEDS-ALTERNATE-DOC"],
+          "failedCheckDetails": [
+            {
+              "checkMethod": "data",
+              "identityCheckPolicy": "published"
+            }
+          ],
+          "strengthScore": 3,
+          "type": "IdentityCheck",
+          "validityScore": 0
+        }
+      ],
+      "successful": false,
+      "isUkIssued": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "drivingLicence",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_MITIGATION_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "mitigation_type": "invalid-dl"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  }
+]

--- a/api-tests/data/audit-events/delete-pending-f2f-journey.json
+++ b/api-tests/data/audit-events/delete-pending-f2f-journey.json
@@ -34,7 +34,7 @@
       "iss": "https://claimed-identity-cri.stubs.account.gov.uk",
       "evidence": null,
       "successful": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}
@@ -125,7 +125,7 @@
         }
       ],
       "successful": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/delete-pending-f2f-journey.json
+++ b/api-tests/data/audit-events/delete-pending-f2f-journey.json
@@ -1,0 +1,246 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "NEW_P2_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://claimed-identity-cri.stubs.account.gov.uk",
+      "evidence": null,
+      "successful": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "claimedIdentity",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://address-cri.stubs.account.gov.uk",
+      "evidence": null,
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "address",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://fraud-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 1,
+          "checkDetails": [
+            {
+              "activityFrom": "1963-01-01",
+              "checkMethod": "data",
+              "identityCheckPolicy": "none"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "mortality_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "identity_theft_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "synthetic_identity_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "impersonation_risk_check"
+            }
+          ],
+          "ci": [],
+          "identityFraudScore": 2,
+          "type": "IdentityCheck"
+        }
+      ],
+      "successful": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "fraud",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "F2F_HAND_OFF"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "f2f",
+      "type": "pending"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "pending",
+      "vot": null
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "F2F_PENDING"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_F2F_USER_CANCEL_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_F2F_USER_CANCEL_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  }
+]

--- a/api-tests/data/audit-events/inherited-identity-journey.json
+++ b/api-tests/data/audit-events/inherited-identity-journey.json
@@ -1,0 +1,111 @@
+[
+  {
+    "event_name": "IPV_INHERITED_IDENTITY_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://orch.stubs.account.gov.uk/migration/v1",
+      "evidence": [],
+      "vot": "PCL200",
+      "age": 55
+    },
+    "restricted": {
+      "name": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "Alice"
+            },
+            {
+              "type": "GivenName",
+              "value": "Jane"
+            },
+            {
+              "type": "FamilyName",
+              "value": "Doe"
+            }
+          ]
+        }
+      ],
+      "birthDate": [
+        {
+          "value": "1970-01-01"
+        }
+      ],
+      "socialSecurityRecord": null,
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2", "PCL200", "PCL250"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "OPERATIONAL_PROFILE_MIGRATION"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_ISSUED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "levelOfConfidence": "PCL200",
+      "ciFail": false,
+      "hasMitigations": false,
+      "returnCodes": []
+    }
+  }
+]

--- a/api-tests/data/audit-events/inherited-identity-journey.json
+++ b/api-tests/data/audit-events/inherited-identity-journey.json
@@ -6,7 +6,7 @@
       "iss": "https://orch.stubs.account.gov.uk/migration/v1",
       "evidence": [],
       "vot": "PCL200",
-      "age": 55
+      "age": "type[number]"
     },
     "restricted": {
       "name": [

--- a/api-tests/data/audit-events/international-address-journey.json
+++ b/api-tests/data/audit-events/international-address-journey.json
@@ -1,0 +1,58 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "NEW_P2_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "NEW_P2_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_INTERNATIONAL_ADDRESS_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  }
+]

--- a/api-tests/data/audit-events/new-identity-f2f-journey.json
+++ b/api-tests/data/audit-events/new-identity-f2f-journey.json
@@ -1,0 +1,386 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "NEW_P2_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://claimed-identity-cri.stubs.account.gov.uk",
+      "evidence": null,
+      "successful": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "claimedIdentity",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://address-cri.stubs.account.gov.uk",
+      "evidence": null,
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "address",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://fraud-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 1,
+          "checkDetails": [
+            {
+              "activityFrom": "1963-01-01",
+              "checkMethod": "data",
+              "identityCheckPolicy": "none"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "mortality_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "identity_theft_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "synthetic_identity_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "impersonation_risk_check"
+            }
+          ],
+          "ci": [],
+          "identityFraudScore": 2,
+          "type": "IdentityCheck"
+        }
+      ],
+      "successful": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "fraud",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "F2F_HAND_OFF"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "f2f",
+      "type": "pending"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "pending",
+      "vot": null
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "F2F_PENDING"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_F2F_CRI_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://f2f-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "checkDetails": [
+            {
+              "checkMethod": "vri",
+              "identityCheckPolicy": "published"
+            },
+            {
+              "checkMethod": "pvr",
+              "photoVerificationProcessLevel": 3
+            }
+          ],
+          "strengthScore": 3,
+          "type": "IdentityCheck",
+          "validityScore": 2,
+          "verificationScore": 3
+        }
+      ],
+      "successful": true,
+      "isUkIssued": true,
+      "age": 59
+    }
+  },
+  {
+    "event_name": "IPV_F2F_CRI_VC_CONSUMED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "name": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "KENNETH"
+            },
+            {
+              "type": "FamilyName",
+              "value": "DECERQUEIRA"
+            }
+          ]
+        }
+      ],
+      "docExpiryDate": "2033-01-18"
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "REUSE_EXISTING_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "new",
+      "vot": "P2"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_ISSUED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "levelOfConfidence": "P2",
+      "ciFail": false,
+      "hasMitigations": false,
+      "returnCodes": []
+    }
+  }
+]

--- a/api-tests/data/audit-events/new-identity-f2f-journey.json
+++ b/api-tests/data/audit-events/new-identity-f2f-journey.json
@@ -34,7 +34,7 @@
       "iss": "https://claimed-identity-cri.stubs.account.gov.uk",
       "evidence": null,
       "successful": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}
@@ -125,7 +125,7 @@
         }
       ],
       "successful": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}
@@ -254,7 +254,7 @@
       ],
       "successful": true,
       "isUkIssued": true,
-      "age": 59
+      "age": "type[number]"
     }
   },
   {

--- a/api-tests/data/audit-events/new-identity-p2-app-journey.json
+++ b/api-tests/data/audit-events/new-identity-p2-app-journey.json
@@ -51,7 +51,7 @@
       ],
       "successful": true,
       "isUkIssued": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}
@@ -142,7 +142,7 @@
         }
       ],
       "successful": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/new-identity-p2-app-journey.json
+++ b/api-tests/data/audit-events/new-identity-p2-app-journey.json
@@ -100,7 +100,10 @@
   },
   {
     "event_name": "IPV_REDIRECT_TO_CRI",
-    "component_id": "https://identity.local.account.gov.uk"
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
   },
   {
     "event_name": "IPV_VC_RECEIVED",
@@ -182,7 +185,7 @@
         "fraud": 2,
         "verification": 3
       },
-      "vcTxnIds": ["RB000117420948", "3fc67c56-74da-402c-b906-49bb4a06ed23"]
+      "vcTxnIds": []
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/new-identity-p2-journey.json
+++ b/api-tests/data/audit-events/new-identity-p2-journey.json
@@ -1,0 +1,246 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "NEW_P2_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://dcmaw-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 1,
+          "checkDetails": [
+            {
+              "checkMethod": "vri"
+            },
+            {
+              "biometricVerificationProcessLevel": 3,
+              "checkMethod": "bvr"
+            }
+          ],
+          "strengthScore": 4,
+          "type": "IdentityCheck",
+          "validityScore": 3
+        }
+      ],
+      "successful": true,
+      "isUkIssued": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "dcmaw",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://address-cri.stubs.account.gov.uk",
+      "evidence": null,
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "address",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk"
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://fraud-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 1,
+          "checkDetails": [
+            {
+              "activityFrom": "1963-01-01",
+              "checkMethod": "data",
+              "identityCheckPolicy": "none"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "mortality_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "identity_theft_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "synthetic_identity_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "impersonation_risk_check"
+            }
+          ],
+          "ci": [],
+          "identityFraudScore": 2,
+          "type": "IdentityCheck"
+        }
+      ],
+      "successful": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "fraud",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "EVALUATE_SCORES"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1A",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 4,
+            "validity": 3
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": ["RB000117420948", "3fc67c56-74da-402c-b906-49bb4a06ed23"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "new",
+      "vot": "P2"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_ISSUED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "levelOfConfidence": "P2",
+      "ciFail": false,
+      "hasMitigations": false,
+      "returnCodes": []
+    }
+  }
+]

--- a/api-tests/data/audit-events/no-photo-id-journey.json
+++ b/api-tests/data/audit-events/no-photo-id-journey.json
@@ -1,0 +1,37 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P1"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "NEW_P1_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_NO_PHOTO_ID_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  }
+]

--- a/api-tests/data/audit-events/reprove-identity-journey.json
+++ b/api-tests/data/audit-events/reprove-identity-journey.json
@@ -1,0 +1,323 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": true,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_ACCOUNT_INTERVENTION_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "reprove_identity"
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "NEW_P2_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://dcmaw-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 1,
+          "checkDetails": [
+            {
+              "checkMethod": "vri"
+            },
+            {
+              "biometricVerificationProcessLevel": 3,
+              "checkMethod": "bvr"
+            }
+          ],
+          "strengthScore": 4,
+          "type": "IdentityCheck",
+          "validityScore": 3
+        }
+      ],
+      "successful": true,
+      "isUkIssued": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "dcmaw",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://address-cri.stubs.account.gov.uk",
+      "evidence": null,
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "address",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://fraud-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 1,
+          "checkDetails": [
+            {
+              "activityFrom": "1963-01-01",
+              "checkMethod": "data",
+              "identityCheckPolicy": "none"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "mortality_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "identity_theft_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "synthetic_identity_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "impersonation_risk_check"
+            }
+          ],
+          "ci": [],
+          "identityFraudScore": 2,
+          "type": "IdentityCheck"
+        }
+      ],
+      "successful": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "fraud",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "EVALUATE_SCORES"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "ACCOUNT_INTERVENTION"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "ACCOUNT_INTERVENTION",
+      "successful": true
+    },
+    "restricted": {
+      "oldName": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "KENNETH"
+            },
+            {
+              "type": "FamilyName",
+              "value": "DECERQUEIRA"
+            }
+          ]
+        }
+      ],
+      "newName": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "Kenneth"
+            },
+            {
+              "type": "FamilyName",
+              "value": "Decerqueira"
+            }
+          ]
+        }
+      ],
+      "oldBirthDate": [
+        {
+          "value": "1965-07-08"
+        }
+      ],
+      "newBirthDate": [
+        {
+          "value": "1965-07-08"
+        }
+      ],
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1A",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 4,
+            "validity": 3
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "new",
+      "vot": "P2"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_ACCOUNT_INTERVENTION_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "success": true,
+      "type": "reprove_identity"
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_ISSUED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "levelOfConfidence": "P2",
+      "ciFail": false,
+      "hasMitigations": false,
+      "returnCodes": []
+    }
+  }
+]

--- a/api-tests/data/audit-events/reprove-identity-journey.json
+++ b/api-tests/data/audit-events/reprove-identity-journey.json
@@ -58,7 +58,7 @@
       ],
       "successful": true,
       "isUkIssued": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}
@@ -149,7 +149,7 @@
         }
       ],
       "successful": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/reuse-journey.json
+++ b/api-tests/data/audit-events/reuse-journey.json
@@ -1,0 +1,96 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "REUSE_EXISTING_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_ISSUED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "levelOfConfidence": "P2",
+      "ciFail": false,
+      "hasMitigations": false,
+      "returnCodes": []
+    }
+  }
+]

--- a/api-tests/data/audit-events/strategic-app-journey.json
+++ b/api-tests/data/audit-events/strategic-app-journey.json
@@ -1,0 +1,41 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "NEW_P2_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "dcmawAsync",
+      "type": "pending"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_APP_HANDOFF_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  }
+]

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -233,7 +233,7 @@
       ],
       "successful": true,
       "isUkIssued": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}
@@ -324,7 +324,7 @@
         }
       ],
       "successful": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -1,0 +1,490 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "REUSE_EXISTING_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_USER_DETAILS_UPDATE_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_USER_DETAILS_UPDATE_ABORTED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "REUSE_EXISTING_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_USER_DETAILS_UPDATE_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_USER_DETAILS_UPDATE_SELECTED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "update_fields": ["family-name", "address"],
+      "update_supported": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "UPDATE_NAME"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://dcmaw-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 1,
+          "checkDetails": [
+            {
+              "checkMethod": "vri"
+            },
+            {
+              "biometricVerificationProcessLevel": 3,
+              "checkMethod": "bvr"
+            }
+          ],
+          "strengthScore": 3,
+          "type": "IdentityCheck",
+          "validityScore": 2
+        }
+      ],
+      "successful": true,
+      "isUkIssued": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "dcmaw",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://address-cri.stubs.account.gov.uk",
+      "evidence": null,
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "address",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://fraud-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 1,
+          "checkDetails": [
+            {
+              "activityFrom": "1963-01-01",
+              "checkMethod": "data",
+              "identityCheckPolicy": "none"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "mortality_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "identity_theft_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "synthetic_identity_check"
+            },
+            {
+              "checkMethod": "data",
+              "fraudCheck": "impersonation_risk_check"
+            }
+          ],
+          "ci": [],
+          "identityFraudScore": 2,
+          "type": "IdentityCheck"
+        }
+      ],
+      "successful": true,
+      "age": 59
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "fraud",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "STANDARD"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "STANDARD",
+      "successful": true
+    },
+    "restricted": {
+      "oldName": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "KENNETH"
+            },
+            {
+              "type": "FamilyName",
+              "value": "DECERQUEIRA"
+            }
+          ]
+        }
+      ],
+      "newName": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "KENNETH"
+            },
+            {
+              "type": "FamilyName",
+              "value": "SMITH"
+            }
+          ]
+        }
+      ],
+      "oldBirthDate": [
+        {
+          "value": "1965-07-08"
+        }
+      ],
+      "newBirthDate": [
+        {
+          "value": "1965-07-08"
+        }
+      ],
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "update",
+      "vot": "P2"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_USER_DETAILS_UPDATE_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_ISSUED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "levelOfConfidence": "P2",
+      "ciFail": false,
+      "hasMitigations": false,
+      "returnCodes": []
+    }
+  }
+]

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -1,29 +1,62 @@
 Feature: Audit Events
-  Scenario: New identity - via F2F journey
-      Given I start a new 'medium-confidence' journey
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'end' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit a 'next' event
-      Then I get a 'claimedIdentity' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
-      Then I get a 'f2f' CRI response
-      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-        | Attribute          | Values                                      |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
-      Then I get a 'page-face-to-face-handoff' page response
+  Scenario: New identity - p2 app journey
+    Given I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And audit events for 'new-identity-p2-app-journey' are recorded [local only]
 
-        # Return journey
-      When I start a new 'medium-confidence' journey and return to a 'page-ipv-reuse' page response
-      When I submit a 'next' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P2' identity
-      And audit events for 'new-identity-f2f-journey' are recorded [local only]
+  Scenario: Reuse journey
+    Given the subject already has the following credentials
+      | CRI     | scenario                     |
+      | dcmaw   | kenneth-driving-permit-valid |
+      | address | kenneth-current              |
+      | fraud   | kenneth-score-2              |
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-reuse' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And audit events for 'reuse-journey' are recorded [local only]
+
+  Scenario: New identity - via F2F journey
+    Given I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'page-ipv-identity-postoffice-start' page response
+    When I submit a 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'f2f' CRI response
+    When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+    Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+    When I start a new 'medium-confidence' journey and return to a 'page-ipv-reuse' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And audit events for 'new-identity-f2f-journey' are recorded [local only]
 
   Scenario: Delete pending F2F
     Given I start a new 'medium-confidence' journey

--- a/api-tests/features/cimit/alternate-doc.feature
+++ b/api-tests/features/cimit/alternate-doc.feature
@@ -286,5 +286,3 @@ Feature: CIMIT - Alternate doc
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
       Then I get a 'pyi-no-match' page response
-      And an 'IPV_CONTINUITY_OF_IDENTITY_CHECK_START' audit event was recorded [local only]
-      And an 'IPV_CONTINUITY_OF_IDENTITY_CHECK_END' audit event was recorded [local only]

--- a/api-tests/features/inherited-identity/extended-scenarios.feature
+++ b/api-tests/features/inherited-identity/extended-scenarios.feature
@@ -66,7 +66,6 @@ Feature: Inherited identity extended scenarios
     Then I get a 'pyi-no-match' page response
     When I submit a 'next' event
     Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
     Then I get a 'P0' identity
 
@@ -93,7 +92,6 @@ Feature: Inherited identity extended scenarios
     # Return journey with inherited identity for the same user
     When I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'kenneth-vot-pcl250-passport'
     Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
     Then I get a 'PCL250' identity
 

--- a/api-tests/features/inherited-identity/inherited-identity.feature
+++ b/api-tests/features/inherited-identity/inherited-identity.feature
@@ -4,7 +4,6 @@ Feature: Inherited Identity
   Scenario Outline: Inherited Identity Scenarios
     Given I start a new '<journey-type>' journey with inherited identity '<inherited-identity>'
     Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
     Then I get a '<expected-identity>' identity
     When I start a new '<journey-type>' journey
@@ -22,7 +21,6 @@ Feature: Inherited Identity
   Scenario Outline: Migrating a <expected-identity> HMRC profile successfully and returning with <vtr> VTR requires a P2 identity to be proved
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<inherited-identity>'
     Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
     Then I get a '<expected-identity>' identity
 
@@ -38,7 +36,6 @@ Feature: Inherited Identity
   Scenario: Migrate PCL250 HRMC profile successfully with no evidence and returns with P2/PCL250
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
     Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
     Then I get a 'PCL250' identity
     When I start a new 'medium-confidence-pcl250' journey
@@ -69,7 +66,6 @@ Feature: Inherited Identity
     Then I get a 'page-ipv-reuse' page response
     When I submit an 'next' event
     Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
 
@@ -81,7 +77,6 @@ Feature: Inherited Identity
   Scenario Outline: Previous <old-identity> is <is-replaced> with new <new-identity> for the same user
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<old-details>'
     Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
     Then I get a '<old-expected-vot>' identity
     And my identity 'GivenName' is '<old-expected-name>'
@@ -89,7 +84,6 @@ Feature: Inherited Identity
     # New journey with new inherited identity for the same user
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<new-details>'
     Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
     Then I get a '<new-expected-vot>' identity
     And my identity 'GivenName' is '<new-expected-name>'
@@ -105,7 +99,6 @@ Feature: Inherited Identity
   Scenario: Previous PCL250 inherited identity is replaced with new P2 identity for the same user
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
     Then I get an OAuth response
-    And an 'IPV_INHERITED_IDENTITY_VC_RECEIVED' audit event was recorded [local only]
     When I use the OAuth response to get my identity
     Then I get a 'PCL250' identity
     And my identity 'GivenName' is 'Alice'

--- a/api-tests/features/p1-journeys.feature
+++ b/api-tests/features/p1-journeys.feature
@@ -19,7 +19,6 @@ Feature: P1 journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 Passport after DCMAW dropout
     Given I activate the 'p1Journeys' feature set
@@ -47,7 +46,6 @@ Feature: P1 journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 Driving Licence after DCMAW dropout
     Given I activate the 'p1Journeys' feature set
@@ -75,7 +73,6 @@ Feature: P1 journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 Face to Face after DCMAW dropout
     Given I activate the 'p1Journeys' feature set
@@ -134,7 +131,6 @@ Feature: P1 journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 DCMAW after KBV dropout Journey
     Given I activate the 'p1Journeys' feature set
@@ -170,7 +166,6 @@ Feature: P1 journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 F2F Journey
     Given I activate the 'p1Journeys' feature set

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -31,7 +31,6 @@ Feature: P1 No Photo Id Journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 No Photo Id after DCMAW dropout Journey
     Given I activate the 'p1Journeys' feature set
@@ -65,7 +64,6 @@ Feature: P1 No Photo Id Journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: P1 No Photo Id Journey - NINO dropout
     Given I activate the 'p1Journeys,dwpKbvTest' feature sets

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -21,7 +21,6 @@ Feature: P2 App journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
     Examples:
       | doc      | details                      |

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -36,7 +36,6 @@ Feature: P2 F2F journey
       Then I get a 'pyi-confirm-delete-details' page response with context 'f2f'
       When I submit a 'next' event
       Then I get a 'pyi-details-deleted' page response with context 'f2f'
-      And an 'IPV_F2F_USER_CANCEL_START' audit event was recorded [local only]
 
     Scenario: Pending F2F request continue without delete identity
       # Initial journey
@@ -80,7 +79,6 @@ Feature: P2 F2F journey
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P2' identity
-      And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
       Examples:
         | doc      | details                      |
@@ -115,7 +113,6 @@ Feature: P2 F2F journey
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P2' identity
-      And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
       Examples:
         | doc      | details                      |

--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -16,7 +16,6 @@ Feature: P2 App journey
     Then I get a 'non-uk-app-intro' page response
     When I submit a 'useApp' event
     Then I get a 'dcmaw' CRI response
-    And an 'IPV_INTERNATIONAL_ADDRESS_START' audit event was recorded [local only]
 
   Scenario: International address user sends a next event on exit page from DCMAW
     When I submit a 'international' event
@@ -58,7 +57,6 @@ Feature: P2 App journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
   Scenario: User looks for alternative methods to prove identity without using the app
     When I submit an 'international' event

--- a/api-tests/features/p2-reprove-identity.feature
+++ b/api-tests/features/p2-reprove-identity.feature
@@ -24,9 +24,6 @@ Feature: Reprove Identity Journey
         Then I get an OAuth response
         When I use the OAuth response to get my identity
         Then I get a 'P2' identity
-        And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
-        And an 'IPV_ACCOUNT_INTERVENTION_START' audit event was recorded [local only]
-        And an 'IPV_ACCOUNT_INTERVENTION_END' audit event was recorded [local only]
 
     Scenario: User reproves with F2F
         Given the subject already has the following credentials
@@ -59,7 +56,6 @@ Feature: Reprove Identity Journey
         Then I get an OAuth response
         When I use the OAuth response to get my identity
         Then I get a 'P2' identity
-        And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
     Scenario: User needs to reprove their identity with F2F pending
         Given I start a new 'medium-confidence' journey
@@ -112,9 +108,6 @@ Feature: Reprove Identity Journey
                 | Attribute          | Values                                          |
                 | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
             Then I get a 'page-face-to-face-handoff' page response
-            And an 'IPV_ACCOUNT_INTERVENTION_START' audit event was recorded [local only]
-            And an 'IPV_CONTINUITY_OF_IDENTITY_CHECK_START' audit event was recorded [local only]
-            And an 'IPV_CONTINUITY_OF_IDENTITY_CHECK_END' audit event was recorded [local only]
 
             # Return journey after popping out to the Post Office
             When I start a new 'medium-confidence' journey with reprove identity and return to a 'page-ipv-reuse' page response
@@ -122,8 +115,6 @@ Feature: Reprove Identity Journey
             Then I get an OAuth response
             When I use the OAuth response to get my identity
             Then I get a 'P2' identity
-            And an 'IPV_ACCOUNT_INTERVENTION_START' audit event was recorded [local only]
-            And an 'IPV_ACCOUNT_INTERVENTION_END' audit event was recorded [local only]
 
         Scenario: Reproving with F2F journey with different identity fails COI check
             When I submit 'lora' details to the CRI stub
@@ -136,7 +127,3 @@ Feature: Reprove Identity Journey
             Then I get an OAuth response
             When I use the OAuth response to get my identity
             Then I get a 'P0' identity
-            And an 'IPV_CONTINUITY_OF_IDENTITY_CHECK_START' audit event was recorded [local only]
-            And an 'IPV_CONTINUITY_OF_IDENTITY_CHECK_END' audit event was recorded [local only]
-            And an 'IPV_ACCOUNT_INTERVENTION_START' audit event was recorded [local only]
-            And an 'IPV_ACCOUNT_INTERVENTION_END' audit event was recorded [local only]

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -122,7 +122,6 @@ Feature: M2B Strategic App Journeys
     Then I get a 'non-uk-passport' page response
     When I submit a 'next' event
     Then I get a 'identify-device' page response
-    And an 'IPV_INTERNATIONAL_ADDRESS_START' audit event was recorded [local only]
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
     When I submit a 'computer-or-tablet' event

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -28,7 +28,6 @@ Feature: P2 Web document journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
-    And an 'IPV_IDENTITY_ISSUED' audit event was recorded [local only]
 
     Examples:
       | cri            | details                      |

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
@@ -29,7 +29,6 @@ Feature: Identity reuse update details
         Then I get a 'P2' identity
         And my identity 'GivenName' is '<expected-given-name>'
         And my identity 'FamilyName' is '<expected-family-name>'
-        And an 'IPV_USER_DETAILS_UPDATE_END' audit event was recorded [local only]
 
     Examples:
         | selected-name-change | actual-name-change | details                                          | fraud-details                       | expected-given-name | expected-family-name |
@@ -124,4 +123,3 @@ Feature: Identity reuse update details
         Then I get a 'update-name-date-birth' page response with context 'reuse'
         When I submit a 'continue' event
         Then I get an OAuth response
-        And an 'IPV_USER_DETAILS_UPDATE_ABORTED' audit event was recorded [local only]

--- a/api-tests/src/clients/local-audit-client.ts
+++ b/api-tests/src/clients/local-audit-client.ts
@@ -1,17 +1,17 @@
 import config from "../config/config.js";
 import { AuditEvent } from "../types/audit-events.js";
 
-export const getAuditEvents = async (
-  journeyId: string,
-): Promise<AuditEvent[]> => {
+export const getAuditEvents = async (userId: string): Promise<AuditEvent[]> => {
   const response = await fetch(
     `${config.core.externalApiUrl}/audit-events?${new URLSearchParams({
-      govuk_signin_journey_id: journeyId,
+      user_id: userId,
     }).toString()}`,
   );
 
   if (!response.ok) {
-    throw new Error(`getAuditEvents request failed: ${response.statusText}`);
+    throw new Error(
+      `getAuditEventsForUser request failed: ${response.statusText}`,
+    );
   }
 
   return (await response.json()) as AuditEvent[];

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -34,6 +34,10 @@ import { VcJwtPayload } from "../types/external-api.js";
 import * as jose from "jose";
 import { buildCredentialIssuerUrl } from "../clients/cri-stub-client.js";
 import { ApiRequestError } from "../types/errors.js";
+import {
+  compareAuditEvents,
+  getAuditEventsForJourneyType,
+} from "../utils/audit-events.js";
 
 const RETRY_DELAY_MILLIS = 2000;
 const MAX_ATTEMPTS = 5;
@@ -420,16 +424,19 @@ Then("I don't get any return codes", function (this: World): void {
 });
 
 Then(
-  "a(n) {string} audit event was recorded [local only]",
-  async function (this: World, eventName: string): Promise<void> {
+  "audit events for {string} are recorded [local only]",
+  async function (this: World, journeyName: string): Promise<void> {
     if (config.localAuditEvents) {
-      const auditEvents = await auditClient.getAuditEvents(this.journeyId);
-      const event = auditEvents.find((e) => e.event_name === eventName);
-      if (!event) {
-        assert.fail(
-          `Could not find ${eventName} audit event, found: ${auditEvents.map((e) => e.event_name).join(", ")}`,
-        );
-      }
+      const expectedEvents = await getAuditEventsForJourneyType(journeyName);
+      const actualEvents = await auditClient.getAuditEvents(this.userId);
+
+      console.log(JSON.stringify(actualEvents));
+
+      const comparisonResult = compareAuditEvents(actualEvents, expectedEvents);
+      assert.ok(
+        comparisonResult.isPartiallyEqual,
+        comparisonResult.errorMessage,
+      );
     }
   },
 );

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -430,8 +430,6 @@ Then(
       const expectedEvents = await getAuditEventsForJourneyType(journeyName);
       const actualEvents = await auditClient.getAuditEvents(this.userId);
 
-      console.log(JSON.stringify(actualEvents));
-
       const comparisonResult = compareAuditEvents(actualEvents, expectedEvents);
       assert.ok(
         comparisonResult.isPartiallyEqual,

--- a/api-tests/src/utils/audit-events.ts
+++ b/api-tests/src/utils/audit-events.ts
@@ -1,0 +1,37 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import fs from "node:fs/promises";
+import { AuditEvent } from "../types/audit-events.js";
+import {
+  comparePartialEqualityBetweenObjects,
+  ObjectPartialEqualityResult,
+} from "./object-matchers.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const getAuditEventsForJourneyType = async (journeyName: string) => {
+  return JSON.parse(
+    await fs.readFile(
+      path.join(__dirname, `../../data/audit-events/${journeyName}.json`),
+      "utf8",
+    ),
+  ) as AuditEvent[];
+};
+
+export const compareAuditEvents = (
+  actualAuditEvents: AuditEvent[],
+  expectedAuditEvent: AuditEvent[],
+): ObjectPartialEqualityResult => {
+  for (let i = 0; i < expectedAuditEvent.length; i++) {
+    const comparisonResult = comparePartialEqualityBetweenObjects(
+      actualAuditEvents[i],
+      expectedAuditEvent[i],
+    );
+
+    if (!comparisonResult.isPartiallyEqual) {
+      return comparisonResult;
+    }
+  }
+
+  return { isPartiallyEqual: true };
+};

--- a/api-tests/src/utils/object-matchers.ts
+++ b/api-tests/src/utils/object-matchers.ts
@@ -10,12 +10,9 @@ export const comparePartialEqualityBetweenObjects = (
 ): ObjectPartialEqualityResult => {
   for (const [expectedKey, expectedValue] of Object.entries(expectedObject)) {
     if (actualObject[expectedKey] === undefined) {
-      console.log(
-        `Expected ${expectedKey} to be a property in object ${actualObject}`,
-      );
       return {
         isPartiallyEqual: false,
-        errorMessage: `Expected ${expectedKey} to be a property in object ${actualObject}`,
+        errorMessage: `Expected ${expectedKey} to be a property in ${actualObject}`,
       };
     }
 
@@ -35,12 +32,9 @@ export const comparePartialEqualityBetweenObjects = (
     }
 
     if (expectedValue !== actualObject[expectedKey]) {
-      console.log(
-        `Expected ${expectedValue} for index ${expectedKey} but got ${actualObject[expectedKey]}`,
-      );
       return {
         isPartiallyEqual: false,
-        errorMessage: `Expected ${expectedValue} for index ${expectedKey} but got ${actualObject[expectedKey]}`,
+        errorMessage: `Expected ${expectedValue} for field ${expectedKey} but got ${actualObject[expectedKey]}`,
       };
     }
   }

--- a/api-tests/src/utils/object-matchers.ts
+++ b/api-tests/src/utils/object-matchers.ts
@@ -1,0 +1,48 @@
+export interface ObjectPartialEqualityResult {
+  isPartiallyEqual: boolean;
+  errorMessage?: string;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const comparePartialEqualityBetweenObjects = (
+  actualObject: Record<string, any>,
+  expectedObject: Record<string, any>,
+): ObjectPartialEqualityResult => {
+  for (const [expectedKey, expectedValue] of Object.entries(expectedObject)) {
+    if (actualObject[expectedKey] === undefined) {
+      console.log(
+        `Expected ${expectedKey} to be a property in object ${actualObject}`,
+      );
+      return {
+        isPartiallyEqual: false,
+        errorMessage: `Expected ${expectedKey} to be a property in object ${actualObject}`,
+      };
+    }
+
+    if (
+      expectedValue instanceof Object &&
+      actualObject[expectedKey] instanceof Object
+    ) {
+      const isEqual = comparePartialEqualityBetweenObjects(
+        actualObject[expectedKey],
+        expectedValue,
+      );
+
+      if (!isEqual.isPartiallyEqual) {
+        return isEqual;
+      }
+      continue;
+    }
+
+    if (expectedValue !== actualObject[expectedKey]) {
+      console.log(
+        `Expected ${expectedValue} for index ${expectedKey} but got ${actualObject[expectedKey]}`,
+      );
+      return {
+        isPartiallyEqual: false,
+        errorMessage: `Expected ${expectedValue} for index ${expectedKey} but got ${actualObject[expectedKey]}`,
+      };
+    }
+  }
+  return { isPartiallyEqual: true };
+};

--- a/api-tests/src/utils/object-matchers.ts
+++ b/api-tests/src/utils/object-matchers.ts
@@ -3,6 +3,13 @@ export interface ObjectPartialEqualityResult {
   errorMessage?: string;
 }
 
+enum SupportedTypeMatchers {
+  "string",
+  "number",
+}
+
+const TYPE_CHECK_REGEX = /^type\[(\w+)\]$/;
+
 // In node v23, there is a feature called partialDeepStrictEqual which does what we want
 // However, since we are on node v22, we create a partial matcher from scratch.
 // When we upgrade to node >=v23, we could replace this matcher with partialDeepStrictEqual instead.
@@ -39,15 +46,57 @@ export const comparePartialEqualityBetweenObjects = (
       continue;
     }
 
-    if (expectedValue !== actualObject[expectedKey]) {
+    const actualValue = actualObject[expectedKey];
+    if (
+      typeof expectedValue === "string" &&
+      TYPE_CHECK_REGEX.test(expectedValue)
+    ) {
+      const validationRes = validateValueType(
+        expectedValue,
+        actualValue,
+        objectKeyHistory,
+      );
+
+      if (!validationRes.isPartiallyEqual) {
+        return validationRes;
+      }
+
+      objectKeyHistory.pop();
+      continue;
+    }
+
+    if (expectedValue !== actualValue) {
       return {
         isPartiallyEqual: false,
-        errorMessage: `Expected "${expectedValue}" for field ${formatKeyHistory(objectKeyHistory)} but got "${actualObject[expectedKey]}"`,
+        errorMessage: `Expected "${expectedValue}" for field ${formatKeyHistory(objectKeyHistory)} but got "${actualValue}"`,
       };
     }
     objectKeyHistory.pop();
   }
   return { isPartiallyEqual: true };
+};
+
+const validateValueType = (
+  expectedType: string,
+  actualValue: any,
+  keyHistory: string[],
+): ObjectPartialEqualityResult => {
+  const typeMatch = expectedType.match(TYPE_CHECK_REGEX);
+  if (!typeMatch) {
+    throw new Error(`${expectedType} is unsupported.`);
+  }
+
+  const type = typeMatch[1].toLowerCase();
+  if (type in SupportedTypeMatchers) {
+    return typeof actualValue === type
+      ? { isPartiallyEqual: true }
+      : {
+          isPartiallyEqual: false,
+          errorMessage: `Expected ${formatKeyHistory(keyHistory)} to be type ${type} but it was type ${typeof actualValue}`,
+        };
+  } else {
+    throw new Error(`${expectedType} is unsupported.`);
+  }
 };
 
 const formatKeyHistory = (keyHistory: string[]): string => {

--- a/api-tests/src/utils/object-matchers.ts
+++ b/api-tests/src/utils/object-matchers.ts
@@ -3,19 +3,25 @@ export interface ObjectPartialEqualityResult {
   errorMessage?: string;
 }
 
+// In node v23, there is a feature called partialDeepStrictEqual which does what we want
+// However, since we are on node v22, we create a partial matcher from scratch.
+// When we upgrade to node >=v23, we could replace this matcher with partialDeepStrictEqual instead.
+// Read up on docs for the feature here: https://nodejs.org/api/assert.html#assertpartialdeepstrictequalactual-expected-message
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const comparePartialEqualityBetweenObjects = (
   actualObject: Record<string, any>,
   expectedObject: Record<string, any>,
+  objectKeyHistory: string[] = [],
 ): ObjectPartialEqualityResult => {
   for (const [expectedKey, expectedValue] of Object.entries(expectedObject)) {
-    if (actualObject[expectedKey] === undefined) {
+    if (!(expectedKey in actualObject)) {
       return {
         isPartiallyEqual: false,
-        errorMessage: `Expected ${expectedKey} to be a property in ${actualObject}`,
+        errorMessage: `Expected ${expectedKey} to be a property in ${JSON.stringify(actualObject)}`,
       };
     }
 
+    objectKeyHistory.push(expectedKey);
     if (
       expectedValue instanceof Object &&
       actualObject[expectedKey] instanceof Object
@@ -23,20 +29,38 @@ export const comparePartialEqualityBetweenObjects = (
       const isEqual = comparePartialEqualityBetweenObjects(
         actualObject[expectedKey],
         expectedValue,
+        objectKeyHistory,
       );
 
       if (!isEqual.isPartiallyEqual) {
         return isEqual;
       }
+      objectKeyHistory.pop();
       continue;
     }
 
     if (expectedValue !== actualObject[expectedKey]) {
       return {
         isPartiallyEqual: false,
-        errorMessage: `Expected ${expectedValue} for field ${expectedKey} but got ${actualObject[expectedKey]}`,
+        errorMessage: `Expected "${expectedValue}" for field ${formatKeyHistory(objectKeyHistory)} but got "${actualObject[expectedKey]}"`,
       };
     }
+    objectKeyHistory.pop();
   }
   return { isPartiallyEqual: true };
 };
+
+const formatKeyHistory = (keyHistory: string[]): string => {
+  const formattedKeyHistory: string[] = [keyHistory[0]];
+  for (let i = 1; i < keyHistory.length; i++) {
+    const key = keyHistory[i];
+    if (isNumeric(key)) {
+      formattedKeyHistory.push(`[${key}]`);
+      continue;
+    }
+    formattedKeyHistory.push(`.${key}`);
+  }
+  return formattedKeyHistory.join("");
+};
+
+const isNumeric = (target: string): boolean => !isNaN(parseInt(target));

--- a/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandler.java
+++ b/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandler.java
@@ -66,8 +66,8 @@ public class CallDcmawAsyncCriHandler
         this.configService = configService;
         this.ipvSessionService = new IpvSessionService(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
-        this.dcmawAsyncCriService = new DcmawAsyncCriService(configService);
         this.auditService = AuditService.create(configService);
+        this.dcmawAsyncCriService = new DcmawAsyncCriService(configService, auditService);
         this.criStoringService =
                 new CriStoringService(
                         configService,

--- a/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
+++ b/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
@@ -40,9 +40,9 @@ public class DcmawAsyncCriService {
     private final CriOAuthSessionService criOAuthSessionService;
 
     @ExcludeFromGeneratedCoverageReport
-    public DcmawAsyncCriService(ConfigService configService) {
+    public DcmawAsyncCriService(ConfigService configService, AuditService auditService) {
         this.configService = configService;
-        this.auditService = AuditService.create(configService);
+        this.auditService = auditService;
         this.criApiService = new CriApiService(configService);
         this.ipvSessionService = new IpvSessionService(configService);
         this.criOAuthSessionService = new CriOAuthSessionService(configService);

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/LocalAuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/LocalAuditService.java
@@ -19,10 +19,8 @@ public class LocalAuditService implements AuditService {
 
     private Deque<AuditEvent> pendingAuditEvents = new ConcurrentLinkedDeque<>();
 
-    public static List<AuditEvent> getAuditEvents(String journeyId) {
-        return AUDIT_EVENTS.stream()
-                .filter(e -> e.getUser().getGovukSigninJourneyId().equals(journeyId))
-                .toList();
+    public static List<AuditEvent> getAuditEvents(String userId) {
+        return AUDIT_EVENTS.stream().filter(e -> e.getUser().getUserId().equals(userId)).toList();
     }
 
     @Override

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/AuditHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/AuditHandler.java
@@ -5,6 +5,6 @@ import uk.gov.di.ipv.core.library.service.LocalAuditService;
 
 public class AuditHandler {
     public void getAuditEvents(Context ctx) {
-        ctx.json(LocalAuditService.getAuditEvents(ctx.queryParam("govuk_signin_journey_id")));
+        ctx.json(LocalAuditService.getAuditEvents(ctx.queryParam("user_id")));
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- adds api tests for audit events
  - this looks like a new features file which contains key journeys to test for all possible audit events
  - we compare these against a set of pre-defined audit events in `api-tests/data/audit-events`
  - new audit events will need to be added to these as well as a new journey if required

### Why did it change
There wasn't a pre-defined way of testing for audit events in the api tests - only testing them in some scenarios and for only a handful of events. This PR tests adds api tests for all possible events.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7926](https://govukverify.atlassian.net/browse/PYIC-7926)


[PYIC-7926]: https://govukverify.atlassian.net/browse/PYIC-7926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ