### PR TITLE
BAU: perf support

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -10,7 +10,7 @@ Globals:
       ApplyOn: PublishedVersions
     Architectures:
       - arm64
-    MemorySize: !If [UseDynatrace, 3072, 1024]
+    MemorySize: !If [IsPerformanceSensitive, 3072, 1024]
     Runtime: java17
     Environment:
       Variables:
@@ -52,9 +52,9 @@ Globals:
         POWERTOOLS_TRACER_CAPTURE_RESPONSE: false
         POWERTOOLS_TRACER_CAPTURE_ERROR: false
         CONFIG_SERVICE_CACHE_DURATION_MINUTES: !If
-          - IsDevelopment
-          - 0
+          - IsPerformanceSensitive
           - 3
+          - 0
     CodeSigningConfigArn: !If
       - UseCodeSigning
       - !Ref CodeSigningConfigArn
@@ -137,7 +137,10 @@ Conditions:
   UseCanaryDeploymentAlarms: !Or
     - !Not [ !Equals [ !Ref StepFunctionDeploymentPreference, ALL_AT_ONCE ]]
     - !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
-  UseDynatrace: !Not [ !Condition IsDevelopment ]
+  IsPerformanceSensitive: !Or
+    - !Not [ !Condition IsDevelopment ]
+    - !Equals [ !Ref Environment, "dev-perf" ]
+  UseDynatrace: !Condition IsPerformanceSensitive
 
 # The AWS Account Id is used in the following mapping section because we have
 # multiple developer environments and it is undesirable to have to keep this


### PR DESCRIPTION
## Proposed changes

### What changed

There is an existing PR (https://github.com/govuk-one-login/ipv-core-back/pull/2234) for this, but it's quite old and has drifted out of date.

### Why did it change

We want to be able to deploy branches to the perf environment without needing to make temporary changes (e.g. dynatrace, config caching, lambda memory) in the cloudformation