### PR TITLE
PYIC-7797: route failed + reverification journeys to use process-candidate-identity-lambda

### DIFF
--- a/api-tests/data/audit-events/delete-pending-f2f-journey.json
+++ b/api-tests/data/audit-events/delete-pending-f2f-journey.json
@@ -204,7 +204,7 @@
     "event_name": "IPV_IDENTITY_STORED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "PENDING",
+      "identity_type": "pending",
       "vot": null
     },
     "restricted": {

--- a/api-tests/data/audit-events/delete-pending-f2f-journey.json
+++ b/api-tests/data/audit-events/delete-pending-f2f-journey.json
@@ -153,6 +153,27 @@
     }
   },
   {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "STANDARD"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "STANDARD",
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
@@ -180,6 +201,17 @@
     }
   },
   {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "PENDING",
+      "vot": null
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_REDIRECT_TO_CRI",
     "component_id": "https://identity.local.account.gov.uk",
     "restricted": {
@@ -192,17 +224,6 @@
     "extensions": {
       "cri": "f2f",
       "type": "pending"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_IDENTITY_STORED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "extensions": {
-      "identity_type": "pending",
-      "vot": null
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/international-address-journey.json
+++ b/api-tests/data/audit-events/international-address-journey.json
@@ -21,27 +21,6 @@
     }
   },
   {
-    "event_name": "IPV_JOURNEY_START",
-    "component_id": "https://identity.local.account.gov.uk",
-    "extensions": {
-      "reprove_identity": false,
-      "vtr": ["P2"]
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_SUBJOURNEY_START",
-    "component_id": "https://identity.local.account.gov.uk",
-    "extensions": {
-      "journey_type": "NEW_P2_IDENTITY"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_INTERNATIONAL_ADDRESS_START",
     "component_id": "https://identity.local.account.gov.uk",
     "restricted": {

--- a/api-tests/data/audit-events/new-identity-f2f-journey.json
+++ b/api-tests/data/audit-events/new-identity-f2f-journey.json
@@ -153,6 +153,27 @@
     }
   },
   {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "STANDARD"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "STANDARD",
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
@@ -180,6 +201,17 @@
     }
   },
   {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "PENDING",
+      "vot": null
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_REDIRECT_TO_CRI",
     "component_id": "https://identity.local.account.gov.uk",
     "restricted": {
@@ -192,17 +224,6 @@
     "extensions": {
       "cri": "f2f",
       "type": "pending"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_IDENTITY_STORED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "extensions": {
-      "identity_type": "pending",
-      "vot": null
     },
     "restricted": {
       "device_information": {}
@@ -329,11 +350,62 @@
     }
   },
   {
-    "event_name": "IPV_IDENTITY_STORED",
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_START",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "new",
-      "vot": "P2"
+      "type": "STANDARD"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "STANDARD",
+      "successful": true
+    },
+    "restricted": {
+      "newName": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "KENNETH"
+            },
+            {
+              "type": "FamilyName",
+              "value": "DECERQUEIRA"
+            }
+          ]
+        }
+      ],
+      "newBirthDate": [
+        {
+          "value": "1965-07-08"
+        }
+      ],
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
     },
     "restricted": {
       "device_information": {}
@@ -361,6 +433,17 @@
     "extensions": {
       "cri": "ticf",
       "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "NEW",
+      "vot": "P2"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/new-identity-f2f-journey.json
+++ b/api-tests/data/audit-events/new-identity-f2f-journey.json
@@ -204,7 +204,7 @@
     "event_name": "IPV_IDENTITY_STORED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "PENDING",
+      "identity_type": "pending",
       "vot": null
     },
     "restricted": {
@@ -442,7 +442,7 @@
     "event_name": "IPV_IDENTITY_STORED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "NEW",
+      "identity_type": "new",
       "vot": "P2"
     },
     "restricted": {

--- a/api-tests/data/audit-events/new-identity-f2f-journey.json
+++ b/api-tests/data/audit-events/new-identity-f2f-journey.json
@@ -311,28 +311,6 @@
     }
   },
   {
-    "event_name": "IPV_GPG45_PROFILE_MATCHED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "extensions": {
-      "gpg45Profile": "M1B",
-      "gpg45Scores": {
-        "evidences": [
-          {
-            "strength": 3,
-            "validity": 2
-          }
-        ],
-        "activity": 1,
-        "fraud": 2,
-        "verification": 3
-      },
-      "vcTxnIds": []
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
     "component_id": "https://identity.local.account.gov.uk",
     "restricted": {

--- a/api-tests/data/audit-events/new-identity-p2-app-journey.json
+++ b/api-tests/data/audit-events/new-identity-p2-app-journey.json
@@ -142,7 +142,7 @@
         }
       ],
       "successful": true,
-      "age": 59
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/new-identity-p2-app-journey.json
+++ b/api-tests/data/audit-events/new-identity-p2-app-journey.json
@@ -252,7 +252,7 @@
     "event_name": "IPV_IDENTITY_STORED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "NEW",
+      "identity_type": "new",
       "vot": "P2"
     },
     "restricted": {

--- a/api-tests/data/audit-events/new-identity-p2-app-journey.json
+++ b/api-tests/data/audit-events/new-identity-p2-app-journey.json
@@ -142,7 +142,7 @@
         }
       ],
       "successful": true,
-      "age": "type[number]"
+      "age": 59
     },
     "restricted": {
       "device_information": {}
@@ -160,12 +160,42 @@
     }
   },
   {
-    "event_name": "IPV_SUBJOURNEY_START",
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_START",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "journey_type": "EVALUATE_SCORES"
+      "type": "STANDARD"
     },
     "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "type": "STANDARD",
+      "successful": true
+    },
+    "restricted": {
+      "newName": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "Kenneth"
+            },
+            {
+              "type": "FamilyName",
+              "value": "Decerqueira"
+            }
+          ]
+        }
+      ],
+      "newBirthDate": [
+        {
+          "value": "1965-07-08"
+        }
+      ],
       "device_information": {}
     }
   },
@@ -222,7 +252,7 @@
     "event_name": "IPV_IDENTITY_STORED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "new",
+      "identity_type": "NEW",
       "vot": "P2"
     },
     "restricted": {

--- a/api-tests/data/audit-events/reprove-identity-journey.json
+++ b/api-tests/data/audit-events/reprove-identity-journey.json
@@ -278,7 +278,7 @@
     "event_name": "IPV_IDENTITY_STORED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "NEW",
+      "identity_type": "new",
       "vot": "P2"
     },
     "restricted": {

--- a/api-tests/data/audit-events/reprove-identity-journey.json
+++ b/api-tests/data/audit-events/reprove-identity-journey.json
@@ -167,16 +167,6 @@
     }
   },
   {
-    "event_name": "IPV_SUBJOURNEY_START",
-    "component_id": "https://identity.local.account.gov.uk",
-    "extensions": {
-      "journey_type": "EVALUATE_SCORES"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_START",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
@@ -288,7 +278,7 @@
     "event_name": "IPV_IDENTITY_STORED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "new",
+      "identity_type": "NEW",
       "vot": "P2"
     },
     "restricted": {

--- a/api-tests/data/audit-events/reuse-journey.json
+++ b/api-tests/data/audit-events/reuse-journey.json
@@ -50,6 +50,28 @@
     }
   },
   {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {

--- a/api-tests/data/audit-events/reuse-journey.json
+++ b/api-tests/data/audit-events/reuse-journey.json
@@ -11,28 +11,6 @@
     }
   },
   {
-    "event_name": "IPV_GPG45_PROFILE_MATCHED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "extensions": {
-      "gpg45Profile": "M1B",
-      "gpg45Scores": {
-        "evidences": [
-          {
-            "strength": 3,
-            "validity": 2
-          }
-        ],
-        "activity": 1,
-        "fraud": 2,
-        "verification": 3
-      },
-      "vcTxnIds": []
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
     "component_id": "https://identity.local.account.gov.uk",
     "restricted": {

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -11,28 +11,6 @@
     }
   },
   {
-    "event_name": "IPV_GPG45_PROFILE_MATCHED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "extensions": {
-      "gpg45Profile": "M1B",
-      "gpg45Scores": {
-        "evidences": [
-          {
-            "strength": 3,
-            "validity": 2
-          }
-        ],
-        "activity": 1,
-        "fraud": 2,
-        "verification": 3
-      },
-      "vcTxnIds": []
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
     "component_id": "https://identity.local.account.gov.uk",
     "restricted": {
@@ -125,28 +103,6 @@
     "extensions": {
       "reprove_identity": false,
       "vtr": ["P2"]
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_GPG45_PROFILE_MATCHED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "extensions": {
-      "gpg45Profile": "M1B",
-      "gpg45Scores": {
-        "evidences": [
-          {
-            "strength": 3,
-            "validity": 2
-          }
-        ],
-        "activity": 1,
-        "fraud": 2,
-        "verification": 3
-      },
-      "vcTxnIds": []
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -50,6 +50,28 @@
     }
   },
   {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
@@ -142,6 +164,28 @@
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
       "journey_type": "REUSE_EXISTING_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
     },
     "restricted": {
       "device_information": {}
@@ -453,7 +497,7 @@
     "event_name": "IPV_IDENTITY_STORED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "update",
+      "identity_type": "UPDATE",
       "vot": "P2"
     },
     "restricted": {

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -497,7 +497,7 @@
     "event_name": "IPV_IDENTITY_STORED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "identity_type": "UPDATE",
+      "identity_type": "update",
       "vot": "P2"
     },
     "restricted": {

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -79,7 +79,7 @@ Feature: Audit Events
       | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
     Then I get a 'page-face-to-face-handoff' page response
 
-    Given I activate the 'pendingF2FResetEnabled' feature set along with the e
+    Given I activate the 'pendingF2FResetEnabled' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-pending' page response with context 'f2f-delete-details'
     When I submit a 'next' event
@@ -132,7 +132,7 @@ Feature: Audit Events
     And audit events for 'reprove-identity-journey' are recorded [local only]
 
   Scenario: No photo ID
-    Given I activate the 'p1Journeys' feature set along with the existing feature set
+    Given I activate the 'p1Journeys' feature set
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -187,7 +187,7 @@ Feature: Audit Events
     And audit events for 'inherited-identity-journey' are recorded [local only]
 
   Scenario: International address journey
-    Given I activate the 'internationalAddress' feature set along with the existing feature set
+    Given I activate the 'internationalAddress' feature set
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'international' event
@@ -197,7 +197,7 @@ Feature: Audit Events
     And audit events for 'international-address-journey' are recorded [local only]
 
   Scenario: Strategic app journey
-    Given I activate the 'strategicApp' feature set along with the existing feature set
+    Given I activate the 'strategicApp' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -1,6 +1,7 @@
 Feature: Audit Events
   Scenario: New identity - p2 app journey
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'processCandidateIdentity' feature set
+    And I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -24,6 +25,7 @@ Feature: Audit Events
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
+    And I activate the 'processCandidateIdentity' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'next' event
@@ -33,7 +35,8 @@ Feature: Audit Events
     And audit events for 'reuse-journey' are recorded [local only]
 
   Scenario: New identity - via F2F journey
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'processCandidateIdentity' feature set
+    And I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'page-ipv-identity-postoffice-start' page response
@@ -59,7 +62,8 @@ Feature: Audit Events
     And audit events for 'new-identity-f2f-journey' are recorded [local only]
 
   Scenario: Delete pending F2F
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'processCandidateIdentity' feature set
+    And I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
     Then I get a 'page-ipv-identity-postoffice-start' page response
@@ -76,7 +80,7 @@ Feature: Audit Events
       | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
     Then I get a 'page-face-to-face-handoff' page response
 
-    Given I activate the 'pendingF2FResetEnabled' feature set
+    Given I activate the 'pendingF2FResetEnabled,processCandidateIdentity' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-pending' page response with context 'f2f-delete-details'
     When I submit a 'next' event
@@ -88,7 +92,8 @@ Feature: Audit Events
     And audit events for 'delete-pending-f2f-journey' are recorded [local only]
 
   Scenario: Alternate doc mitigation
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'processCandidateIdentity' feature set
+    And I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
@@ -108,7 +113,8 @@ Feature: Audit Events
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
-    When I start a new 'medium-confidence' journey with reprove identity
+    Given I activate the 'processCandidateIdentity' feature set
+    And I start a new 'medium-confidence' journey with reprove identity
     Then I get a 'reprove-identity-start' page response
     When I submit a 'next' event
     Then I get a 'page-ipv-identity-document-start' page response
@@ -129,7 +135,7 @@ Feature: Audit Events
     And audit events for 'reprove-identity-journey' are recorded [local only]
 
   Scenario: No photo ID
-    Given I activate the 'p1Journeys' feature set
+    Given I activate the 'p1Journeys,processCandidateIdentity' feature set
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -144,6 +150,7 @@ Feature: Audit Events
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
+    And I activate the 'processCandidateIdentity' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'update-details' event
@@ -179,7 +186,8 @@ Feature: Audit Events
     And audit events for 'update-name-and-address-journey' are recorded [local only]
 
   Scenario: Inherited identity journey
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
+    Given I activate the 'processCandidateIdentity' feature set
+    And I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'PCL200' identity
@@ -187,7 +195,7 @@ Feature: Audit Events
 
   Scenario: International address journey
     Given I start a new 'medium-confidence' journey
-    And I activate the 'internationalAddress' feature sets
+    And I activate the 'internationalAddress,processCandidateIdentity' feature sets
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'international' event
@@ -197,7 +205,7 @@ Feature: Audit Events
     And audit events for 'international-address-journey' are recorded [local only]
 
   Scenario: Strategic app journey
-    Given I activate the 'strategicApp' feature set
+    Given I activate the 'strategicApp,processCandidateIdentity' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -1,6 +1,8 @@
 Feature: Audit Events
-  Scenario: New identity - p2 app journey
+  Background: Set processCandidateIdentity feature set
     Given I activate the 'processCandidateIdentity' feature set
+
+  Scenario: New identity - p2 app journey
     And I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -25,7 +27,6 @@ Feature: Audit Events
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
-    And I activate the 'processCandidateIdentity' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'next' event
@@ -35,7 +36,6 @@ Feature: Audit Events
     And audit events for 'reuse-journey' are recorded [local only]
 
   Scenario: New identity - via F2F journey
-    Given I activate the 'processCandidateIdentity' feature set
     And I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -62,7 +62,6 @@ Feature: Audit Events
     And audit events for 'new-identity-f2f-journey' are recorded [local only]
 
   Scenario: Delete pending F2F
-    Given I activate the 'processCandidateIdentity' feature set
     And I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -80,7 +79,7 @@ Feature: Audit Events
       | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
     Then I get a 'page-face-to-face-handoff' page response
 
-    Given I activate the 'pendingF2FResetEnabled,processCandidateIdentity' feature set
+    Given I activate the 'pendingF2FResetEnabled' feature set along with the e
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-pending' page response with context 'f2f-delete-details'
     When I submit a 'next' event
@@ -92,7 +91,6 @@ Feature: Audit Events
     And audit events for 'delete-pending-f2f-journey' are recorded [local only]
 
   Scenario: Alternate doc mitigation
-    Given I activate the 'processCandidateIdentity' feature set
     And I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -113,7 +111,6 @@ Feature: Audit Events
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
-    Given I activate the 'processCandidateIdentity' feature set
     And I start a new 'medium-confidence' journey with reprove identity
     Then I get a 'reprove-identity-start' page response
     When I submit a 'next' event
@@ -135,7 +132,7 @@ Feature: Audit Events
     And audit events for 'reprove-identity-journey' are recorded [local only]
 
   Scenario: No photo ID
-    Given I activate the 'p1Journeys,processCandidateIdentity' feature set
+    Given I activate the 'p1Journeys' feature set along with the existing feature set
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -150,7 +147,6 @@ Feature: Audit Events
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
-    And I activate the 'processCandidateIdentity' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'update-details' event
@@ -181,12 +177,9 @@ Feature: Audit Events
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
-    And my identity 'FamilyName' is 'Smith'
-    And my address 'addressLocality' is 'Bristol'
     And audit events for 'update-name-and-address-journey' are recorded [local only]
 
   Scenario: Inherited identity journey
-    Given I activate the 'processCandidateIdentity' feature set
     And I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
     Then I get an OAuth response
     When I use the OAuth response to get my identity
@@ -194,8 +187,7 @@ Feature: Audit Events
     And audit events for 'inherited-identity-journey' are recorded [local only]
 
   Scenario: International address journey
-    Given I start a new 'medium-confidence' journey
-    And I activate the 'internationalAddress,processCandidateIdentity' feature sets
+    Given I activate the 'internationalAddress' feature set along with the existing feature set
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'international' event
@@ -205,7 +197,7 @@ Feature: Audit Events
     And audit events for 'international-address-journey' are recorded [local only]
 
   Scenario: Strategic app journey
-    Given I activate the 'strategicApp,processCandidateIdentity' feature set
+    Given I activate the 'strategicApp' feature set along with the existing feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event

--- a/api-tests/features/inherited-identity/inherited-identity.feature
+++ b/api-tests/features/inherited-identity/inherited-identity.feature
@@ -73,7 +73,7 @@ Feature: Inherited Identity
     | inherited-identity                |
     | alice-vot-pcl200-no-evidence      |
     | kenneth-vot-pcl250-driving-permit |
-#
+
   Scenario Outline: Previous <old-identity> is <is-replaced> with new <new-identity> for the same user
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity '<old-details>'
     Then I get an OAuth response

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -111,9 +111,18 @@ const startNewJourney = async (
 };
 
 When(
-  "I activate the {string} feature set(s)",
-  function (this: World, featureSet: string) {
-    this.featureSet = featureSet;
+  /I activate the '([\w,]+)' feature set(?:s)?( along with the existing feature set(?:s)?)?/,
+  function (
+    this: World,
+    featureSet: string,
+    addToExistingFeatureSets:
+      | " along with the existing feature set"
+      | " along with the existing feature sets"
+      | undefined,
+  ) {
+    this.featureSet = addToExistingFeatureSets
+      ? this.featureSet + "," + featureSet
+      : featureSet;
   },
 );
 

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -450,7 +450,7 @@ Then(
       const comparisonResult = compareAuditEvents(actualEvents, expectedEvents);
       assert.ok(
         comparisonResult.isPartiallyEqual,
-        comparisonResult.errorMessage + JSON.stringify(actualEvents),
+        comparisonResult.errorMessage,
       );
     }
   },

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -111,18 +111,18 @@ const startNewJourney = async (
 };
 
 When(
-  /I activate the '([\w,]+)' feature set(?:s)?( along with the existing feature set(?:s)?)?/,
+  /I (override the existing feature set(?:s)? and )?activate the '([\w,]+)' feature set(?:s)?/,
   function (
     this: World,
-    featureSet: string,
-    addToExistingFeatureSets:
-      | " along with the existing feature set"
-      | " along with the existing feature sets"
+    overrideExistingFeatureSets:
+      | "override the existing feature set and "
+      | "override the existing feature sets and "
       | undefined,
+    featureSet: string,
   ) {
-    this.featureSet = addToExistingFeatureSets
-      ? this.featureSet + "," + featureSet
-      : featureSet;
+    this.featureSet = overrideExistingFeatureSets
+      ? featureSet
+      : this.featureSet + "," + featureSet;
   },
 );
 

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -450,7 +450,7 @@ Then(
       const comparisonResult = compareAuditEvents(actualEvents, expectedEvents);
       assert.ok(
         comparisonResult.isPartiallyEqual,
-        comparisonResult.errorMessage,
+        comparisonResult.errorMessage + JSON.stringify(actualEvents),
       );
     }
   },

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -62,6 +62,7 @@ import java.util.Optional;
 import static com.amazonaws.util.CollectionUtils.isNullOrEmpty;
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_NOT_FOUND;
 import static java.lang.Boolean.TRUE;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.PROCESS_CANDIDATE_IDENTITY;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.REPEAT_FRAUD_CHECK;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.RESET_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
@@ -429,7 +430,8 @@ public class CheckExistingIdentityHandler
 
         var votMatchingResult = maybeVotMatchingResult.get();
 
-        if (GPG45.equals(votMatchingResult.vot().getProfileType())) {
+        if (GPG45.equals(votMatchingResult.vot().getProfileType())
+                && !configService.enabled(PROCESS_CANDIDATE_IDENTITY)) {
             sendProfileMatchedAuditEvent(
                     votMatchingResult.gpg45Profile(),
                     votMatchingResult.gpg45Scores(),

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -95,6 +95,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.FRAUD_CHECK_EXPIRY_PERIOD_HOURS;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.P1_JOURNEYS_ENABLED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.PROCESS_CANDIDATE_IDENTITY;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.REPEAT_FRAUD_CHECK;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.RESET_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
@@ -338,6 +339,8 @@ class CheckExistingIdentityHandlerTest {
                             Optional.of(
                                     new VotMatchingResult(
                                             P2, matchedProfile, Gpg45Scores.builder().build())));
+            when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
+            when(configService.enabled(PROCESS_CANDIDATE_IDENTITY)).thenReturn(false);
 
             var journeyResponse =
                     toResponseClass(
@@ -1436,6 +1439,7 @@ class CheckExistingIdentityHandlerTest {
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
         when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
         when(configService.enabled(REPEAT_FRAUD_CHECK)).thenReturn(true);
+        when(configService.enabled(PROCESS_CANDIDATE_IDENTITY)).thenReturn(false);
         when(configService.getParameter(COMPONENT_ID)).thenReturn("http://ipv/");
         when(configService.getParameter(FRAUD_CHECK_EXPIRY_PERIOD_HOURS)).thenReturn("1");
 
@@ -1471,6 +1475,7 @@ class CheckExistingIdentityHandlerTest {
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
         when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
         when(configService.enabled(REPEAT_FRAUD_CHECK)).thenReturn(true);
+        when(configService.enabled(PROCESS_CANDIDATE_IDENTITY)).thenReturn(false);
         when(configService.getParameter(COMPONENT_ID)).thenReturn("http://ipv/");
         when(configService.getParameter(FRAUD_CHECK_EXPIRY_PERIOD_HOURS))
                 .thenReturn("100000000"); // not the best way to test this

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -74,6 +74,7 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_STOR
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNEXPECTED_PROCESS_IDENTITY_TYPE;
+import static uk.gov.di.ipv.core.library.enums.CandidateIdentityType.EXISTING;
 import static uk.gov.di.ipv.core.library.enums.CandidateIdentityType.NEW;
 import static uk.gov.di.ipv.core.library.enums.CandidateIdentityType.PENDING;
 import static uk.gov.di.ipv.core.library.enums.CandidateIdentityType.REVERIFICATION;
@@ -119,7 +120,7 @@ public class ProcessCandidateIdentityHandler
 
     // Candidate identities that should match a profile
     private static final Set<CandidateIdentityType> PROFILE_MATCHING_TYPES =
-            EnumSet.of(NEW, UPDATE);
+            EnumSet.of(NEW, UPDATE, EXISTING);
 
     @ExcludeFromGeneratedCoverageReport
     public ProcessCandidateIdentityHandler() {

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -113,6 +113,7 @@ class ProcessCandidateIdentityHandlerTest {
                 ClientOAuthSessionItem.builder()
                         .userId(USER_ID)
                         .govukSigninJourneyId(SIGNIN_JOURNEY_ID)
+                        .vtr(List.of())
                         .reproveIdentity(false);
 
         ipvSessionItem.setIpvSessionId(SESSION_ID);
@@ -366,6 +367,11 @@ class ProcessCandidateIdentityHandlerTest {
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
+            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+            when(cimitService.getContraIndicators(USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS))
+                    .thenReturn(List.of());
+            when(votMatcher.matchFirstVot(eq(List.of(P2)), eq(List.of()), eq(List.of()), eq(true)))
+                    .thenReturn(Optional.of(new VotMatchingResult(P2, M1A, M1A.getScores())));
 
             var request =
                     requestBuilder
@@ -381,7 +387,6 @@ class ProcessCandidateIdentityHandlerTest {
             // Assert
             assertEquals(JOURNEY_NEXT.getJourney(), response.get("journey"));
 
-            verify(votMatcher, times(0)).matchFirstVot(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(0))
                     .storeIdentity(any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -370,7 +370,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
             when(cimitService.getContraIndicators(USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS))
                     .thenReturn(List.of());
-            when(votMatcher.matchFirstVot(eq(List.of(P2)), eq(List.of()), eq(List.of()), eq(true)))
+            when(votMatcher.matchFirstVot(List.of(P2), List.of(), List.of(), true))
                     .thenReturn(Optional.of(new VotMatchingResult(P2, M1A, M1A.getScores())));
 
             var request =

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -497,6 +497,25 @@ states:
     events:
       next:
         targetState: EVALUATE_GPG45_SCORES
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_VALID_IDENTITY
+
+  PROCESS_VALID_IDENTITY:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: EXISTING
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      profile-unmet:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+      vcs-not-correlated:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
   EVALUATE_GPG45_SCORES:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -27,14 +27,14 @@ states:
   FAILED_CONFIRM_DETAILS:
     events:
       next:
-        targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_VALID_ID
+        targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_VALID_ID
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
           successful: false
         checkJourneyContext:
           rfc:
-            targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_INVALID_ID
+            targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_INVALID_ID
             auditEvents:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
@@ -57,7 +57,7 @@ states:
   FAILED_CONFIRM_DETAILS_INVALID_ID:
     events:
       next:
-        targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_INVALID_ID
+        targetState: CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_INVALID_ID
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
@@ -211,15 +211,34 @@ states:
         identityType: INCOMPLETE
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       enhanced-verification:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       alternate-doc-invalid-dl:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       alternate-doc-invalid-passport:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       fail-with-ci:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_VALID_ID:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
+      enhanced-verification:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
+      alternate-doc-invalid-dl:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
+      alternate-doc-invalid-passport:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
+      fail-with-ci:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -230,15 +249,15 @@ states:
       lambda: call-ticf-cri
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       enhanced-verification:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       alternate-doc-invalid-dl:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       alternate-doc-invalid-passport:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       fail-with-ci:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -251,15 +270,34 @@ states:
         identityType: INCOMPLETE
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       enhanced-verification:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       alternate-doc-invalid-dl:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       alternate-doc-invalid-passport:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       fail-with-ci:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_INVALID_ID:
+    response:
+      type: process
+      lambda: call-ticf-cri
+    events:
+      next:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
+      enhanced-verification:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
+      alternate-doc-invalid-dl:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
+      alternate-doc-invalid-passport:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
+      fail-with-ci:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -270,15 +308,15 @@ states:
       lambda: call-ticf-cri
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       enhanced-verification:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       alternate-doc-invalid-dl:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       alternate-doc-invalid-passport:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       fail-with-ci:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -443,6 +481,17 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
+  COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID:
+    response:
+      type: page
+      pageId: sorry-could-not-confirm-details
+      context: existingIdentityValid
+    events:
+      returnToRp:
+        targetState: REINSTATE_EXISTING_IDENTITY
+      delete:
+        targetState: DELETE_HANDOVER_PAGE
+
   COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID:
     response:
       type: page
@@ -451,6 +500,17 @@ states:
     events:
       returnToRp:
         targetState: REINSTATE_EXISTING_IDENTITY
+      delete:
+        targetState: DELETE_HANDOVER_PAGE
+
+  COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID:
+    response:
+      type: page
+      pageId: sorry-could-not-confirm-details
+      context: existingIdentityInvalid
+    events:
+      returnToRp:
+        targetState: RETURN_TO_RP
       delete:
         targetState: DELETE_HANDOVER_PAGE
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -41,14 +41,14 @@ states:
               successful: false
             checkFeatureFlag:
               processCandidateIdentity:
-                targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_WITH_DELETION_INVALID_ID
+                targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_DETAILS_INVALID_ID
                 auditEvents:
                   - IPV_USER_DETAILS_UPDATE_END
                 auditContext:
                   successful: false
         checkFeatureFlag:
           processCandidateIdentity:
-            targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_VALID_ID
+            targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_DETAILS_VALID_ID
             auditEvents:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
@@ -64,7 +64,7 @@ states:
           successful: false
         checkFeatureFlag:
           processCandidateIdentity:
-            targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_WITH_DELETION_INVALID_ID
+            targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_DETAILS_INVALID_ID
             auditEvents:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
@@ -203,7 +203,7 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
-  PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_VALID_ID:
+  PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_DETAILS_VALID_ID:
     response:
       type: process
       lambda: process-candidate-identity
@@ -243,7 +243,7 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
-  PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_WITH_DELETION_INVALID_ID:
+  PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_DETAILS_INVALID_ID:
     response:
       type: process
       lambda: process-candidate-identity

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -12,11 +12,17 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_NO_MATCH
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH
 
   FAILED_SKIP_MESSAGE:
     events:
       next:
         targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_RETURN_TO_RP
 
   FAILED_CONFIRM_DETAILS:
     events:
@@ -33,6 +39,20 @@ states:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
               successful: false
+            checkFeatureFlag:
+              processCandidateIdentity:
+                targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_WITH_DELETION_INVALID_ID
+                auditEvents:
+                  - IPV_USER_DETAILS_UPDATE_END
+                auditContext:
+                  successful: false
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_VALID_ID
+            auditEvents:
+              - IPV_USER_DETAILS_UPDATE_END
+            auditContext:
+              successful: false
 
   FAILED_CONFIRM_DETAILS_INVALID_ID:
     events:
@@ -42,6 +62,13 @@ states:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
           successful: false
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_WITH_DELETION_INVALID_ID
+            auditEvents:
+              - IPV_USER_DETAILS_UPDATE_END
+            auditContext:
+              successful: false
 
   FAILED_UPDATE_DETAILS:
     events:
@@ -58,16 +85,37 @@ states:
               - IPV_USER_DETAILS_UPDATE_END
             auditContext:
               successful: false
+            checkFeatureFlag:
+              processCandidateIdentity:
+              targetState: PROCESS_INCOMPLETE_IDENTITY_UPDATE_DETAILS_INVALID_IDENTITY
+              auditEvents:
+                - IPV_USER_DETAILS_UPDATE_END
+              auditContext:
+                successful: false
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_UPDATE_DETAILS
+            auditEvents:
+              - IPV_USER_DETAILS_UPDATE_END
+            auditContext:
+              successful: false
+
 
   FAILED_BAV:
     events:
       next:
         targetState: CRI_TICF_BEFORE_NO_MATCH_BAV
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_BAV
 
   FAILED_NINO:
     events:
       next:
         targetState: CRI_TICF_BEFORE_NO_MATCH_NINO
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_NINO
 
   FAILED_NO_TICF:
     events:
@@ -75,6 +123,26 @@ states:
         targetState: NO_MATCH_PAGE
 
   # Journey states
+  PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: NO_MATCH_PAGE
+      enhanced-verification:
+        targetState: NO_MATCH_PAGE
+      alternate-doc-invalid-dl:
+        targetState: NO_MATCH_PAGE
+      alternate-doc-invalid-passport:
+        targetState: NO_MATCH_PAGE
+      fail-with-ci:
+        targetState: NO_MATCH_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
   CRI_TICF_BEFORE_NO_MATCH:
     response:
@@ -91,6 +159,27 @@ states:
         targetState: NO_MATCH_PAGE
       fail-with-ci:
         targetState: NO_MATCH_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  PROCESS_INCOMPLETE_IDENTITY_BEFORE_RETURN_TO_RP:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      enhanced-verification:
+        targetState: RETURN_TO_RP
+      alternate-doc-invalid-dl:
+        targetState: RETURN_TO_RP
+      alternate-doc-invalid-passport:
+        targetState: RETURN_TO_RP
+      fail-with-ci:
+        targetState: RETURN_TO_RP
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -114,6 +203,27 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
+  PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_VALID_ID:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+      enhanced-verification:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+      alternate-doc-invalid-dl:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+      alternate-doc-invalid-passport:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+      fail-with-ci:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
   CRI_TICF_BEFORE_COULD_NOT_CONFIRM_DETAILS_WITH_DELETION_VALID_ID:
     response:
       type: process
@@ -127,6 +237,27 @@ states:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
       alternate-doc-invalid-passport:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_VALID_ID
+      fail-with-ci:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_CONFIRM_WITH_DELETION_INVALID_ID:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+      enhanced-verification:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+      alternate-doc-invalid-dl:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
+      alternate-doc-invalid-passport:
+        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_WITH_DELETION_INVALID_ID
       error:
@@ -152,6 +283,27 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
+  PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_UPDATE_DETAILS:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      enhanced-verification:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      alternate-doc-invalid-dl:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      alternate-doc-invalid-passport:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      fail-with-ci:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
   CRI_TICF_BEFORE_COULD_NOT_UPDATE_DETAILS:
     response:
       type: process
@@ -165,6 +317,27 @@ states:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE
       alternate-doc-invalid-passport:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+      fail-with-ci:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  PROCESS_INCOMPLETE_IDENTITY_UPDATE_DETAILS_INVALID_IDENTITY:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
+      enhanced-verification:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
+      alternate-doc-invalid-dl:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
+      alternate-doc-invalid-passport:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
       fail-with-ci:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
       error:
@@ -190,6 +363,27 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
+  PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_BAV:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_BAV
+      enhanced-verification:
+        targetState: NO_MATCH_PAGE_BAV
+      alternate-doc-invalid-dl:
+        targetState: NO_MATCH_PAGE_BAV
+      alternate-doc-invalid-passport:
+        targetState: NO_MATCH_PAGE_BAV
+      fail-with-ci:
+        targetState: NO_MATCH_PAGE_BAV
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
   CRI_TICF_BEFORE_NO_MATCH_BAV:
     response:
       type: process
@@ -205,6 +399,27 @@ states:
         targetState: NO_MATCH_PAGE_BAV
       fail-with-ci:
         targetState: NO_MATCH_PAGE_BAV
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_NINO:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_NINO
+      enhanced-verification:
+        targetState: NO_MATCH_PAGE_NINO
+      alternate-doc-invalid-dl:
+        targetState: NO_MATCH_PAGE_NINO
+      alternate-doc-invalid-passport:
+        targetState: NO_MATCH_PAGE_NINO
+      fail-with-ci:
+        targetState: NO_MATCH_PAGE_NINO
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -87,11 +87,11 @@ states:
               successful: false
             checkFeatureFlag:
               processCandidateIdentity:
-              targetState: PROCESS_INCOMPLETE_IDENTITY_UPDATE_DETAILS_INVALID_IDENTITY
-              auditEvents:
-                - IPV_USER_DETAILS_UPDATE_END
-              auditContext:
-                successful: false
+                targetState: PROCESS_INCOMPLETE_IDENTITY_UPDATE_DETAILS_INVALID_IDENTITY
+                auditEvents:
+                  - IPV_USER_DETAILS_UPDATE_END
+                auditContext:
+                  successful: false
         checkFeatureFlag:
           processCandidateIdentity:
             targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_UPDATE_DETAILS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
@@ -10,8 +10,35 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_EXISTING_IDENTITY
 
   # Journey states
+  PROCESS_EXISTING_IDENTITY:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: EXISTING
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
   CRI_TICF_BEFORE_RETURN_TO_RP:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -10,8 +10,35 @@ states:
     events:
       next:
         targetState: CRI_TICF_BEFORE_RETURN_TO_RP
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_EXISTING_IDENTITY
 
   # Journey states
+  PROCESS_EXISTING_IDENTITY:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: EXISTING
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      enhanced-verification:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      alternate-doc-invalid-passport:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
   CRI_TICF_BEFORE_RETURN_TO_RP:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -173,6 +173,26 @@ states:
     events:
       next:
         targetState: CHECK_COI
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_REVERIFICATION_IDENTITY
+
+  PROCESS_REVERIFICATION_IDENTITY:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: REVERIFICATION
+    parent: CRI_TICF_STATE
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      coi-check-failed:
+        targetJourney: FAILED
+        targetState: FAILED
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   CHECK_COI:
     response:

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -9,7 +9,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     P1_JOURNEYS_ENABLED("p1JourneysEnabled"),
     SQS_ASYNC("sqsAsync"),
     KID_JAR_HEADER("kidJarHeaderEnabled"),
-    DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck");
+    DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
+    PROCESS_CANDIDATE_IDENTITY("processCandidateIdentity");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/CandidateIdentityType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/CandidateIdentityType.java
@@ -1,13 +1,20 @@
 package uk.gov.di.ipv.core.library.enums;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 @ExcludeFromGeneratedCoverageReport
 public enum CandidateIdentityType {
+    @JsonProperty("existing")
     EXISTING,
+    @JsonProperty("new")
     NEW,
+    @JsonProperty("pending")
     PENDING,
+    @JsonProperty("reverification")
     REVERIFICATION,
+    @JsonProperty("incomplete")
     INCOMPLETE,
+    @JsonProperty("update")
     UPDATE
 }

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -390,7 +390,7 @@ core:
     sqsAsync: true
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: false
-    processCandidateIdentity: false
+    processCandidateIdentity: true
   features:
     processCandidateIdentity:
       featureFlags:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -390,7 +390,7 @@ core:
     sqsAsync: true
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: false
-    processCandidateIdentity: true
+    processCandidateIdentity: false
   features:
     processCandidateIdentity:
       featureFlags:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Added routing to failed and reverification journeys to use new process-candidate-identity lambda

### Why did it change
We made a new lambda to consolidate a bunch of other lambdas, this PR uses that lambda on journeys that don't yet use it yet.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7797](https://govukverify.atlassian.net/browse/PYIC-7797)


[PYIC-7797]: https://govukverify.atlassian.net/browse/PYIC-7797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ