### PR TITLE
Pyic 7785: Add API tests to complete a strategic app journey

### DIFF
--- a/api-tests/cucumber.js
+++ b/api-tests/cucumber.js
@@ -7,7 +7,7 @@ const base = {
   publish: false,
   retry: 0,
   loader: ["ts-node/esm"],
-  import: ["src/steps/**/*.ts", "src/config/**/*.ts"],
+  import: ["src/steps/**/*.ts", "src/config/**/*.ts", "src/hooks.ts"],
 };
 
 export default base;

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -62,6 +62,8 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
     When I submit 'kennethD' 'ukChippedPassport' 'success' details to the async DCMAW CRI stub
     Then I callback from the app in a separate session
+    # To give time for VC to be processed
+    And I poll for async DCMAW credential receipt
     When I start a new 'medium-confidence' journey
     Then I get a 'page-dcmaw-success' page response
     When I submit a 'next' event
@@ -75,7 +77,7 @@ Feature: M2B Strategic App Journeys
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
 
-  Scenario: MAM journey credential fails
+  Scenario: MAM journey credential fails with no ci
     Given I activate the 'strategicApp' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
@@ -88,6 +90,25 @@ Feature: M2B Strategic App Journeys
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
     When I submit 'kennethD' 'ukChippedPassport' 'fail' details to the async DCMAW CRI stub
+    And I callback from the app
+    Then I get an 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    And I submit the returned journey event
+    Then I get an 'page-multiple-doc-check' page response
+
+  Scenario: MAM journey credential fails with ci
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    When I submit 'kennethD' 'ukChippedPassport' 'failWithCi' details to the async DCMAW CRI stub
     And I callback from the app
     Then I get an 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -42,7 +42,8 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-    And I callback from the app
+    And I do not submit VC to the async DCMAW CRI stub
+    When I callback from the app
     Then I get an 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt
     Then the poll returns a 404

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -30,6 +30,67 @@ Feature: M2B Strategic App Journeys
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
 
+  Scenario: MAM journey pending credential
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    And I callback from the app
+    Then I get an 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a 404
+
+  Scenario: MAM journey cross-browser scenario
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    When I submit 'kennethD' 'ukChippedPassport' 'success' details to the async DCMAW CRI stub
+    And I callback from the app in a separate session
+    Then I get an OAuth response
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+  Scenario: MAM journey credential fails
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    When I submit 'kennethD' 'ukChippedPassport' 'fail' details to the async DCMAW CRI stub
+    And I callback from the app
+    Then I get an 'pyi-technical' page response
+
   Scenario: MAM journey detected iphone
     Given I activate the 'strategicApp' feature set
     When I start a new 'medium-confidence' journey

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -68,6 +68,7 @@ Feature: M2B Strategic App Journeys
     When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session
+    Then I get an error response with message 'Missing ipv session id header' and status code '400'
     # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
     # has managed to log back in to the site.
     When I poll for async DCMAW credential receipt

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -1,4 +1,4 @@
-@Build
+@Build @InitialisesDCMAWSessionState
 Feature: M2B Strategic App Journeys
 
   Scenario: MAM journey declared iphone
@@ -13,10 +13,12 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-    When I submit 'kennethD' 'ukChippedPassport' 'success' details to the async DCMAW CRI stub
-    And I callback from the app
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
     Then I get an 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
     And I submit the returned journey event
     Then I get a 'page-dcmaw-success' page response
     When I submit a 'next' event
@@ -42,11 +44,14 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-    And I do not submit VC to the async DCMAW CRI stub
-    When I callback from the app
+    # And the user returns from the app to core-front
+    When I pass on the DCMAW callback
     Then I get an 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt
-    Then the poll returns a 404
+    Then the poll returns a '404'
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '200'
 
   Scenario: MAM journey cross-browser scenario
     Given I activate the 'strategicApp' feature set
@@ -60,9 +65,10 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-    When I submit 'kennethD' 'ukChippedPassport' 'success' details to the async DCMAW CRI stub
-    Then I callback from the app in a separate session
-    # To give time for VC to be processed
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+    # And the user returns from the app to core-front
+    Then I pass on the DCMAW callback in a separate session
+    # Mocking the time for the user to log back in
     And I poll for async DCMAW credential receipt
     When I start a new 'medium-confidence' journey
     Then I get a 'page-dcmaw-success' page response
@@ -89,10 +95,12 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-    When I submit 'kennethD' 'ukChippedPassport' 'fail' details to the async DCMAW CRI stub
-    And I callback from the app
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
     Then I get an 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
     And I submit the returned journey event
     Then I get an 'page-multiple-doc-check' page response
 
@@ -108,10 +116,12 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-    When I submit 'kennethD' 'ukChippedPassport' 'failWithCi' details to the async DCMAW CRI stub
-    And I callback from the app
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'failWithCi' VC
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
     Then I get an 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
     And I submit the returned journey event
     Then I get an 'pyi-technical' page response
 

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -51,7 +51,7 @@ Feature: M2B Strategic App Journeys
     Then the poll returns a '404'
     When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     When I poll for async DCMAW credential receipt
-    Then the poll returns a '200'
+    Then the poll returns a '201'
 
   Scenario: MAM journey cross-browser scenario
     Given I activate the 'strategicApp' feature set
@@ -116,14 +116,14 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'failWithCi' VC
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
     Then I get an 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt
     Then the poll returns a '201'
     And I submit the returned journey event
-    Then I get an 'pyi-technical' page response
+    Then I get an 'pyi-no-match' page response
 
   Scenario: MAM journey detected iphone
     Given I activate the 'strategicApp' feature set

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -13,6 +13,22 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    When I submit 'kennethD' 'ukChippedPassport' 'success' details to the async DCMAW CRI stub
+    And I callback from the app
+    Then I get an 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    And I submit the returned journey event
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
 
   Scenario: MAM journey detected iphone
     Given I activate the 'strategicApp' feature set

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -61,8 +61,7 @@ Feature: M2B Strategic App Journeys
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
     When I submit 'kennethD' 'ukChippedPassport' 'success' details to the async DCMAW CRI stub
-    And I callback from the app in a separate session
-    Then I get an OAuth response
+    Then I callback from the app in a separate session
     When I start a new 'medium-confidence' journey
     Then I get a 'page-dcmaw-success' page response
     When I submit a 'next' event
@@ -90,6 +89,9 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
     When I submit 'kennethD' 'ukChippedPassport' 'fail' details to the async DCMAW CRI stub
     And I callback from the app
+    Then I get an 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    And I submit the returned journey event
     Then I get an 'pyi-technical' page response
 
   Scenario: MAM journey detected iphone

--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -16,10 +16,10 @@ Feature: M2B Strategic App Journeys
     When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
-    Then I get an 'check-mobile-app-result' page response
+    Then I get a 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt
     Then the poll returns a '201'
-    And I submit the returned journey event
+    When I submit the returned journey event
     Then I get a 'page-dcmaw-success' page response
     When I submit a 'next' event
     Then I get an 'address' CRI response
@@ -50,7 +50,7 @@ Feature: M2B Strategic App Journeys
     When I poll for async DCMAW credential receipt
     Then the poll returns a '404'
     When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
-    When I poll for async DCMAW credential receipt
+    And I poll for async DCMAW credential receipt
     Then the poll returns a '201'
 
   Scenario: MAM journey cross-browser scenario
@@ -67,10 +67,11 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
     When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     # And the user returns from the app to core-front
-    Then I pass on the DCMAW callback in a separate session
-    # Mocking the time for the user to log back in
-    And I poll for async DCMAW credential receipt
-    When I start a new 'medium-confidence' journey
+    And I pass on the DCMAW callback in a separate session
+    # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+    # has managed to log back in to the site.
+    When I poll for async DCMAW credential receipt
+    And I start a new 'medium-confidence' journey
     Then I get a 'page-dcmaw-success' page response
     When I submit a 'next' event
     Then I get an 'address' CRI response
@@ -101,7 +102,7 @@ Feature: M2B Strategic App Journeys
     Then I get an 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt
     Then the poll returns a '201'
-    And I submit the returned journey event
+    When I submit the returned journey event
     Then I get an 'page-multiple-doc-check' page response
 
   Scenario: MAM journey credential fails with ci
@@ -122,7 +123,7 @@ Feature: M2B Strategic App Journeys
     Then I get an 'check-mobile-app-result' page response
     When I poll for async DCMAW credential receipt
     Then the poll returns a '201'
-    And I submit the returned journey event
+    When I submit the returned journey event
     Then I get an 'pyi-no-match' page response
 
   Scenario: MAM journey detected iphone

--- a/api-tests/src/clients/core-back-internal-client.ts
+++ b/api-tests/src/clients/core-back-internal-client.ts
@@ -118,9 +118,7 @@ export const pollAsyncDcmaw = async (
     return;
   }
 
-  throw new Error(
-    `callbackFromStrategicApp request failed: ${response.statusText}`,
-  );
+  throw new Error(`pollAsyncDcmaw request failed: ${response.statusText}`);
 };
 
 export const processCriCallback = async (

--- a/api-tests/src/clients/core-back-internal-client.ts
+++ b/api-tests/src/clients/core-back-internal-client.ts
@@ -74,7 +74,7 @@ export const callbackFromStrategicApp = async (
   ipvSessionId: string | undefined,
   featureSet: string | undefined,
 ): Promise<JourneyEngineResponse> => {
-  const url = `${config.core.internalApiUrl}/app/callback/${oauthState}`;
+  const url = `${config.core.internalApiUrl}/app/callback`;
   const response = await fetch(url, {
     method: POST,
     headers: {
@@ -82,6 +82,7 @@ export const callbackFromStrategicApp = async (
       ...(featureSet ? { "feature-set": featureSet } : {}),
       ...(ipvSessionId ? { "ipv-session-id": ipvSessionId } : {}),
     },
+    body: JSON.stringify({ state: oauthState }),
   });
 
   if (!response.ok) {
@@ -89,12 +90,16 @@ export const callbackFromStrategicApp = async (
       `callbackFromStrategicApp request failed: ${response.statusText}`,
     );
   }
+
+  const body = await response.json();
+
+  return await sendJourneyEvent(body?.journey, ipvSessionId, featureSet);
 };
 
 export const pollAsyncDcmaw = async (
   ipvSessionId: string | undefined,
   featureSet: string | undefined,
-): Promise<JourneyResponse> => {
+): Promise<JourneyResponse | undefined> => {
   const url = `${config.core.internalApiUrl}/app/check-vc-receipt`;
   const response = await fetch(url, {
     method: POST,

--- a/api-tests/src/clients/core-back-internal-client.ts
+++ b/api-tests/src/clients/core-back-internal-client.ts
@@ -69,6 +69,55 @@ export const sendJourneyEvent = async (
   return (await response.json()) as JourneyEngineResponse;
 };
 
+export const callbackFromStrategicApp = async (
+  oauthState: string,
+  ipvSessionId: string | undefined,
+  featureSet: string | undefined,
+): Promise<JourneyEngineResponse> => {
+  const url = `${config.core.internalApiUrl}/app/callback/${oauthState}`;
+  const response = await fetch(url, {
+    method: POST,
+    headers: {
+      "Content-Type": "application/json",
+      ...(featureSet ? { "feature-set": featureSet } : {}),
+      ...(ipvSessionId ? { "ipv-session-id": ipvSessionId } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `callbackFromStrategicApp request failed: ${response.statusText}`,
+    );
+  }
+};
+
+export const pollAsyncDcmaw = async (
+  ipvSessionId: string | undefined,
+  featureSet: string | undefined,
+): Promise<JourneyResponse> => {
+  const url = `${config.core.internalApiUrl}/app/check-vc-receipt`;
+  const response = await fetch(url, {
+    method: POST,
+    headers: {
+      "Content-Type": "application/json",
+      ...(featureSet ? { "feature-set": featureSet } : {}),
+      ...(ipvSessionId ? { "ipv-session-id": ipvSessionId } : {}),
+    },
+  });
+
+  if (response.ok) {
+    return response.json();
+  }
+
+  if (response.status === 404) {
+    return;
+  }
+
+  throw new Error(
+    `callbackFromStrategicApp request failed: ${response.statusText}`,
+  );
+};
+
 export const processCriCallback = async (
   requestBody: ProcessCriCallbackRequest,
   ipvSessionId: string | undefined,

--- a/api-tests/src/hooks.ts
+++ b/api-tests/src/hooks.ts
@@ -1,12 +1,12 @@
 import { After } from "@cucumber/cucumber";
 
-After({ tags: "@InitialisesDCMAWSessionState" }, async () => {
+After({ tags: "@InitialisesDCMAWSessionState" }, async function () {
   const response = await fetch(
     `https://dcmaw-async.stubs.account.gov.uk/management/cleanupDcmawState`,
     {
       method: "POST",
       body: JSON.stringify({
-        user_id: this.user_id,
+        user_id: this.userId,
       }),
       redirect: "manual",
     },

--- a/api-tests/src/hooks.ts
+++ b/api-tests/src/hooks.ts
@@ -1,0 +1,20 @@
+import { After } from "@cucumber/cucumber";
+
+After({ tags: "@InitialisesDCMAWSessionState" }, async () => {
+  const response = await fetch(
+    `https://dcmaw-async.stubs.account.gov.uk/management/cleanupDcmawState`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        user_id: this.user_id,
+      }),
+      redirect: "manual",
+    },
+  );
+
+  if (response.status !== 200) {
+    throw new Error(
+      `DCMAW session state cleanup request failed: ${response.statusText}`,
+    );
+  }
+});

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -500,6 +500,10 @@ When(
       });
     }
 
+    if (!this.oauthState) {
+      throw new Error("Oauth state must not be undefined");
+    }
+
     this.lastJourneyEngineResponse = await callbackFromStrategicApp(
       this.oauthState,
       separateSession ? undefined : this.ipvSessionId,

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -467,7 +467,7 @@ When(
       },
     );
 
-    if (response.status !== 200) {
+    if (response.status !== 201) {
       throw new Error(`DCMAW enqueue request failed: ${response.statusText}`);
     }
 
@@ -494,7 +494,7 @@ When(
       throw new Error("Oauth state required for app callback");
     }
 
-    await callbackFromStrategicApp(
+    this.lastJourneyEngineResponse = await callbackFromStrategicApp(
       this.oauthState,
       separateSession ? undefined : this.ipvSessionId,
       this.featureSet,
@@ -514,6 +514,10 @@ When(
       numberOfAttempts++;
 
       await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    if (!this.strategicAppPollResult) {
+      throw new Error("Polling unsuccessful.");
     }
   },
 );

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -29,6 +29,7 @@ import {
   callbackFromStrategicApp,
   pollAsyncDcmaw,
 } from "../clients/core-back-internal-client.js";
+import config from "../config/config.js";
 
 const EXPIRED_NBF = 1658829758; // 26/07/2022 in epoch seconds
 const STANDARD_JAR_VALUES = [
@@ -449,16 +450,13 @@ When(
     documentType: string,
     evidenceType: string,
   ): Promise<void> {
-    // TODO: Don't we want a similar layout for the async dcmaw and f2f queue requests?
-
     const body = {
       user_id: this.userId,
       test_user: testUser,
       document_type: documentType,
       evidence_type: evidenceType,
+      queue_name: config.asyncQueue.name,
     };
-
-    // TODO: how can it do this in local?
 
     const response = await fetch(
       `https://dcmaw-async.stubs.account.gov.uk/management/enqueueVc`,

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -469,12 +469,13 @@ const postToEnqueue = async (body: object) => {
 };
 
 When(
-  /^the DCMAW CRI produces a '([\w-]+)' '([\w-]+)' '([\w-]+)' VC$/,
+  /^the DCMAW CRI produces a '([\w-]+)' '([\w-]+)' '([\w-]+)' VC( with a CI)?$/,
   async function (
     this: World,
     testUser: string,
     documentType: string,
     evidenceType: string,
+    hasCi: " with a CI" | undefined,
   ): Promise<void> {
     this.oauthState = await postToEnqueue({
       user_id: this.userId,
@@ -482,6 +483,7 @@ When(
       document_type: documentType,
       evidence_type: evidenceType,
       queue_name: config.asyncQueue.name,
+      ci: hasCi && ["BREACHING"],
     });
   },
 );

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -1,4 +1,4 @@
-import { DataTable, When } from "@cucumber/cucumber";
+import { DataTable, Then, When } from "@cucumber/cucumber";
 import { World } from "../types/world.js";
 import * as internalClient from "../clients/core-back-internal-client.js";
 import * as criStubClient from "../clients/cri-stub-client.js";
@@ -515,10 +515,6 @@ When(
 
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
-
-    if (!this.strategicAppPollResult) {
-      throw new Error("Polling unsuccessful.");
-    }
   },
 );
 
@@ -537,6 +533,12 @@ When(
     );
   },
 );
+
+Then("the poll returns a 404", async function (this: World): Promise<void> {
+  if (this.strategicAppPollResult?.journey) {
+    throw new Error("Poll should have not returned a journey.");
+  }
+});
 
 const assertNoUnexpectedJarProperties = (
   jarPayload: CriStubResponseJarPayload,

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -494,7 +494,9 @@ When(
     this: World,
     separateSession: " in a separate session" | undefined,
   ): Promise<void> {
+    // If we've asked the stub to create a VC for us, we will already have the OAuth state.
     if (!this.oauthState) {
+      // If we post to the stub's Enqueue endpoint without specifying VC details it just returns the OAuth state to us.
       this.oauthState = await postToEnqueue({
         user_id: this.userId,
       });

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -465,7 +465,7 @@ const postToEnqueue = async (body: object) => {
       `DCMAW enqueue request did not return a string oauthState: ${responsePayload.oauthState}`,
     );
   }
-  this.oauthState = responsePayload.oauthState;
+  return responsePayload.oauthState;
 };
 
 When(
@@ -476,7 +476,7 @@ When(
     documentType: string,
     evidenceType: string,
   ): Promise<void> {
-    await postToEnqueue({
+    this.oauthState = await postToEnqueue({
       user_id: this.userId,
       test_user: testUser,
       document_type: documentType,
@@ -489,7 +489,7 @@ When(
 When(
   "I do not submit VC to the async DCMAW CRI stub",
   async function (this: World): Promise<void> {
-    await postToEnqueue({
+    this.oauthState = await postToEnqueue({
       user_id: this.userId,
     });
   },

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -160,6 +160,26 @@ Then(
   },
 );
 
+Then(
+    /I get an error response with message '([\w,: ]+)' and status code '(\d{3})'/,
+    function (
+        this: World,
+        expectedMessage: string,
+        expectedStatusCode: number,
+    ) {
+        if (!this.lastJourneyEngineResponse) {
+            throw new Error("No last journey engine response found.");
+        }
+
+        assert.ok(
+            isErrorResponse(this.lastJourneyEngineResponse),
+            `got a ${describeResponse(this.lastJourneyEngineResponse)}`,
+        );
+        assert.equal(this.lastJourneyEngineResponse.message, expectedMessage);
+        assert.equal(this.lastJourneyEngineResponse.statusCode, expectedStatusCode);
+    },
+);
+
 When(
   "I start a new {string} inherited identity journey with an invalid inherited identity JWT",
   async function (this: World, journeyType: string): Promise<void> {

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -19,6 +19,7 @@ import { getRandomString } from "../utils/random-string-generator.js";
 import {
   isClientResponse,
   isCriResponse,
+  isErrorResponse,
   isJourneyResponse,
   isPageResponse,
   JourneyEngineResponse,

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -161,23 +161,19 @@ Then(
 );
 
 Then(
-    /I get an error response with message '([\w,: ]+)' and status code '(\d{3})'/,
-    function (
-        this: World,
-        expectedMessage: string,
-        expectedStatusCode: number,
-    ) {
-        if (!this.lastJourneyEngineResponse) {
-            throw new Error("No last journey engine response found.");
-        }
+  /I get an error response with message '([\w,: ]+)' and status code '(\d{3})'/,
+  function (this: World, expectedMessage: string, expectedStatusCode: number) {
+    if (!this.lastJourneyEngineResponse) {
+      throw new Error("No last journey engine response found.");
+    }
 
-        assert.ok(
-            isErrorResponse(this.lastJourneyEngineResponse),
-            `got a ${describeResponse(this.lastJourneyEngineResponse)}`,
-        );
-        assert.equal(this.lastJourneyEngineResponse.message, expectedMessage);
-        assert.equal(this.lastJourneyEngineResponse.statusCode, expectedStatusCode);
-    },
+    assert.ok(
+      isErrorResponse(this.lastJourneyEngineResponse),
+      `got a ${describeResponse(this.lastJourneyEngineResponse)}`,
+    );
+    assert.equal(this.lastJourneyEngineResponse.message, expectedMessage);
+    assert.equal(this.lastJourneyEngineResponse.statusCode, expectedStatusCode);
+  },
 );
 
 When(

--- a/api-tests/src/types/internal-api.ts
+++ b/api-tests/src/types/internal-api.ts
@@ -64,11 +64,13 @@ export const isClientResponse = (
 };
 
 export interface ErrorResponse {
-  code: number, message: string, statusCode: number;
+  code: number;
+  message: string;
+  statusCode: number;
 }
 
 export const isErrorResponse = (
-    journeyEngineResponse: JourneyEngineResponse,
+  journeyEngineResponse: JourneyEngineResponse,
 ): journeyEngineResponse is ErrorResponse => {
   return !!(journeyEngineResponse as ErrorResponse).code;
 };

--- a/api-tests/src/types/internal-api.ts
+++ b/api-tests/src/types/internal-api.ts
@@ -16,7 +16,8 @@ export type JourneyEngineResponse =
   | JourneyResponse
   | PageResponse
   | CriResponse
-  | ClientResponse;
+  | ClientResponse
+  | ErrorResponse;
 
 export interface JourneyResponse {
   journey: string;
@@ -60,6 +61,16 @@ export const isClientResponse = (
   journeyEngineResponse: JourneyEngineResponse,
 ): journeyEngineResponse is ClientResponse => {
   return !!(journeyEngineResponse as ClientResponse).client?.redirectUrl;
+};
+
+export interface ErrorResponse {
+  code: number, message: string, statusCode: number;
+}
+
+export const isErrorResponse = (
+    journeyEngineResponse: JourneyEngineResponse,
+): journeyEngineResponse is ErrorResponse => {
+  return !!(journeyEngineResponse as ErrorResponse).code;
 };
 
 export interface ProcessCriCallbackRequest {

--- a/api-tests/src/types/world.ts
+++ b/api-tests/src/types/world.ts
@@ -1,4 +1,4 @@
-import { JourneyEngineResponse } from "./internal-api.js";
+import { JourneyEngineResponse, JourneyResponse } from "./internal-api.js";
 import { MfaResetResult, UserIdentity } from "./external-api.js";
 import { World as CucumberWorld } from "@cucumber/cucumber";
 import { VcJwtPayload } from "./external-api.js";
@@ -33,4 +33,8 @@ export interface World extends CucumberWorld {
 
   // Latest error to assert against
   error?: Error;
+
+  // Strategic app latent variables
+  oauthState?: string;
+  strategicAppPollResult?: JourneyResponse;
 }

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -110,7 +110,7 @@ public class CheckMobileAppVcReceiptHandler
             }
 
             // Frontend will continue polling
-            return ApiGatewayResponseGenerator.proxyResponse(HttpStatus.SC_NOT_FOUND);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_NOT_FOUND, null);
         } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
             return buildErrorResponse(e, HttpStatus.SC_BAD_REQUEST, e.getErrorResponse());
         } catch (IpvSessionNotFoundException e) {
@@ -197,12 +197,19 @@ public class CheckMobileAppVcReceiptHandler
         sessionCredentialsService.persistCredentials(
                 List.of(dcmawAsyncVc.get()), ipvSessionItem.getIpvSessionId(), false);
 
-        return criCheckingService.checkVcResponse(
-                List.of(dcmawAsyncVc.get()),
-                request.getIpAddress(),
-                clientOAuthSessionItem,
-                ipvSessionItem,
-                sessionCredentialsService.getCredentials(ipvSessionItem.getIpvSessionId(), userId));
+        System.out.printf("dcmawAsyncVc %s", dcmawAsyncVc.get().getVcString());
+
+        var a =
+                criCheckingService.checkVcResponse(
+                        List.of(dcmawAsyncVc.get()),
+                        request.getIpAddress(),
+                        clientOAuthSessionItem,
+                        ipvSessionItem,
+                        sessionCredentialsService.getCredentials(
+                                ipvSessionItem.getIpvSessionId(), userId));
+
+        System.out.printf("dcmawAsyncVc a %s", a.getJourney());
+        return a;
     }
 
     private void validateSessionId(CheckMobileAppVcReceiptRequest request)

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -197,19 +197,12 @@ public class CheckMobileAppVcReceiptHandler
         sessionCredentialsService.persistCredentials(
                 List.of(dcmawAsyncVc.get()), ipvSessionItem.getIpvSessionId(), false);
 
-        System.out.printf("dcmawAsyncVc %s", dcmawAsyncVc.get().getVcString());
-
-        var a =
-                criCheckingService.checkVcResponse(
-                        List.of(dcmawAsyncVc.get()),
-                        request.getIpAddress(),
-                        clientOAuthSessionItem,
-                        ipvSessionItem,
-                        sessionCredentialsService.getCredentials(
-                                ipvSessionItem.getIpvSessionId(), userId));
-
-        System.out.printf("dcmawAsyncVc a %s", a.getJourney());
-        return a;
+        return criCheckingService.checkVcResponse(
+                List.of(dcmawAsyncVc.get()),
+                request.getIpAddress(),
+                clientOAuthSessionItem,
+                ipvSessionItem,
+                sessionCredentialsService.getCredentials(ipvSessionItem.getIpvSessionId(), userId));
     }
 
     private void validateSessionId(CheckMobileAppVcReceiptRequest request)

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -110,7 +110,7 @@ public class CheckMobileAppVcReceiptHandler
             }
 
             // Frontend will continue polling
-            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_NOT_FOUND, null);
+            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_NOT_FOUND, "No VC found");
         } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
             return buildErrorResponse(e, HttpStatus.SC_BAD_REQUEST, e.getErrorResponse());
         } catch (IpvSessionNotFoundException e) {

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -110,7 +110,8 @@ public class CheckMobileAppVcReceiptHandler
             }
 
             // Frontend will continue polling
-            return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatus.SC_NOT_FOUND, "No VC found");
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    HttpStatus.SC_NOT_FOUND, "No VC found");
         } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
             return buildErrorResponse(e, HttpStatus.SC_BAD_REQUEST, e.getErrorResponse());
         } catch (IpvSessionNotFoundException e) {

--- a/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
@@ -236,6 +236,7 @@ class CheckMobileAppVcReceiptHandlerTest {
 
         // Assert
         assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        assertEquals("\"No VC found\"", response.getBody());
         verify(sessionCredentialsService, never()).persistCredentials(any(), any(), anyBoolean());
     }
 

--- a/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -237,7 +236,6 @@ class CheckMobileAppVcReceiptHandlerTest {
 
         // Assert
         assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
-        assertNull(response.getBody());
         verify(sessionCredentialsService, never()).persistCredentials(any(), any(), anyBoolean());
     }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/ApiGatewayResponseGenerator.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/ApiGatewayResponseGenerator.java
@@ -33,14 +33,6 @@ public class ApiGatewayResponseGenerator {
         }
     }
 
-    public static APIGatewayProxyResponseEvent proxyResponse(int statusCode) {
-        APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =
-                new APIGatewayProxyResponseEvent();
-        apiGatewayProxyResponseEvent.setStatusCode(statusCode);
-
-        return apiGatewayProxyResponseEvent;
-    }
-
     public static APIGatewayProxyResponseEvent proxyResponse(
             int statusCode, String body, Map<String, String> headers) {
         APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 			project(":lambdas:check-coi"),
 			project(":lambdas:check-existing-identity"),
 			project(":lambdas:check-gpg45-score"),
+			project(":lambdas:check-mobile-app-vc-receipt"),
 			project(":lambdas:check-reverification-identity"),
 			project(":lambdas:evaluate-gpg45-scores"),
 			project(":lambdas:initialise-ipv-session"),

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -134,6 +134,7 @@ core:
           "credentialUrl": "https://dcmaw-async.stubs.account.gov.uk/async/credential",
           "tokenUrl":"https://dcmaw-async.stubs.account.gov.uk/async/token",
           "clientId": "dummyClientId",
+          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}","encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
           "componentId":"https://dcmaw-async.stubs.account.gov.uk",
           "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/dcmawAsync",
           "requiresApiKey": "false",

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/CoreBack.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/CoreBack.java
@@ -36,6 +36,7 @@ public class CoreBack {
         app.post("/journey/{event}", journeyEngineHandler::journeyEngine);
         app.post("/cri/callback", lambdaHandler::criCallback);
         app.post("/app/callback", lambdaHandler::appCallback);
+        app.post("/app/check-vc-receipt", lambdaHandler::checkMobileAppVcReceipt);
         app.get("/user/proven-identity-details", lambdaHandler::getProvenUserIdentityDetails);
 
         // External APIs

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/LambdaHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import io.javalin.http.Context;
 import uk.gov.di.ipv.core.buildprovenuseridentitydetails.BuildProvenUserIdentityDetailsHandler;
 import uk.gov.di.ipv.core.builduseridentity.BuildUserIdentityHandler;
+import uk.gov.di.ipv.core.checkmobileappvcreceipt.CheckMobileAppVcReceiptHandler;
 import uk.gov.di.ipv.core.initialiseipvsession.InitialiseIpvSessionHandler;
 import uk.gov.di.ipv.core.issueclientaccesstoken.IssueClientAccessTokenHandler;
 import uk.gov.di.ipv.core.processcricallback.ProcessCriCallbackHandler;
@@ -23,6 +24,8 @@ public class LambdaHandler {
     private final ProcessCriCallbackHandler criCallbackHandler = new ProcessCriCallbackHandler();
     private final ProcessMobileAppCallbackHandler appCallbackHandler =
             new ProcessMobileAppCallbackHandler();
+    private final CheckMobileAppVcReceiptHandler checkMobileAppVcReceiptHandler =
+            new CheckMobileAppVcReceiptHandler();
     private final IssueClientAccessTokenHandler tokenHandler = new IssueClientAccessTokenHandler();
     private final BuildUserIdentityHandler userIdentityHandler = new BuildUserIdentityHandler();
     private final UserReverificationHandler userReverificationHandler =
@@ -60,6 +63,10 @@ public class LambdaHandler {
 
     public void appCallback(Context ctx) {
         handleApiGatewayProxyRoute(ctx, this.appCallbackHandler);
+    }
+
+    public void checkMobileAppVcReceipt(Context ctx) {
+        handleApiGatewayProxyRoute(ctx, this.checkMobileAppVcReceiptHandler);
     }
 
     public void getToken(Context ctx) {


### PR DESCRIPTION
## Proposed changes

Copy of https://github.com/govuk-one-login/ipv-core-back/pull/2833 to see if a fresh PR fixes pact upload

### What changed

- Add steps to complete a strategic app journey in API tests

### Why did it change

- To improve API tests cover of the new async DCMAW feature

### Issue tracking

- [PYIC-7785](https://govukverify.atlassian.net/browse/PYIC-7785)

[PYIC-7785]: https://govukverify.atlassian.net/browse/PYIC-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ