### PR TITLE
PYIC-7941: add workaround to fix driving licence cimit bug

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -260,7 +260,7 @@ public class CriCheckingService {
                         && requiresAuthoritativeSourceCheck(newVcs, sessionVcs)) {
                     return JOURNEY_DL_AUTH_SOURCE_CHECK;
                 }
-                return journeyResponse.get();
+                return jr;
             }
         }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- Add workaround to fix driving licence cimit bug

### What changed

- Added extra check to redirect to auth source check when licence details doesn't match

<!-- Describe the changes in detail - the "what"-->


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7941](https://govukverify.atlassian.net/browse/PYIC-7941)


[PYIC-7941]: https://govukverify.atlassian.net/browse/PYIC-7941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ