### PR TITLE
PYIC-7785: Add internal headers to new test methods calling internal API methods

### DIFF
--- a/api-tests/src/clients/core-back-internal-client.ts
+++ b/api-tests/src/clients/core-back-internal-client.ts
@@ -78,7 +78,7 @@ export const callbackFromStrategicApp = async (
   const response = await fetch(url, {
     method: POST,
     headers: {
-      "Content-Type": "application/json",
+      ...internalApiHeaders,
       ...(featureSet ? { "feature-set": featureSet } : {}),
       ...(ipvSessionId ? { "ipv-session-id": ipvSessionId } : {}),
     },
@@ -104,7 +104,7 @@ export const pollAsyncDcmaw = async (
   const response = await fetch(url, {
     method: POST,
     headers: {
-      "Content-Type": "application/json",
+      ...internalApiHeaders,
       ...(featureSet ? { "feature-set": featureSet } : {}),
       ...(ipvSessionId ? { "ipv-session-id": ipvSessionId } : {}),
     },


### PR DESCRIPTION


## Proposed changes

### What changed

Bring these methods in to line with all the other API calling methods

### Why did it change

We are getting a `Forbidden` response on build in `callbackFromStrategicApp`

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7785](https://govukverify.atlassian.net/browse/PYIC-7785)


[PYIC-7785]: https://govukverify.atlassian.net/browse/PYIC-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ