### PR TITLE
PYIC-7785: [TEST] Reinstate complete Strategic App journeys API tests

### DIFF
--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -13,119 +13,119 @@ Feature: M2B Strategic App Journeys
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-#    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
-#    # And the user returns from the app to core-front
-#    And I pass on the DCMAW callback
-#    Then I get a 'check-mobile-app-result' page response
-#    When I poll for async DCMAW credential receipt
-#    Then the poll returns a '201'
-#    When I submit the returned journey event
-#    Then I get a 'page-dcmaw-success' page response
-#    When I submit a 'next' event
-#    Then I get an 'address' CRI response
-#    When I submit 'kenneth-current' details to the CRI stub
-#    Then I get a 'fraud' CRI response
-#    When I submit 'kenneth-score-2' details to the CRI stub
-#    Then I get a 'page-ipv-success' page response
-#    When I submit a 'next' event
-#    Then I get an OAuth response
-#    When I use the OAuth response to get my identity
-#    Then I get a 'P2' identity
-#
-#  Scenario: MAM journey pending credential
-#    Given I activate the 'strategicApp' feature set
-#    When I start a new 'medium-confidence' journey
-#    Then I get a 'page-ipv-identity-document-start' page response
-#    When I submit an 'appTriage' event
-#    Then I get a 'identify-device' page response
-#    When I submit an 'appTriage' event
-#    Then I get a 'pyi-triage-select-device' page response
-#    When I submit a 'smartphone' event
-#    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-#    When I submit an 'iphone' event
-#    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-#    # And the user returns from the app to core-front
-#    When I pass on the DCMAW callback
-#    Then I get an 'check-mobile-app-result' page response
-#    When I poll for async DCMAW credential receipt
-#    Then the poll returns a '404'
-#    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
-#    And I poll for async DCMAW credential receipt
-#    Then the poll returns a '201'
-#
-#  Scenario: MAM journey cross-browser scenario
-#    Given I activate the 'strategicApp' feature set
-#    When I start a new 'medium-confidence' journey
-#    Then I get a 'page-ipv-identity-document-start' page response
-#    When I submit an 'appTriage' event
-#    Then I get a 'identify-device' page response
-#    When I submit an 'appTriage' event
-#    Then I get a 'pyi-triage-select-device' page response
-#    When I submit a 'smartphone' event
-#    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-#    When I submit an 'iphone' event
-#    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-#    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
-#    # And the user returns from the app to core-front
-#    And I pass on the DCMAW callback in a separate session
-#    Then I get an error response with message 'Missing ipv session id header' and status code '400'
-#    # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
-#    # has managed to log back in to the site.
-#    When I poll for async DCMAW credential receipt
-#    And I start a new 'medium-confidence' journey
-#    Then I get a 'page-dcmaw-success' page response
-#    When I submit a 'next' event
-#    Then I get an 'address' CRI response
-#    When I submit 'kenneth-current' details to the CRI stub
-#    Then I get a 'fraud' CRI response
-#    When I submit 'kenneth-score-2' details to the CRI stub
-#    Then I get a 'page-ipv-success' page response
-#    When I submit a 'next' event
-#    Then I get an OAuth response
-#    When I use the OAuth response to get my identity
-#    Then I get a 'P2' identity
-#
-#  Scenario: MAM journey credential fails with no ci
-#    Given I activate the 'strategicApp' feature set
-#    When I start a new 'medium-confidence' journey
-#    Then I get a 'page-ipv-identity-document-start' page response
-#    When I submit an 'appTriage' event
-#    Then I get a 'identify-device' page response
-#    When I submit an 'appTriage' event
-#    Then I get a 'pyi-triage-select-device' page response
-#    When I submit a 'smartphone' event
-#    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-#    When I submit an 'iphone' event
-#    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-#    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
-#    # And the user returns from the app to core-front
-#    And I pass on the DCMAW callback
-#    Then I get an 'check-mobile-app-result' page response
-#    When I poll for async DCMAW credential receipt
-#    Then the poll returns a '201'
-#    When I submit the returned journey event
-#    Then I get an 'page-multiple-doc-check' page response
-#
-#  Scenario: MAM journey credential fails with ci
-#    Given I activate the 'strategicApp' feature set
-#    When I start a new 'medium-confidence' journey
-#    Then I get a 'page-ipv-identity-document-start' page response
-#    When I submit an 'appTriage' event
-#    Then I get a 'identify-device' page response
-#    When I submit an 'appTriage' event
-#    Then I get a 'pyi-triage-select-device' page response
-#    When I submit a 'smartphone' event
-#    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-#    When I submit an 'iphone' event
-#    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-#    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
-#    # And the user returns from the app to core-front
-#    And I pass on the DCMAW callback
-#    Then I get an 'check-mobile-app-result' page response
-#    When I poll for async DCMAW credential receipt
-#    Then the poll returns a '201'
-#    When I submit the returned journey event
-#    Then I get an 'pyi-no-match' page response
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get a 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+  Scenario: MAM journey pending credential
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    # And the user returns from the app to core-front
+    When I pass on the DCMAW callback
+    Then I get an 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '404'
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+    And I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+
+  Scenario: MAM journey cross-browser scenario
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback in a separate session
+    Then I get an error response with message 'Missing ipv session id header' and status code '400'
+    # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+    # has managed to log back in to the site.
+    When I poll for async DCMAW credential receipt
+    And I start a new 'medium-confidence' journey
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+  Scenario: MAM journey credential fails with no ci
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get an 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get an 'page-multiple-doc-check' page response
+
+  Scenario: MAM journey credential fails with ci
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    When the DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get an 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get an 'pyi-no-match' page response
 
   Scenario: MAM journey detected iphone
     Given I activate the 'strategicApp' feature set


### PR DESCRIPTION
## Proposed changes

### What changed

- Reinstate Strategic App full journey routes

### Why did it change

- To test how the API tests are broken

### Issue tracking

- [PYIC-7785](https://govukverify.atlassian.net/browse/PYIC-7785)

[PYIC-7785]: https://govukverify.atlassian.net/browse/PYIC-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ