### PR TITLE
PYIC-7938: configure canary alarms for process candidate identity lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1625,6 +1625,7 @@ Resources:
             - !Ref ResetSessionIdentityFunctionErrorCanaryAlarm
             - !Ref CheckCoiFunctionErrorCanaryAlarm
             - !Ref CheckReverificationIdentityFunctionErrorCanaryAlarm
+            - !Ref ProcessCandidateIdentityFunctionErrorCanaryAlarm
           - !Ref AWS::NoValue
         StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${JourneyEngineStepFunction}:live"
       Events:
@@ -4104,6 +4105,32 @@ Resources:
           Value: !Ref CheckReverificationIdentityFunction
         - Name: ExecutedVersion
           Value: !GetAtt CheckReverificationIdentityFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 3
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  ProcessCandidateIdentityFunctionErrorCanaryAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      AlarmDescription: !Sub "Error returned from the ProcessCandidateIdentityFunction."
+      AlarmName: !Sub ${AWS::StackName}-ProcessCandidateIdentityFunction-ErrorCanary
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "process-candidate-identity-${Environment}:live"
+        - Name: FunctionName
+          Value: !Ref ProcessCandidateIdentityFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt ProcessCandidateIdentityFunction.Version.Version
       Namespace: AWS/Lambda
       Statistic: Sum
       Unit: Count


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Configures canary alarm for new lambda

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7938](https://govukverify.atlassian.net/browse/PYIC-7938)


[PYIC-7938]: https://govukverify.atlassian.net/browse/PYIC-7938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ