### PR TITLE
PYIC-7963: Deduplicate shared claims names with case insensitivity

### DIFF
--- a/api-tests/data/audit-events/new-identity-p2-app-journey.json
+++ b/api-tests/data/audit-events/new-identity-p2-app-journey.json
@@ -182,11 +182,11 @@
           "nameParts": [
             {
               "type": "GivenName",
-              "value": "Kenneth"
+              "value": "KENNETH"
             },
             {
               "type": "FamilyName",
-              "value": "Decerqueira"
+              "value": "DECERQUEIRA"
             }
           ]
         }

--- a/api-tests/data/audit-events/reprove-identity-journey.json
+++ b/api-tests/data/audit-events/reprove-identity-journey.json
@@ -203,11 +203,11 @@
           "nameParts": [
             {
               "type": "GivenName",
-              "value": "Kenneth"
+              "value": "KENNETH"
             },
             {
               "type": "FamilyName",
-              "value": "Decerqueira"
+              "value": "DECERQUEIRA"
             }
           ]
         }

--- a/api-tests/data/cri-stub-requests/dcmaw/alice-passport-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/alice-passport-valid/credentialSubject.json
@@ -3,19 +3,19 @@
     {
       "nameParts": [
         {
-          "value": "Alice",
+          "value": "ALICE",
           "type": "GivenName"
         },
         {
-          "value": "Jane",
+          "value": "JANE",
           "type": "GivenName"
         },
         {
-          "value": "Laura",
+          "value": "LAURA",
           "type": "GivenName"
         },
         {
-          "value": "Doe",
+          "value": "DOE",
           "type": "FamilyName"
         }
       ]

--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-brc-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-brc-valid/credentialSubject.json
@@ -12,11 +12,11 @@
       "nameParts": [
         {
           "type": "GivenName",
-          "value": "Kenneth"
+          "value": "KENNETH"
         },
         {
           "type": "FamilyName",
-          "value": "Decerqueira"
+          "value": "DECERQUEIRA"
         }
       ]
     }

--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-family-name-passport-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-family-name-passport-valid/credentialSubject.json
@@ -11,11 +11,11 @@
       "nameParts": [
         {
           "type": "GivenName",
-          "value": "Kenneth"
+          "value": "KENNETH"
         },
         {
           "type": "FamilyName",
-          "value": "Smith"
+          "value": "SMITH"
         }
       ]
     }

--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-given-name-passport-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-changed-given-name-passport-valid/credentialSubject.json
@@ -11,11 +11,11 @@
       "nameParts": [
         {
           "type": "GivenName",
-          "value": "Ken"
+          "value": "KEN"
         },
         {
           "type": "FamilyName",
-          "value": "Decerqueira"
+          "value": "DECERQUEIRA"
         }
       ]
     }

--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-fail-no-ci/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-fail-no-ci/credentialSubject.json
@@ -11,11 +11,11 @@
       "nameParts": [
         {
           "type": "GivenName",
-          "value": "Kenneth"
+          "value": "KENNETH"
         },
         {
           "type": "FamilyName",
-          "value": "Decerqueira"
+          "value": "DECERQUEIRA"
         }
       ]
     }

--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-valid/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-valid/credentialSubject.json
@@ -11,11 +11,11 @@
       "nameParts": [
         {
           "type": "GivenName",
-          "value": "Kenneth"
+          "value": "KENNETH"
         },
         {
           "type": "FamilyName",
-          "value": "Decerqueira"
+          "value": "DECERQUEIRA"
         }
       ]
     }

--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-verification-zero/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-passport-verification-zero/credentialSubject.json
@@ -11,11 +11,11 @@
       "nameParts": [
         {
           "type": "GivenName",
-          "value": "Kenneth"
+          "value": "KENNETH"
         },
         {
           "type": "FamilyName",
-          "value": "Decerqueira"
+          "value": "DECERQUEIRA"
         }
       ]
     }

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -334,7 +334,6 @@ public class BuildCriOauthRequestHandler
         var sharedClaims =
                 SharedClaimsHelper.generateSharedClaims(
                         ipvSessionItem.getEmailAddress(), vcs, getAllowedSharedClaimAttrs(cri));
-        sharedClaims.setName(userIdentityService.deduplicateNames(sharedClaims.getName()));
 
         if (cri.equals(F2F)) {
             evidenceRequest =

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -103,7 +103,6 @@ public class BuildCriOauthRequestHandler
     private final Gpg45ProfileEvaluator gpg45ProfileEvaluator;
     private final SessionCredentialsService sessionCredentialsService;
     private final OAuthKeyService oAuthKeyService;
-    private final UserIdentityService userIdentityService;
 
     @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public BuildCriOauthRequestHandler(
@@ -126,7 +125,6 @@ public class BuildCriOauthRequestHandler
         this.gpg45ProfileEvaluator = gpg45ProfileEvaluator;
         this.sessionCredentialsService = sessionCredentialsService;
         this.oAuthKeyService = oAuthKeyService;
-        this.userIdentityService = userIdentityService;
 
         VcHelper.setConfigService(this.configService);
     }
@@ -147,7 +145,6 @@ public class BuildCriOauthRequestHandler
         this.gpg45ProfileEvaluator = new Gpg45ProfileEvaluator();
         this.sessionCredentialsService = new SessionCredentialsService(configService);
         this.oAuthKeyService = new OAuthKeyService(configService);
-        this.userIdentityService = new UserIdentityService(configService);
         VcHelper.setConfigService(configService);
     }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
@@ -1,0 +1,61 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.model.Name;
+import uk.gov.di.model.NamePart;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class NameHelper {
+
+    @ExcludeFromGeneratedCoverageReport
+    private NameHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static Set<Name> deduplicateNames(Set<Name> names) {
+        if (names == null) {
+            return null;
+        }
+
+        var capitalisedFullNames = new ArrayList<String>();
+
+        return names.stream()
+                .filter(
+                        name -> {
+                            var capitalisedFullName = NameHelper.getFullName(name).toUpperCase();
+
+                            if (!capitalisedFullNames.contains(capitalisedFullName)) {
+                                capitalisedFullNames.add(capitalisedFullName);
+                                return true;
+                            }
+                            return false;
+                        })
+                .collect(Collectors.toSet());
+    }
+
+    public static String getFullName(Name name) {
+        var nameParts = name.getNameParts();
+
+        String givenNames =
+                nameParts.stream()
+                        .filter(
+                                namePart ->
+                                        NamePart.NamePartType.GIVEN_NAME.equals(namePart.getType()))
+                        .map(NamePart::getValue)
+                        .collect(Collectors.joining(" "));
+
+        String familyNames =
+                nameParts.stream()
+                        .filter(
+                                namePart ->
+                                        NamePart.NamePartType.FAMILY_NAME.equals(
+                                                namePart.getType()))
+                        .map(NamePart::getValue)
+                        .collect(Collectors.joining(" "));
+
+        return (givenNames + " " + familyNames).trim();
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
@@ -17,7 +17,7 @@ public class NameHelper {
 
     public static Set<Name> deduplicateNames(Set<Name> names) {
         if (names == null) {
-            return null;
+            return Set.of();
         }
 
         var capitalisedFullNames = new ArrayList<String>();

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/NameHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/NameHelperTest.java
@@ -5,25 +5,24 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
 
 class NameHelperTest {
     @Test
     void shouldDeduplicateNamesWithCaseInsensitivity() {
         // Arrange
-        var names =
-                Set.of(
-                        createName("martin", "smith"),
-                        createName("Martin", "Smith"),
-                        createName("MARTIN", "SMITH"),
-                        createName("Harry", "Smithy"));
+        var name1 = createName("martin", "smith");
+        var name2 = createName("Martin", "smith");
+        var name3 = createName("MARTIN", "smith");
+        var name4 = createName("Harry", "smith");
+        var names = Set.of(name1, name2, name3, name4);
 
         // Act
         var deduplicateNames = NameHelper.deduplicateNames(names);
 
         // Assert
-        assertEquals(
-                Set.of(createName("martin", "smith"), createName("Harry", "Smithy")),
-                deduplicateNames);
+        assertEquals(2, deduplicateNames.size());
+        assertTrue(deduplicateNames.contains(name4));
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/NameHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/NameHelperTest.java
@@ -1,0 +1,29 @@
+package uk.gov.di.ipv.core.library.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
+
+class NameHelperTest {
+    @Test
+    void shouldDeduplicateNamesWithCaseInsensitivity() {
+        // Arrange
+        var names =
+                Set.of(
+                        createName("martin", "smith"),
+                        createName("Martin", "Smith"),
+                        createName("MARTIN", "SMITH"),
+                        createName("Harry", "Smithy"));
+
+        // Act
+        var deduplicateNames = NameHelper.deduplicateNames(names);
+
+        // Assert
+        assertEquals(
+                Set.of(createName("martin", "smith"), createName("Harry", "Smithy")),
+                deduplicateNames);
+    }
+}

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -18,6 +18,7 @@ import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.helpers.NameHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.model.AddressCredential;
 import uk.gov.di.model.BirthDate;
@@ -38,7 +39,6 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -353,48 +353,8 @@ public class UserIdentityService {
     private List<String> getFullNamesFromCredentials(List<IdentityClaim> identityClaims) {
         return identityClaims.stream()
                 .flatMap(claim -> claim.getName().stream())
-                .map(this::getFullName)
+                .map(NameHelper::getFullName)
                 .toList();
-    }
-
-    public Set<Name> deduplicateNames(Set<Name> names) {
-        var capitalisedFullNames = new ArrayList<String>();
-
-        return names.stream()
-                .filter(
-                        name -> {
-                            var capitalisedFullName = this.getFullName(name).toUpperCase();
-
-                            if (!capitalisedFullNames.contains(capitalisedFullName)) {
-                                capitalisedFullNames.add(capitalisedFullName);
-                                return true;
-                            }
-                            return false;
-                        })
-                .collect(Collectors.toSet());
-    }
-
-    private String getFullName(Name name) {
-        var nameParts = name.getNameParts();
-
-        String givenNames =
-                nameParts.stream()
-                        .filter(
-                                namePart ->
-                                        NamePart.NamePartType.GIVEN_NAME.equals(namePart.getType()))
-                        .map(NamePart::getValue)
-                        .collect(Collectors.joining(" "));
-
-        String familyNames =
-                nameParts.stream()
-                        .filter(
-                                namePart ->
-                                        NamePart.NamePartType.FAMILY_NAME.equals(
-                                                namePart.getType()))
-                        .map(NamePart::getValue)
-                        .collect(Collectors.joining(" "));
-
-        return (givenNames + " " + familyNames).trim();
     }
 
     private List<String> getFamilyNameWithCharAllowanceForCoiCheck(

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/service/UserIdentityService.java
@@ -362,7 +362,7 @@ public class UserIdentityService {
 
         return names.stream()
                 .filter(
-                        (name) -> {
+                        name -> {
                             var capitalisedFullName = this.getFullName(name).toUpperCase();
 
                             if (!capitalisedFullNames.contains(capitalisedFullName)) {

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -1769,25 +1769,25 @@ class UserIdentityServiceTest {
             // Act & Assert
             assertFalse(userIdentityService.areNamesAndDobCorrelatedForReverification(vcs));
         }
+    }
 
-        @Test
-        void shouldDeduplicateNamesWithCaseInsensitivity() {
-            // Arrange
-            var names =
-                    Set.of(
-                            createName("martin", "smith"),
-                            createName("Martin", "Smith"),
-                            createName("MARTIN", "SMITH"),
-                            createName("Harry", "Smithy"));
+    @Test
+    void shouldDeduplicateNamesWithCaseInsensitivity() {
+        // Arrange
+        var names =
+                Set.of(
+                        createName("martin", "smith"),
+                        createName("Martin", "Smith"),
+                        createName("MARTIN", "SMITH"),
+                        createName("Harry", "Smithy"));
 
-            // Act
-            var deduplicateNames = userIdentityService.deduplicateNames(names);
+        // Act
+        var deduplicateNames = userIdentityService.deduplicateNames(names);
 
-            // Assert
-            assertEquals(
-                    Set.of(createName("martin", "smith"), createName("Harry", "Smithy")),
-                    deduplicateNames);
-        }
+        // Assert
+        assertEquals(
+                Set.of(createName("martin", "smith"), createName("Harry", "Smithy")),
+                deduplicateNames);
     }
 
     private void mockParamStoreCalls(Map<ConfigurationVariable, String> params) {

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -63,6 +64,7 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.*;
 import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.generateVerifiableCredential;
 import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.NamePartGenerator.createNamePart;
+import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
 import static uk.gov.di.model.NamePart.NamePartType.FAMILY_NAME;
 import static uk.gov.di.model.NamePart.NamePartType.GIVEN_NAME;
 
@@ -1766,6 +1768,25 @@ class UserIdentityServiceTest {
 
             // Act & Assert
             assertFalse(userIdentityService.areNamesAndDobCorrelatedForReverification(vcs));
+        }
+
+        @Test
+        void shouldDeduplicateNamesWithCaseInsensitivity() {
+            // Arrange
+            var names =
+                    Set.of(
+                            createName("martin", "smith"),
+                            createName("Martin", "Smith"),
+                            createName("MARTIN", "SMITH"),
+                            createName("Harry", "Smithy"));
+
+            // Act
+            var deduplicateNames = userIdentityService.deduplicateNames(names);
+
+            // Assert
+            assertEquals(
+                    Set.of(createName("martin", "smith"), createName("Harry", "Smithy")),
+                    deduplicateNames);
         }
     }
 

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/UserIdentityServiceTest.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -64,7 +63,6 @@ import static uk.gov.di.ipv.core.library.domain.VerifiableCredentialConstants.VC
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.*;
 import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.generateVerifiableCredential;
 import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.NamePartGenerator.createNamePart;
-import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
 import static uk.gov.di.model.NamePart.NamePartType.FAMILY_NAME;
 import static uk.gov.di.model.NamePart.NamePartType.GIVEN_NAME;
 
@@ -1769,25 +1767,6 @@ class UserIdentityServiceTest {
             // Act & Assert
             assertFalse(userIdentityService.areNamesAndDobCorrelatedForReverification(vcs));
         }
-    }
-
-    @Test
-    void shouldDeduplicateNamesWithCaseInsensitivity() {
-        // Arrange
-        var names =
-                Set.of(
-                        createName("martin", "smith"),
-                        createName("Martin", "Smith"),
-                        createName("MARTIN", "SMITH"),
-                        createName("Harry", "Smithy"));
-
-        // Act
-        var deduplicateNames = userIdentityService.deduplicateNames(names);
-
-        // Assert
-        assertEquals(
-                Set.of(createName("martin", "smith"), createName("Harry", "Smithy")),
-                deduplicateNames);
     }
 
     private void mockParamStoreCalls(Map<ConfigurationVariable, String> params) {


### PR DESCRIPTION
## Proposed changes

### What changed

- Deduplicate shared claims names with case insensitivity.

### Why did it change

- To prevent the same name in different formats from triggering TICF to fail.

### Issue tracking

- [PYIC-7963](https://govukverify.atlassian.net/browse/PYIC-7963)

[PYIC-7963]: https://govukverify.atlassian.net/browse/PYIC-7963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ