### PR TITLE
PYIC-7961: pass only dcmaw VC to DL cri

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -330,7 +330,10 @@ public class BuildCriOauthRequestHandler
 
         var sharedClaims =
                 SharedClaimsHelper.generateSharedClaims(
-                        ipvSessionItem.getEmailAddress(), vcs, getAllowedSharedClaimAttrs(cri));
+                        ipvSessionItem.getEmailAddress(),
+                        vcs,
+                        getAllowedSharedClaimAttrs(cri),
+                        cri);
 
         if (cri.equals(F2F)) {
             evidenceRequest =

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -330,10 +330,7 @@ public class BuildCriOauthRequestHandler
 
         var sharedClaims =
                 SharedClaimsHelper.generateSharedClaims(
-                        ipvSessionItem.getEmailAddress(),
-                        vcs,
-                        getAllowedSharedClaimAttrs(cri),
-                        cri);
+                        ipvSessionItem.getEmailAddress(), vcs, getAllowedSharedClaimAttrs(cri));
 
         if (cri.equals(F2F)) {
             evidenceRequest =

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
@@ -9,11 +9,9 @@ import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.NameHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.model.AddressAssertion;
-import uk.gov.di.model.DrivingPermitDetails;
 import uk.gov.di.model.PersonWithDocuments;
 import uk.gov.di.model.PersonWithIdentity;
 
-import java.util.EnumMap;
 import java.util.List;
 import java.util.Set;
 
@@ -36,8 +34,6 @@ public class SharedClaimsHelper {
             List<String> allowedSharedClaims,
             Cri targetCri) {
         var sharedClaims = new SharedClaims();
-        var sharedDrivingPermitsMappedToVc =
-                new EnumMap<Cri, List<DrivingPermitDetails>>(Cri.class);
 
         // Email address is provided separately in the session, not from a VC
         sharedClaims.setEmailAddress(emailAddress);
@@ -55,10 +51,7 @@ public class SharedClaimsHelper {
                                 !(Cri.DRIVING_LICENCE.equals(targetCri)
                                         && Cri.DRIVING_LICENCE.equals(vc.getCri())))
                 .filter(VcHelper::isSuccessfulVc)
-                .forEach(
-                        vc ->
-                                addSharedClaimsFromVc(
-                                        sharedClaims, vc, sharedDrivingPermitsMappedToVc));
+                .forEach(vc -> addSharedClaimsFromVc(sharedClaims, vc));
 
         // Deduplicate name with case insensitivity
         sharedClaims.setName(NameHelper.deduplicateNames(sharedClaims.getName()));
@@ -83,10 +76,7 @@ public class SharedClaimsHelper {
         return set != null ? set.size() : 0;
     }
 
-    private static void addSharedClaimsFromVc(
-            SharedClaims sharedClaims,
-            VerifiableCredential vc,
-            EnumMap<Cri, List<DrivingPermitDetails>> existingDrivingPermitSharedClaims) {
+    private static void addSharedClaimsFromVc(SharedClaims sharedClaims, VerifiableCredential vc) {
         var credentialSubject = vc.getCredential().getCredentialSubject();
         var vcCri = vc.getCri();
 

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
@@ -69,7 +69,10 @@ public class SharedClaimsHelper {
         return set != null ? set.size() : 0;
     }
 
-    private static void addSharedClaimsFromVc(SharedClaims sharedClaims, VerifiableCredential vc, HashMap<Cri, List<DrivingPermitDetails>> drivingPermitsSharedClaims) {
+    private static void addSharedClaimsFromVc(
+            SharedClaims sharedClaims,
+            VerifiableCredential vc,
+            HashMap<Cri, List<DrivingPermitDetails>> drivingPermitsSharedClaims) {
         var credentialSubject = vc.getCredential().getCredentialSubject();
         var vcCri = vc.getCri();
 
@@ -102,7 +105,7 @@ public class SharedClaimsHelper {
 
             // De-duplicate driving permit shared claims by removing existing DL VC driving permit
             // shared claim and
-            // replacing with DCMAW VC driving permit instead.
+            // replacing with the DCMAW VC driving permit instead.
             if (((Cri.DCMAW.equals(vcCri) || Cri.DCMAW_ASYNC.equals(vcCri))
                     && drivingPermitsSharedClaims.containsKey(Cri.DRIVING_LICENCE))) {
                 drivingPermitsSharedClaims

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.buildcrioauthrequest.helpers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.buildcrioauthrequest.domain.SharedClaims;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.NameHelper;

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelper.java
@@ -77,48 +77,49 @@ public class SharedClaimsHelper {
         var credentialSubject = vc.getCredential().getCredentialSubject();
         var vcCri = vc.getCri();
 
-        if (credentialSubject instanceof PersonWithIdentity personWithIdentity
-                && personWithIdentity.getName() != null) {
-            sharedClaims.getName().addAll(personWithIdentity.getName());
+        if (credentialSubject instanceof PersonWithIdentity personWithIdentity) {
+            if (personWithIdentity.getName() != null) {
+                sharedClaims.getName().addAll(personWithIdentity.getName());
+            }
+
+            if (personWithIdentity.getBirthDate() != null) {
+                sharedClaims.getBirthDate().addAll(personWithIdentity.getBirthDate());
+            }
         }
-        if (credentialSubject instanceof PersonWithIdentity personWithIdentity
-                && personWithIdentity.getBirthDate() != null) {
-            sharedClaims.getBirthDate().addAll(personWithIdentity.getBirthDate());
-        }
+
         if (ADDRESS.equals(vcCri)
                 && credentialSubject instanceof AddressAssertion addressAssertion
                 && addressAssertion.getAddress() != null) {
             sharedClaims.getAddress().addAll(addressAssertion.getAddress());
         }
-        if (credentialSubject instanceof PersonWithDocuments personWithDocuments
-                && personWithDocuments.getSocialSecurityRecord() != null) {
-            sharedClaims
-                    .getSocialSecurityRecord()
-                    .addAll(personWithDocuments.getSocialSecurityRecord());
-        }
-        var isExistingDcmawDrivingPermitSharedClaim =
-                drivingPermitsSharedClaims.containsKey(Cri.DCMAW)
-                        || drivingPermitsSharedClaims.containsKey(Cri.DCMAW_ASYNC);
-        if (credentialSubject instanceof PersonWithDocuments personWithDocuments
-                && personWithDocuments.getDrivingPermit() != null
-                // skip adding driving permit from DL VC if there is already a drivingPermit from
-                // DCMAW
-                && !(isExistingDcmawDrivingPermitSharedClaim
-                        && Cri.DRIVING_LICENCE.equals(vcCri))) {
 
-            // De-duplicate driving permit shared claims by removing existing DL VC driving permit
-            // shared claim and
-            // replacing with the DCMAW VC driving permit instead.
-            var isDcmawVc = Cri.DCMAW.equals(vcCri) || Cri.DCMAW_ASYNC.equals(vcCri);
-            if (isDcmawVc && drivingPermitsSharedClaims.containsKey(Cri.DRIVING_LICENCE)) {
-                drivingPermitsSharedClaims
-                        .get(Cri.DRIVING_LICENCE)
-                        .forEach(sharedClaims.getDrivingPermit()::remove);
-                drivingPermitsSharedClaims.remove(Cri.DRIVING_LICENCE);
+        if (credentialSubject instanceof PersonWithDocuments personWithDocuments) {
+            if (personWithDocuments.getSocialSecurityRecord() != null) {
+                sharedClaims
+                        .getSocialSecurityRecord()
+                        .addAll(personWithDocuments.getSocialSecurityRecord());
             }
 
-            drivingPermitsSharedClaims.put(vcCri, personWithDocuments.getDrivingPermit());
-            sharedClaims.getDrivingPermit().addAll(personWithDocuments.getDrivingPermit());
+            if (personWithDocuments.getDrivingPermit() != null
+                    // skip adding driving permit from DL VC if there is already a drivingPermit
+                    // from
+                    // DCMAW
+                    && !((drivingPermitsSharedClaims.containsKey(Cri.DCMAW)
+                                    || drivingPermitsSharedClaims.containsKey(Cri.DCMAW_ASYNC))
+                            && Cri.DRIVING_LICENCE.equals(vcCri))) {
+                // De-duplicate driving permit shared claims by removing existing DL VC driving
+                // permit shared claim and replacing with the DCMAW VC driving permit instead.
+                var isDcmawVc = Cri.DCMAW.equals(vcCri) || Cri.DCMAW_ASYNC.equals(vcCri);
+                if (isDcmawVc && drivingPermitsSharedClaims.containsKey(Cri.DRIVING_LICENCE)) {
+                    drivingPermitsSharedClaims
+                            .get(Cri.DRIVING_LICENCE)
+                            .forEach(sharedClaims.getDrivingPermit()::remove);
+                    drivingPermitsSharedClaims.remove(Cri.DRIVING_LICENCE);
+                }
+
+                drivingPermitsSharedClaims.put(vcCri, personWithDocuments.getDrivingPermit());
+                sharedClaims.getDrivingPermit().addAll(personWithDocuments.getDrivingPermit());
+            }
         }
     }
 

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -276,7 +276,7 @@ class BuildCriOauthRequestHandlerTest {
         ipvSessionItem.setTargetVot(Vot.P2);
 
         mockSharedClaimsHelper
-                .when(() -> SharedClaimsHelper.generateSharedClaims(any(), any(), any()))
+                .when(() -> SharedClaimsHelper.generateSharedClaims(any(), any(), any(), any()))
                 .thenReturn(TEST_SHARED_CLAIMS);
     }
 

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -276,7 +276,7 @@ class BuildCriOauthRequestHandlerTest {
         ipvSessionItem.setTargetVot(Vot.P2);
 
         mockSharedClaimsHelper
-                .when(() -> SharedClaimsHelper.generateSharedClaims(any(), any(), any(), any()))
+                .when(() -> SharedClaimsHelper.generateSharedClaims(any(), any(), any()))
                 .thenReturn(TEST_SHARED_CLAIMS);
     }
 

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelperTest.java
@@ -47,6 +47,8 @@ class SharedClaimsHelperTest {
                     SHARED_CLAIM_ATTR_SOCIAL_SECURITY_RECORD,
                     SHARED_CLAIM_ATTR_DRIVING_PERMIT);
 
+    private static final Cri TEST_CRI = Cri.DCMAW;
+
     private static final String TEST_EMAIL = "test@example.com";
     private static final Name TEST_NAME = createName("Test", "User");
     private static final BirthDate TEST_DOB = createBirthDate("1970-01-01");
@@ -76,7 +78,7 @@ class SharedClaimsHelperTest {
                                         .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertEquals(TEST_EMAIL, sharedClaims.getEmailAddress());
         assertEquals(Set.of(TEST_NAME), sharedClaims.getName());
@@ -87,7 +89,8 @@ class SharedClaimsHelperTest {
     }
 
     @Test
-    void generatesSharedClaimsShouldReturnOnlyOneDrivingPermitSharedClaimFromDcmawVcIfPresent() {
+    void
+            generatesSharedClaimsShouldNotReturnDrivingPermitSharedClaimFromDrivingLicenceIfTargetCriIsDrivingLicence() {
         var dlCredentialSubjectBuilder =
                 TestVc.TestCredentialSubject.builder()
                         .name(List.of(Map.of(VC_NAME_PARTS, TEST_NAME.getNameParts())))
@@ -118,14 +121,19 @@ class SharedClaimsHelperTest {
                                 Cri.DRIVING_LICENCE));
 
         var sharedClaims =
-                generateSharedClaims(TEST_EMAIL, vcs, List.of(SHARED_CLAIM_ATTR_DRIVING_PERMIT));
+                generateSharedClaims(
+                        TEST_EMAIL,
+                        vcs,
+                        List.of(SHARED_CLAIM_ATTR_DRIVING_PERMIT),
+                        Cri.DRIVING_LICENCE);
 
         assertEquals(1, sharedClaims.getDrivingPermit().size());
         assertEquals(Set.of(updatedTestDrivingPermit), sharedClaims.getDrivingPermit());
     }
 
     @Test
-    void generatesSharedClaimsShouldReturnDrivingPermitFromDrivingLicenceCriIfNoDcmawVcPresent() {
+    void
+            generatesSharedClaimsShouldReturnDrivingPermitFromDrivingLicenceCriIfTargetCriIsNotDrivingLicence() {
         var dlCredentialSubjectBuilder =
                 TestVc.TestCredentialSubject.builder()
                         .name(List.of(Map.of(VC_NAME_PARTS, TEST_NAME.getNameParts())))
@@ -148,7 +156,8 @@ class SharedClaimsHelperTest {
                                 Cri.DRIVING_LICENCE));
 
         var sharedClaims =
-                generateSharedClaims(TEST_EMAIL, vcs, List.of(SHARED_CLAIM_ATTR_DRIVING_PERMIT));
+                generateSharedClaims(
+                        TEST_EMAIL, vcs, List.of(SHARED_CLAIM_ATTR_DRIVING_PERMIT), TEST_CRI);
 
         assertEquals(
                 Set.of(TEST_DRIVING_PERMIT, updatedTestDrivingPermit),
@@ -157,7 +166,7 @@ class SharedClaimsHelperTest {
 
     @Test
     void generatesEmptySetsIfNoAttributePresent() {
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, List.of(), ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, List.of(), ALL_ATTRIBUTES, TEST_CRI);
 
         assertTrue(sharedClaims.getName().isEmpty());
         assertTrue(sharedClaims.getBirthDate().isEmpty());
@@ -186,7 +195,7 @@ class SharedClaimsHelperTest {
                                         .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, List.of());
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, List.of(), TEST_CRI);
 
         assertNull(sharedClaims.getEmailAddress());
         assertNull(sharedClaims.getName());
@@ -205,7 +214,7 @@ class SharedClaimsHelperTest {
                                         .address(List.of(TEST_ADDRESS))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertTrue(sharedClaims.getAddress().isEmpty());
     }
@@ -234,7 +243,7 @@ class SharedClaimsHelperTest {
                                         .evidence(DCMAW_FAILED_EVIDENCE)
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertTrue(sharedClaims.getName().isEmpty());
         assertTrue(sharedClaims.getBirthDate().isEmpty());
@@ -285,7 +294,7 @@ class SharedClaimsHelperTest {
                                         .drivingPermit(List.of(otherDrivingPermit))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertEquals(Set.of(TEST_NAME, otherName), sharedClaims.getName());
         assertEquals(Set.of(TEST_DOB, otherDob), sharedClaims.getBirthDate());
@@ -330,7 +339,7 @@ class SharedClaimsHelperTest {
                                         .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertEquals(Set.of(TEST_NAME), sharedClaims.getName());
         assertEquals(Set.of(TEST_DOB), sharedClaims.getBirthDate());

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/SharedClaimsHelperTest.java
@@ -47,6 +47,8 @@ class SharedClaimsHelperTest {
                     SHARED_CLAIM_ATTR_SOCIAL_SECURITY_RECORD,
                     SHARED_CLAIM_ATTR_DRIVING_PERMIT);
 
+    private static final Cri TEST_CRI = Cri.DCMAW;
+
     private static final String TEST_EMAIL = "test@example.com";
     private static final Name TEST_NAME = createName("Test", "User");
     private static final BirthDate TEST_DOB = createBirthDate("1970-01-01");
@@ -76,7 +78,7 @@ class SharedClaimsHelperTest {
                                         .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertEquals(TEST_EMAIL, sharedClaims.getEmailAddress());
         assertEquals(Set.of(TEST_NAME), sharedClaims.getName());
@@ -87,8 +89,42 @@ class SharedClaimsHelperTest {
     }
 
     @Test
+    void generatesSharedClaimsShouldReturnOnlyDrivingPermitSharedClaimForDrivingLicenceCri() {
+        var dlCredentialSubjectBuilder =
+                TestVc.TestCredentialSubject.builder()
+                        .name(List.of(Map.of(VC_NAME_PARTS, TEST_NAME.getNameParts())))
+                        .birthDate(List.of(TEST_DOB))
+                        .socialSecurityRecord(List.of(TEST_NINO));
+
+        var updatedTestDrivingPermit =
+                createDrivingPermitDetails("another-number", "2062-02-02", "ISSUER", "2005-02-02");
+        var vcs =
+                List.of(
+                        generateIdentityVc(
+                                dlCredentialSubjectBuilder
+                                        .drivingPermit(List.of(TEST_DRIVING_PERMIT))
+                                        .build(),
+                                Cri.DRIVING_LICENCE),
+                        generateIdentityVc(
+                                dlCredentialSubjectBuilder
+                                        .drivingPermit(List.of(updatedTestDrivingPermit))
+                                        .build(),
+                                Cri.DCMAW));
+
+        var sharedClaims =
+                generateSharedClaims(
+                        TEST_EMAIL,
+                        vcs,
+                        List.of(SHARED_CLAIM_ATTR_DRIVING_PERMIT),
+                        Cri.DRIVING_LICENCE);
+
+        assertEquals(1, sharedClaims.getDrivingPermit().size());
+        assertEquals(Set.of(updatedTestDrivingPermit), sharedClaims.getDrivingPermit());
+    }
+
+    @Test
     void generatesEmptySetsIfNoAttributePresent() {
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, List.of(), ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, List.of(), ALL_ATTRIBUTES, TEST_CRI);
 
         assertTrue(sharedClaims.getName().isEmpty());
         assertTrue(sharedClaims.getBirthDate().isEmpty());
@@ -117,7 +153,7 @@ class SharedClaimsHelperTest {
                                         .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, List.of());
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, List.of(), TEST_CRI);
 
         assertNull(sharedClaims.getEmailAddress());
         assertNull(sharedClaims.getName());
@@ -136,7 +172,7 @@ class SharedClaimsHelperTest {
                                         .address(List.of(TEST_ADDRESS))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertTrue(sharedClaims.getAddress().isEmpty());
     }
@@ -165,7 +201,7 @@ class SharedClaimsHelperTest {
                                         .evidence(DCMAW_FAILED_EVIDENCE)
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertTrue(sharedClaims.getName().isEmpty());
         assertTrue(sharedClaims.getBirthDate().isEmpty());
@@ -216,7 +252,7 @@ class SharedClaimsHelperTest {
                                         .drivingPermit(List.of(otherDrivingPermit))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertEquals(Set.of(TEST_NAME, otherName), sharedClaims.getName());
         assertEquals(Set.of(TEST_DOB, otherDob), sharedClaims.getBirthDate());
@@ -261,7 +297,7 @@ class SharedClaimsHelperTest {
                                         .drivingPermit(List.of(TEST_DRIVING_PERMIT))
                                         .build()));
 
-        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES);
+        var sharedClaims = generateSharedClaims(TEST_EMAIL, vcs, ALL_ATTRIBUTES, TEST_CRI);
 
         assertEquals(Set.of(TEST_NAME), sharedClaims.getName());
         assertEquals(Set.of(TEST_DOB), sharedClaims.getBirthDate());
@@ -271,9 +307,13 @@ class SharedClaimsHelperTest {
     }
 
     private VerifiableCredential generateIdentityVc(TestVc.TestCredentialSubject subject) {
+        return generateIdentityVc(subject, Cri.DCMAW);
+    }
+
+    private VerifiableCredential generateIdentityVc(TestVc.TestCredentialSubject subject, Cri cri) {
         return generateVerifiableCredential(
                 TEST_SUBJECT,
-                Cri.DCMAW,
+                cri,
                 TestVc.builder()
                         .credentialSubject(subject)
                         .evidence(DCMAW_EVIDENCE_VRI_CHECK)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
When building the CRI oath request for the DL cri, we don't pass the DL VC to the DL CRI.

### Why did it change
When a user goes through the web journey with a successful driving permit, fails KBV with a CI and tries to mitigate with DCMAW, when passing in a driving permit with different details, we end up sharing both the driving permit from DCMAW and the DL CRI from the beginning of their web journey. We should only be passing in their DCMAW one.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7961](https://govukverify.atlassian.net/browse/PYIC-7961)

[PYIC-7961]: https://govukverify.atlassian.net/browse/PYIC-7961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ