### PR TITLE
PYIC-7971: remove dcmaw success page + intermediate error pages from …

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -265,8 +265,6 @@ Feature: Audit Events
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
-    Then I get a 'pyi-no-match' page response
-    When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my MFA reset result
     Then I get an unsuccessful MFA reset result with failure code 'identity_check_failed'

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -212,7 +212,7 @@ Feature: Authoritative source checks with driving licence CRI
     When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
       | Attribute | Values          |
       | context   | "check_details" |
-    Then I get a 'page-dcmaw-success' page response
+    Then I get a 'we-matched-you-to-your-one-login' page response
 
   Scenario Outline: Change of details journey through DCMAW with driving licence requires auth source check
     Given I activate the 'drivingLicenceAuthCheck' feature set

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -13,13 +13,11 @@ Feature: MFA reset journey
       Then I get a 'you-can-change-security-code-method' page response
 
     Scenario: Successful MFA reset journey
-      When I submit a 'next' event
+      When I submit a 'next' even
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
-      When I submit a 'next' event
       Then I get a 'we-matched-you-to-your-one-login' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -32,8 +30,6 @@ Feature: MFA reset journey
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
-      Then I get a 'pyi-no-match' page response
-      When I submit a 'next' event
       Then I get an OAuth response
       When I use the OAuth response to get my MFA reset result
       Then I get an unsuccessful MFA reset result with failure code 'identity_check_failed'
@@ -64,8 +60,6 @@ Feature: MFA reset journey
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-verification-zero' details to the CRI stub
-      Then I get a 'pyi-no-match' page response
-      When I submit a 'next' event
       Then I get an OAuth response
       When I use the OAuth response to get my MFA reset result
       Then I get an unsuccessful MFA reset result with failure code 'identity_check_failed'
@@ -76,10 +70,6 @@ Feature: MFA reset journey
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'alice-passport-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response
-      When I submit a 'next' event
-      Then I get a 'pyi-no-match' page response
-      When I submit a 'next' event
       Then I get an OAuth response
       When I use the OAuth response to get my MFA reset result
       Then I get an unsuccessful MFA reset result with failure code 'identity_did_not_match'
@@ -95,8 +85,6 @@ Feature: MFA reset journey
       When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
         | Attribute | Values          |
         | context   | "check_details" |
-      Then I get a 'pyi-no-match' page response
-      When I submit a 'next' event
       Then I get an OAuth response
       When I use the OAuth response to get my MFA reset result
       Then I get an unsuccessful MFA reset result with failure code 'identity_check_failed'

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -13,7 +13,7 @@ Feature: MFA reset journey
       Then I get a 'you-can-change-security-code-method' page response
 
     Scenario: Successful MFA reset journey
-      When I submit a 'next' even
+      When I submit a 'next' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -24,37 +24,37 @@ states:
     events:
       not-found:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       invalid-request:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       enhanced-verification:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       alternate-doc-invalid-dl:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       alternate-doc-invalid-passport:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       dl-auth-source-check:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -62,20 +62,15 @@ states:
   CRI_TICF_STATE:
     events:
       enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
+        targetState: RETURN_TO_RP
       alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
+        targetState: RETURN_TO_RP
       alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
+        targetState: RETURN_TO_RP
       fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
+        targetState: RETURN_TO_RP
       error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
+        targetState: RETURN_TO_RP
 
   # Journey states
 
@@ -126,7 +121,10 @@ states:
     nestedJourney: STRATEGIC_APP_TRIAGE
     exitEvents:
       next:
-        targetState: POST_DCMAW_SUCCESS_PAGE
+        targetState: CHECK_COI
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_REVERIFICATION_IDENTITY
       sessionError:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -143,7 +141,10 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: POST_DCMAW_SUCCESS_PAGE
+        targetState: CHECK_COI
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_REVERIFICATION_IDENTITY
       not-found:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
@@ -164,14 +165,6 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetState: POST_DCMAW_SUCCESS_PAGE
-
-  POST_DCMAW_SUCCESS_PAGE:
-    response:
-      type: page
-      pageId: page-dcmaw-success
-    events:
-      next:
         targetState: CHECK_COI
         checkFeatureFlag:
           processCandidateIdentity:
@@ -186,10 +179,10 @@ states:
     parent: CRI_TICF_STATE
     events:
       next:
-        targetState: RETURN_TO_RP
+        targetState: WE_MATCHED_YOU_TO_YOUR_ONE_LOGIN_PAGE
       coi-check-failed:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -205,7 +198,7 @@ states:
         targetState: CRI_TICF
       coi-check-failed:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR


### PR DESCRIPTION
…reverification

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- removed dcmaw success page from reverification journey
- removed intermediate failure screens from reverification journey
- updated api tests

### Why did it change
Matching this to the [figma](https://www.figma.com/design/aVqNC4pKaebZchIU691f31/DI-Authentication?node-id=41199-17025&t=rlO1RZrVGR23am3I-0) designs

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7971](https://govukverify.atlassian.net/browse/PYIC-7971)


[PYIC-7971]: https://govukverify.atlassian.net/browse/PYIC-7971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ