### PR TITLE
BAU: missing ip address from process-candidate-identity and check-coi lambdas

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -276,6 +276,7 @@
       "Resource": "${CheckCoiFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
+        "ipAddress.$": "$$.Execution.Input.ipAddress",
         "featureSet.$": "$$.Execution.Input.featureSet",
         "lambdaInput.$": "$.lambdaInput"
       },
@@ -309,6 +310,7 @@
       "Resource": "${ProcessCandidateIdentityFunctionArn}",
       "Parameters": {
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
+        "ipAddress.$": "$$.Execution.Input.ipAddress",
         "featureSet.$": "$$.Execution.Input.featureSet",
         "lambdaInput.$": "$.lambdaInput"
       },

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -190,7 +190,7 @@ public class ProcessCandidateIdentityHandler
         IpvSessionItem ipvSessionItem = null;
         try {
             var ipvSessionId = RequestHelper.getIpvSessionId(request);
-            var ipAddress = RequestHelper.getIpAddress(request);
+            var ipAddress = request.getIpAddress();
             var deviceInformation = request.getDeviceInformation();
             var processIdentityType = RequestHelper.getProcessIdentityType(request);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add ip address as input to process-candidate-identity and check-coi lambdas.
Audit events emitted as part of the process-candidate-identity lambda now have non-null ip addresses.
<img width="548" alt="Screenshot 2025-01-28 at 16 57 31" src="https://github.com/user-attachments/assets/017dc3eb-64c3-4186-ba89-8808d66f89bf" />
<img width="531" alt="Screenshot 2025-01-28 at 16 57 50" src="https://github.com/user-attachments/assets/51be9b9c-f775-4a04-9966-505720acbdd8" />
<img width="527" alt="Screenshot 2025-01-28 at 16 57 57" src="https://github.com/user-attachments/assets/5ad9fe29-9f2c-45cb-9e9e-9fc3bbf3037d" />
Audit events emitted as part of the check-coi lambda now have non-null ip addresses.
<img width="537" alt="Screenshot 2025-01-28 at 17 06 21" src="https://github.com/user-attachments/assets/f9d6caaa-78db-4725-a8e8-86593e7a82fb" />

### Why did it change
We weren't passing in the ip address as an input to either of the lambdas although both use the ip address for things like audit events. This means that the ip_address in the audit events have been null.
