### PR TITLE
PYIC-7797: fix logging for process-candidate-identity lambda

### DIFF
--- a/deploy/journeyEngineStepFunction.asl.json
+++ b/deploy/journeyEngineStepFunction.asl.json
@@ -312,6 +312,7 @@
         "ipvSessionId.$": "$$.Execution.Input.ipvSessionId",
         "ipAddress.$": "$$.Execution.Input.ipAddress",
         "featureSet.$": "$$.Execution.Input.featureSet",
+        "deviceInformation.$": "$$.Execution.Input.deviceInformation",
         "lambdaInput.$": "$.lambdaInput"
       },
       "Next": "ProcessNextJourney",

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiService.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.processcandidateidentity.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -74,7 +73,6 @@ public class CheckCoiService {
     }
 
     @Tracing
-    @Logging(clearState = true)
     public boolean isCoiCheckSuccessful(
             IpvSessionItem ipvSessionItem,
             ClientOAuthSessionItem clientOAuthSession,

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -389,7 +389,7 @@ core:
     sqsAsync: true
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: true
-    processCandidateIdentity: false
+    processCandidateIdentity: true
   features:
     processCandidateIdentity:
       featureFlags:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Fix broken logs where we aren't attaching relevant info:
![image](https://github.com/user-attachments/assets/5c3a90ca-3027-4f93-85dc-6f88fdf47b72)

- Pass in device information into the lambda for audit events.
- Turning on lambda for local-running

### Why did it change
To fix some stuff spotted in QA

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7797](https://govukverify.atlassian.net/browse/PYIC-7797)


[PYIC-7797]: https://govukverify.atlassian.net/browse/PYIC-7797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ