### PR TITLE
PYIC-7987: Make driving licence comparison case insensitive

### DIFF
--- a/api-tests/data/cri-stub-requests/drivingLicence/kenneth-driving-permit-valid-lower-case-number/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/drivingLicence/kenneth-driving-permit-valid-lower-case-number/credentialSubject.json
@@ -1,0 +1,37 @@
+{
+  "address": [
+    {
+      "postalCode": "BA2 5AA",
+      "addressCountry": "GB"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "drivingPermit": [
+    {
+      "expiryDate": "2033-01-18",
+      "issueNumber": "5",
+      "issuedBy": "DVLA",
+      "fullAddress": "8 HADLEY ROAD BATH BA2 5AA",
+      "personalNumber": "decer607085k9123",
+      "issueDate": "2023-01-18"
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/drivingLicence/kenneth-driving-permit-valid-lower-case-number/evidence.json
+++ b/api-tests/data/cri-stub-requests/drivingLicence/kenneth-driving-permit-valid-lower-case-number/evidence.json
@@ -1,0 +1,13 @@
+{
+  "type": "IdentityCheck",
+  "validityScore": 2,
+  "strengthScore": 3,
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "published",
+      "activityFrom": "1982-05-23",
+      "checkMethod": "data"
+    }
+  ]
+}

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -136,7 +136,7 @@ Feature: Authoritative source checks with driving licence CRI
       | kenneth-driving-permit-valid               | page-ipv-success |
       | kenneth-driving-permit-needs-alternate-doc | pyi-no-match     |
 
-  Scenario: Auth source check is not required if user already has a good driving licence VC
+  Scenario: Auth source check is not required if user already has a good driving licence VC even with different case
     Given I activate the 'drivingLicenceAuthCheck' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
@@ -146,7 +146,7 @@ Feature: Authoritative source checks with driving licence CRI
     Then I get a 'page-multiple-doc-check' page response
     When I submit a 'drivingLicence' event
     Then I get a 'drivingLicence' CRI response
-    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    When I submit 'kenneth-driving-permit-valid-lower-case-number' details to the CRI stub
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -328,7 +328,7 @@ public class CriCheckingService {
                     permit.getIssuingCountry(),
                     permit.getIssuedBy(),
                     permit.getPersonalNumber(),
-                    permit.getIssueDate());
+                    permit.getIssueDate()).toUpperCase();
         }
         LOGGER.warn(
                 LogHelper.buildLogMessage("Unable to get driving permit identifier from VC")

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -324,11 +324,12 @@ public class CriCheckingService {
                 && !identityCheckSubject.getDrivingPermit().isEmpty()) {
             var permit = identityCheckSubject.getDrivingPermit().get(0);
             return String.format(
-                    "drivingPermit/%s/%s/%s/%s",
-                    permit.getIssuingCountry(),
-                    permit.getIssuedBy(),
-                    permit.getPersonalNumber(),
-                    permit.getIssueDate()).toUpperCase();
+                            "drivingPermit/%s/%s/%s/%s",
+                            permit.getIssuingCountry(),
+                            permit.getIssuedBy(),
+                            permit.getPersonalNumber(),
+                            permit.getIssueDate())
+                    .toUpperCase();
         }
         LOGGER.warn(
                 LogHelper.buildLogMessage("Unable to get driving permit identifier from VC")


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Make driving licence comparisons case insensitive

### Why did it change

They should be

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7987](https://govukverify.atlassian.net/browse/PYIC-7987)


[PYIC-7987]: https://govukverify.atlassian.net/browse/PYIC-7987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ