### PR TITLE
PYIC-7917: add available_authoritative_source fraudCheck type

### DIFF
--- a/api-tests/data/cri-stub-requests/fraud/kenneth-unavailable/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-unavailable/credentialSubject.json
@@ -1,0 +1,32 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "buildingName": "",
+      "streetName": "HADLEY ROAD",
+      "postalCode": "BA2 5AA",
+      "buildingNumber": "8",
+      "addressLocality": "BATH",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-unavailable/evidence.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-unavailable/evidence.json
@@ -1,0 +1,10 @@
+{
+  "failedCheckDetails": [
+    {
+      "checkMethod": "data",
+      "fraudCheck": "available_authoritative_source"
+    }
+  ],
+  "txn": "RB000117420948",
+  "type": "IdentityCheck"
+}

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -44,6 +44,22 @@ Feature: Repeat fraud check failures
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity
 
+    Scenario: Applicable authoritative source failed check evidence too weak
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-unavailable' details to the CRI stub
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+
     Scenario: User is able to delete account from update-details-failed screen
       When I call the CRI stub and get an 'access_denied' OAuth error
       Then I get an 'update-details-failed' page response with context 'existingIdentityInvalid'

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
@@ -223,3 +223,76 @@ Feature: Repeat fraud check journeys
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P2' identity
+
+  Rule: Match M1C Fraud Check Unavailable
+
+    Background:
+      Given the subject already has the following credentials
+        | CRI     | scenario               |
+        | dcmaw   | kenneth-passport-valid |
+        | address | kenneth-current        |
+      And the subject already has the following expired credentials
+        | CRI   | scenario              |
+        | fraud | kenneth-unavailable |
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
+
+    Scenario: Fraud 6 Months Expiry + No Update
+      # Repeat fraud check with no update
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-unavailable' details to the CRI stub
+      Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Fraud 6 Months Expiry + Given Name Update
+      # Repeat fraud check with update name
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
+      When I submit a 'update-name' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-unavailable' details to the CRI stub
+      Then I get a 'page-ipv-success' page response with context 'updateIdentity'
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Fraud 6 Months Expiry + Address Update
+      # Repeat fraud check with update address
+      When I submit a 'address-only' event
+      Then I get a 'address' CRI response
+      When I submit 'kenneth-changed' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-unavailable' details to the CRI stub
+      Then I get a 'page-ipv-success' page response with context 'updateIdentity'
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Fraud 6 Months Expiry + Address and Given Name Update
+      # Repeat fraud check with update address and family name
+      When I submit a 'given-names-and-address' event
+      Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
+      When I submit a 'update-name' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
+      When I submit a 'next' event
+      Then I get a 'address' CRI response
+      When I submit 'kenneth-changed' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-unavailable' details to the CRI stub
+      Then I get a 'page-ipv-success' page response with context 'updateIdentity'
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
 awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
 commonsCodec = "commons-codec:commons-codec:1.17.0"
 commonsCollections = "org.apache.commons:commons-collections4:4.5.0-M2"
-diVocab = "uk.gov.di.model:di-data-model-jackson:v1.9.0"
+diVocab = "uk.gov.di.model:di-data-model-jackson:1.9.1"
 hamcrest = "org.hamcrest:hamcrest:3.0"
 jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java
@@ -570,6 +570,10 @@ class CredentialTests {
                       },
                       {
                         "checkMethod": "data",
+                        "fraudCheck": "available_authoritative_source"
+                      },
+                      {
+                        "checkMethod": "data",
                         "fraudCheck": "mortality_check"
                       },
                       {
@@ -601,7 +605,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_EXPERIAN_FRAUD_CHECK_VC_SIGNATURE =
-            "0Te_kOqYqrvXr03FbJp6mAybcK9wGhS5rxeMbEmsJ8jC4jDjhZcrJ6FslVXyKSkEvIIGn9kKkChwR7NAIrui_g"; // pragma: allowlist secret
+            "CpyzOMgJH0rDzzl-NCy2PXj9fCyCJD5zEGMkejcsfm-TDtkR4Oy4veXV_HR5JGaSVpMMj6UJ05NutcuSQwML9Q"; // pragma: allowlist secret
 
     private static final String FAILED_EXPERIAN_FRAUD_CHECK_VC_BODY =
             """
@@ -661,6 +665,10 @@ class CredentialTests {
                       },
                       {
                         "checkMethod": "data",
+                        "fraudCheck": "available_authoritative_source"
+                      },
+                      {
+                        "checkMethod": "data",
                         "fraudCheck": "mortality_check"
                       },
                       {
@@ -692,7 +700,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_EXPERIAN_FRAUD_CHECK_VC_SIGNATURE =
-            "uC_i9ey1KgH9JX5fwpv4RfY0C8V_bU5impV0KNXjQI5UQrAgSrVk2txtLoMwAZ0vVboPotiTyEipZbMUjRw3Cw"; // pragma: allowlist secret
+            "KhDmliwU2182R-zmUZdm-TccBMrJXOsx1f_-pV_YKYUBr16CWPVpZffwlMr2zOTrzpO_8u_mdCuYm1VmtXFc_A"; // pragma: allowlist secret
 
     private static final String VALID_EXPERIAN_FRAUD_CHECK_FAILED_PEP_BODY =
             """
@@ -750,6 +758,10 @@ class CredentialTests {
                       },
                       {
                         "checkMethod": "data",
+                        "fraudCheck": "available_authoritative_source"
+                      },
+                      {
+                        "checkMethod": "data",
                         "fraudCheck": "mortality_check"
                       },
                       {
@@ -783,5 +795,5 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_EXPERIAN_FRAUD_CHECK_FAILED_PEP_SIGNATURE =
-            "Ps4HKiGwNZSdXWpc7dTndzp0PmJ3GMdZYYry5mDjXdtxxf07N-UrlzxoHK_tPEOjWCV3l3bKUI_0MtJDUI1pMw"; // pragma: allowlist secret
+            "bCHcCM5hoozwTUvVr-6kf623R6gYkbXZL69CD7qH2lGuNf2Ih-dHzFKSUmNFivbD5CE5AOJ0dgpClqvN_X_IbQ"; // pragma: allowlist secret
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -137,6 +137,21 @@ public interface VcFixtures {
                             .txn("some-uuid")
                             .build());
 
+    List<TestVc.TestEvidence> FRAUD_EVIDENCE_FAILED_AUTHORITATIVE_AVAILABLE_SOURCE_CHECK_DETAILS =
+            List.of(
+                    TestVc.TestEvidence.builder()
+                            .checkDetails(null)
+                            .failedCheckDetails(
+                                    List.of(
+                                            Map.of(
+                                                    "checkMethod",
+                                                    "data",
+                                                    "fraudCheck",
+                                                    "available_authoritative_source")))
+                            .type(IDENTITY_CHECK_EVIDENCE_TYPE)
+                            .txn("some-uuid")
+                            .build());
+
     List<TestVc.TestEvidence> DCMAW_EVIDENCE_VRI_CHECK =
             List.of(
                     TestVc.TestEvidence.builder()
@@ -695,6 +710,24 @@ public interface VcFixtures {
                 TestVc.builder()
                         .evidence(
                                 FRAUD_EVIDENCE_FAILED_APPLICABLE_AUTHORITATIVE_SOURCE_CHECK_DETAILS)
+                        .credentialSubject(credentialSubject)
+                        .build(),
+                "https://review-f.integration.account.gov.uk",
+                Instant.ofEpochSecond(1658829758));
+    }
+
+    static VerifiableCredential vcFraudApplicableAuthoritativeAvailableFailed() {
+        TestVc.TestCredentialSubject credentialSubject =
+                TestVc.TestCredentialSubject.builder()
+                        .address(List.of(ADDRESS_3))
+                        .birthDate(List.of(createBirthDate("1959-08-23")))
+                        .build();
+        return generateVerifiableCredential(
+                TEST_SUBJECT,
+                EXPERIAN_FRAUD,
+                TestVc.builder()
+                        .evidence(
+                                FRAUD_EVIDENCE_FAILED_AUTHORITATIVE_AVAILABLE_SOURCE_CHECK_DETAILS)
                         .credentialSubject(credentialSubject)
                         .build(),
                 "https://review-f.integration.account.gov.uk",

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/VotMatcherTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/service/VotMatcherTest.java
@@ -25,6 +25,7 @@ import static uk.gov.di.ipv.core.library.enums.Vot.PCL200;
 import static uk.gov.di.ipv.core.library.enums.Vot.PCL250;
 import static uk.gov.di.ipv.core.library.enums.Vot.SUPPORTED_VOTS_BY_DESCENDING_STRENGTH;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreTwo;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudApplicableAuthoritativeAvailableFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudApplicableAuthoritativeSourceFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL200;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL250;
@@ -145,6 +146,28 @@ public class VotMatcherTest {
     void shouldMatchM1cIfFraudCheckUnavailable() throws Exception {
         // Arrange
         var vcs = List.of(vcVerificationM1a(), vcFraudApplicableAuthoritativeSourceFailed());
+        var expectedProfiles =
+                List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B, Gpg45Profile.M1C);
+        when(mockUseridentityService.checkRequiresAdditionalEvidence(vcs)).thenReturn(false);
+        when(mockGpg45ProfileEvaluator.buildScore(vcs)).thenReturn(GPG_45_SCORES);
+        when(mockGpg45ProfileEvaluator.getFirstMatchingProfile(GPG_45_SCORES, expectedProfiles))
+                .thenReturn(Optional.of(Gpg45Profile.M1C));
+
+        // Act
+        var votMatch =
+                votMatcher.matchFirstVot(
+                        SUPPORTED_VOTS_BY_DESCENDING_STRENGTH, vcs, List.of(), true);
+
+        // Assert
+        verify(mockGpg45ProfileEvaluator).getFirstMatchingProfile(GPG_45_SCORES, expectedProfiles);
+        assertEquals(
+                Optional.of(new VotMatchingResult(P2, Gpg45Profile.M1C, GPG_45_SCORES)), votMatch);
+    }
+
+    @Test
+    void shouldMatchM1cIfFraudCheckAuthoritativeUnavailable() throws Exception {
+        // Arrange
+        var vcs = List.of(vcVerificationM1a(), vcFraudApplicableAuthoritativeAvailableFailed());
         var expectedProfiles =
                 List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B, Gpg45Profile.M1C);
         when(mockUseridentityService.checkRequiresAdditionalEvidence(vcs)).thenReturn(false);

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
@@ -202,34 +203,21 @@ public class VcHelper {
 
     private static boolean hasNoApplicableFraudCheck(VerifiableCredential vc) {
         if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
-            boolean isFraudCheckUnavailable =
-                    identityCheckCredential.getEvidence().stream()
-                            .flatMap(
-                                    evidence ->
-                                            evidence.getFailedCheckDetails() == null
-                                                    ? Stream.empty()
-                                                    : evidence.getFailedCheckDetails().stream())
-                            .anyMatch(
-                                    failedCheck ->
-                                            CheckDetails.FraudCheckType
-                                                    .APPLICABLE_AUTHORITATIVE_SOURCE
-                                                    .equals(failedCheck.getFraudCheck()));
 
-            if (!isFraudCheckUnavailable) {
-                isFraudCheckUnavailable =
-                        identityCheckCredential.getEvidence().stream()
-                                .flatMap(
-                                        evidence ->
-                                                evidence.getFailedCheckDetails() == null
-                                                        ? Stream.empty()
-                                                        : evidence.getFailedCheckDetails().stream())
-                                .anyMatch(
-                                        failedCheck ->
-                                                CheckDetails.FraudCheckType
-                                                        .AVAILABLE_AUTHORITATIVE_SOURCE
-                                                        .equals(failedCheck.getFraudCheck()));
-            }
-            return isFraudCheckUnavailable;
+            return identityCheckCredential.getEvidence().stream()
+                    .flatMap(
+                            evidence ->
+                                    evidence.getFailedCheckDetails() == null
+                                            ? Stream.empty()
+                                            : evidence.getFailedCheckDetails().stream())
+                    .anyMatch(
+                            failedCheck ->
+                                    Set.of(
+                                                    CheckDetails.FraudCheckType
+                                                            .APPLICABLE_AUTHORITATIVE_SOURCE,
+                                                    CheckDetails.FraudCheckType
+                                                            .AVAILABLE_AUTHORITATIVE_SOURCE)
+                                            .contains(failedCheck.getFraudCheck()));
         }
         return false;
     }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -198,10 +198,10 @@ public class VcHelper {
     public static boolean isFraudCheckUnavailable(List<VerifiableCredential> vcs) {
         return vcs.stream()
                 .filter(vc -> vc.getCri() == Cri.EXPERIAN_FRAUD)
-                .anyMatch(VcHelper::hasNoApplicableFraudCheck);
+                .anyMatch(VcHelper::hasNoApplicableOrAvailableFraudCheck);
     }
 
-    private static boolean hasNoApplicableFraudCheck(VerifiableCredential vc) {
+    private static boolean hasNoApplicableOrAvailableFraudCheck(VerifiableCredential vc) {
         if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
 
             return identityCheckCredential.getEvidence().stream()

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -202,16 +202,34 @@ public class VcHelper {
 
     private static boolean hasNoApplicableFraudCheck(VerifiableCredential vc) {
         if (vc.getCredential() instanceof IdentityCheckCredential identityCheckCredential) {
-            return identityCheckCredential.getEvidence().stream()
-                    .flatMap(
-                            evidence ->
-                                    evidence.getFailedCheckDetails() == null
-                                            ? Stream.empty()
-                                            : evidence.getFailedCheckDetails().stream())
-                    .anyMatch(
-                            failedCheck ->
-                                    CheckDetails.FraudCheckType.APPLICABLE_AUTHORITATIVE_SOURCE
-                                            .equals(failedCheck.getFraudCheck()));
+            boolean isFraudCheckUnavailable =
+                    identityCheckCredential.getEvidence().stream()
+                            .flatMap(
+                                    evidence ->
+                                            evidence.getFailedCheckDetails() == null
+                                                    ? Stream.empty()
+                                                    : evidence.getFailedCheckDetails().stream())
+                            .anyMatch(
+                                    failedCheck ->
+                                            CheckDetails.FraudCheckType
+                                                    .APPLICABLE_AUTHORITATIVE_SOURCE
+                                                    .equals(failedCheck.getFraudCheck()));
+
+            if (!isFraudCheckUnavailable) {
+                isFraudCheckUnavailable =
+                        identityCheckCredential.getEvidence().stream()
+                                .flatMap(
+                                        evidence ->
+                                                evidence.getFailedCheckDetails() == null
+                                                        ? Stream.empty()
+                                                        : evidence.getFailedCheckDetails().stream())
+                                .anyMatch(
+                                        failedCheck ->
+                                                CheckDetails.FraudCheckType
+                                                        .AVAILABLE_AUTHORITATIVE_SOURCE
+                                                        .equals(failedCheck.getFraudCheck()));
+            }
+            return isFraudCheckUnavailable;
         }
         return false;
     }

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -38,6 +38,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermit;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudEvidenceFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreOne;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcF2fM1a;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudApplicableAuthoritativeAvailableFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudApplicableAuthoritativeSourceFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudExpired;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudNotExpired;
@@ -258,6 +259,24 @@ class VcHelperTest {
                         DCMAW_PASSPORT_VC,
                         M1A_ADDRESS_VC,
                         vcFraudApplicableAuthoritativeSourceFailed(),
+                        vcVerificationM1a());
+
+        // Act
+        var result = VcHelper.isFraudCheckUnavailable(vcs);
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    void isFraudCheckUnavailableShouldReturnTrueForAuthoritativeAvailableSourceFailedFraudCheck() {
+
+        // Arrange
+        var vcs =
+                List.of(
+                        DCMAW_PASSPORT_VC,
+                        M1A_ADDRESS_VC,
+                        vcFraudApplicableAuthoritativeAvailableFailed(),
                         vcVerificationM1a());
 
         // Act


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

- add available_authoritative_source fraudCheck type

### What changed

- Allowing medium confidence p2 user to prove identity when fraud service is down.
- Updated m1c logic

<!-- Describe the changes in detail - the "what"-->


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7917](https://govukverify.atlassian.net/browse/PYIC-7917)

[PYIC-7917]: https://govukverify.atlassian.net/browse/PYIC-7917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ