### PR TITLE
BAU: enable write to sessions table for CheckMobileAppReceipt lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1272,6 +1272,8 @@ Resources:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
             TableName: !Ref SessionsTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref SessionsTable
         - DynamoDBReadPolicy:
             TableName: !Ref ClientOAuthSessionsTable
         - DynamoDBReadPolicy:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add `DynamoDBWritePolicy` to check-mbile-app-vc-receipt lambda.

### Why did it change
We are getting errors in the check-mbile-app-vc-receipt lambda logs bc we don't have permission to update the sessions table as we're updating the sessions table as part of the [reverification journey](https://github.com/govuk-one-login/ipv-core-back/blob/4918c335deeca8236b7d0b453886f8884d430a4a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java#L294) when a user chooses to use the strategic app.
