### PR TITLE
PYIC-7984: use session security check credential

### DIFF
--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
 	implementation libs.bundles.awsLambda,
 			project(":libs:common-services"),
-			project(":libs:cimit-service"),
 			project(":libs:audit-service"),
 			project(":libs:user-identity-service"),
 			project(":libs:verifiable-credentials")

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -28,7 +28,6 @@ import uk.gov.di.ipv.core.library.exceptions.ExpiredAccessTokenException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.InvalidScopeException;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
-import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.RevokedAccessTokenException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -179,8 +178,6 @@ public class BuildUserIdentityHandler extends UserIdentityRequestHandler
             return getAccessDeniedApiGatewayProxyResponseEvent();
         } catch (IpvSessionNotFoundException e) {
             return getUnknownAccessTokenApiGatewayProxyResponseEvent();
-        } catch (NoCriForIssuerException e) {
-            return serverErrorJsonResponse("Failed to get credential issuer for VC.", e);
         } catch (Exception e) {
             LOGGER.error(LogHelper.buildErrorMessage("Unhandled lambda exception", e));
             throw e;

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -35,7 +35,6 @@ import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
-import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
@@ -751,29 +750,6 @@ class BuildUserIdentityHandlerTest {
         assertEquals("server_error", responseBody.get("error"));
         assertEquals(
                 "Unexpected server error - Failed to parse credentials. Unable to parse VC string",
-                responseBody.get("error_description"));
-        verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockCimitService, times(1)).getContraIndicatorsFromVc(any(), any());
-        verify(mockSessionCredentialsService, never()).deleteSessionCredentials(any());
-    }
-
-    @Test
-    void shouldReturnErrorResponseWhenIssuerCannotBeFound() throws Exception {
-        when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any()))
-                .thenThrow(new NoCriForIssuerException("Issuer does not exist"));
-
-        APIGatewayProxyResponseEvent response =
-                buildUserIdentityHandler.handleRequest(testEvent, mockContext);
-        responseBody = OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(500, response.getStatusCode());
-        assertEquals("server_error", responseBody.get("error"));
-        assertEquals(
-                "Unexpected server error - Failed to get credential issuer for VC. Issuer does not exist",
                 responseBody.get("error_description"));
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
         verify(mockCimitService, times(1)).getContraIndicatorsFromVc(any(), any());

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -22,7 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsUserIdentity;
-import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.domain.AuditEventReturnCode;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
@@ -32,6 +31,7 @@ import uk.gov.di.ipv.core.library.domain.ReturnCode;
 import uk.gov.di.ipv.core.library.domain.UserIdentity;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
@@ -42,7 +42,6 @@ import uk.gov.di.ipv.core.library.helpers.vocab.BirthDateGenerator;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
-import uk.gov.di.ipv.core.library.service.CimitService;
 import uk.gov.di.ipv.core.library.service.CimitUtilityService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -138,7 +137,6 @@ class BuildUserIdentityHandlerTest {
     @Mock private ConfigService mockConfigService;
     @Mock private AuditService mockAuditService;
     @Mock private ClientOAuthSessionDetailsService mockClientOAuthSessionDetailsService;
-    @Mock private CimitService mockCimitService;
     @Mock private CimitUtilityService mockCimitUtilityService;
     @Mock private SessionCredentialsService mockSessionCredentialsService;
     @InjectMocks private BuildUserIdentityHandler buildUserIdentityHandler;
@@ -215,7 +213,7 @@ class BuildUserIdentityHandlerTest {
         mitigatedCi.setMitigation(List.of(new Mitigation()));
         var testCis = List.of(mitigatedCi);
 
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(VC_ADDRESS));
@@ -252,7 +250,7 @@ class BuildUserIdentityHandlerTest {
         assertTrue(extensions.isHasMitigations());
         assertEquals(3, userIdentityResponse.getReturnCode().size());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockCimitService, times(1)).getContraIndicatorsFromVc(any(), any());
+        verify(mockCimitUtilityService, times(1)).getContraIndicatorsFromVc(any(), any());
 
         verify(mockConfigService).setFeatureSet(List.of("someCoolNewThing"));
 
@@ -280,7 +278,7 @@ class BuildUserIdentityHandlerTest {
         mitigatedCi.setMitigation(List.of(new Mitigation()));
         var testCis = List.of(mitigatedCi);
 
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(VC_ADDRESS));
@@ -317,7 +315,7 @@ class BuildUserIdentityHandlerTest {
         assertTrue(extensions.isHasMitigations());
         assertEquals(3, userIdentityResponse.getReturnCode().size());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockCimitService, times(1)).getContraIndicatorsFromVc(any(), any());
+        verify(mockCimitUtilityService, times(1)).getContraIndicatorsFromVc(any(), any());
 
         verify(mockConfigService).setFeatureSet(List.of("someCoolNewThing"));
 
@@ -365,7 +363,7 @@ class BuildUserIdentityHandlerTest {
         mitigatedCi.setMitigation(List.of(new Mitigation()));
         var testCis = List.of(mitigatedCi);
 
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(VC_ADDRESS));
@@ -407,7 +405,7 @@ class BuildUserIdentityHandlerTest {
         assertTrue(extensions.isHasMitigations());
         assertEquals(3, userIdentityResponse.getReturnCode().size());
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockCimitService, times(1)).getContraIndicatorsFromVc(any(), any());
+        verify(mockCimitUtilityService, times(1)).getContraIndicatorsFromVc(any(), any());
 
         verify(mockConfigService).setFeatureSet(List.of("someCoolNewThing"));
 
@@ -436,7 +434,7 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(userIdentity);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any()))
                 .thenReturn(CONTRA_INDICATORS);
         // Act
         APIGatewayProxyResponseEvent response =
@@ -485,7 +483,7 @@ class BuildUserIdentityHandlerTest {
         assertEquals(expectedExtension, capturedAuditEvent.getExtensions());
 
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockCimitService, times(1)).getContraIndicatorsFromVc(any(), any());
+        verify(mockCimitUtilityService, times(1)).getContraIndicatorsFromVc(any(), any());
 
         verify(mockConfigService).setFeatureSet(List.of("someCoolNewThing"));
         verify(mockSessionCredentialsService, times(1))
@@ -509,7 +507,7 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(userIdentity);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any()))
                 .thenReturn(CONTRA_INDICATORS);
         when(mockConfigService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, TICF.getId()))
                 .thenReturn(true);
@@ -574,7 +572,8 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(userIdentity);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(contraIndicators);
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any()))
+                .thenReturn(contraIndicators);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         // Act
         APIGatewayProxyResponseEvent response =
@@ -623,7 +622,7 @@ class BuildUserIdentityHandlerTest {
         assertEquals(expectedExtension, capturedAuditEvent.getExtensions());
 
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockCimitService, times(1)).getContraIndicatorsFromVc(any(), any());
+        verify(mockCimitUtilityService, times(1)).getContraIndicatorsFromVc(any(), any());
 
         verify(mockConfigService).setFeatureSet(List.of("someCoolNewThing"));
         verify(mockSessionCredentialsService, times(1))
@@ -658,13 +657,13 @@ class BuildUserIdentityHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorResponseOnCIRetrievalException() throws Exception {
+    void shouldReturnErrorResponseOnCiExtractionException() throws Exception {
         when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
                 .thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any()))
-                .thenThrow(new CiRetrievalException("Lambda execution failed"));
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any()))
+                .thenThrow(new CiExtractionException("Failed to extract CIs"));
 
         APIGatewayProxyResponseEvent response =
                 buildUserIdentityHandler.handleRequest(testEvent, mockContext);
@@ -673,10 +672,10 @@ class BuildUserIdentityHandlerTest {
         assertEquals(500, response.getStatusCode());
         assertEquals("server_error", responseBody.get("error"));
         assertEquals(
-                "Unexpected server error - Error when fetching CIs from storage system. Lambda execution failed",
+                "Unexpected server error - Failed to extract contra indicators. Failed to extract CIs",
                 responseBody.get("error_description"));
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockCimitService, times(1)).getContraIndicatorsFromVc(any(), any());
+        verify(mockCimitUtilityService, times(1)).getContraIndicatorsFromVc(any(), any());
         verify(mockSessionCredentialsService, never()).deleteSessionCredentials(any());
     }
 
@@ -739,7 +738,7 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any()))
                 .thenThrow(new ParseException("Unable to parse VC string", 0));
 
         APIGatewayProxyResponseEvent response =
@@ -752,7 +751,7 @@ class BuildUserIdentityHandlerTest {
                 "Unexpected server error - Failed to parse credentials. Unable to parse VC string",
                 responseBody.get("error_description"));
         verify(mockClientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockCimitService, times(1)).getContraIndicatorsFromVc(any(), any());
+        verify(mockCimitUtilityService, times(1)).getContraIndicatorsFromVc(any(), any());
         verify(mockSessionCredentialsService, never()).deleteSessionCredentials(any());
     }
 
@@ -775,7 +774,7 @@ class BuildUserIdentityHandlerTest {
         mitigatedCi.setMitigation(List.of(new Mitigation()));
         var testCis = List.of(mitigatedCi);
 
-        when(mockCimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
         when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
 
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
@@ -20,10 +20,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.di.ipv.core.builduseridentity.BuildUserIdentityHandler;
-import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.AccessTokenMetadata;
 import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
@@ -31,7 +31,6 @@ import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.SessionCredentialItem;
 import uk.gov.di.ipv.core.library.retry.Sleeper;
 import uk.gov.di.ipv.core.library.service.AuditService;
-import uk.gov.di.ipv.core.library.service.CimitService;
 import uk.gov.di.ipv.core.library.service.CimitUtilityService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -74,7 +73,6 @@ class BuildUserIdentityHandlerTest {
     @Mock private DataStore<IpvSessionItem> mockIpvSessionDataStore;
     @Mock private DataStore<SessionCredentialItem> mockSessionCredentialItemStore;
     @Mock private DataStore<ClientOAuthSessionItem> mockOAuthSessionStore;
-    @Mock private CimitService mockCimitService;
     @Mock private CimitUtilityService mockCimitUtilityService;
     @Mock private SessionCredentialsService mockSessionCredentialsService;
     @Mock private Sleeper mockSleeper;
@@ -91,7 +89,7 @@ class BuildUserIdentityHandlerTest {
 
     @BeforeEach
     void pactSetup(PactVerificationContext context)
-            throws IOException, CiRetrievalException, ParseException, CredentialParseException {
+            throws IOException, ParseException, CredentialParseException, CiExtractionException {
 
         var userIdentityService = new UserIdentityService(mockConfigService);
         var ipvSessionService = new IpvSessionService(mockIpvSessionDataStore, mockSleeper);
@@ -102,11 +100,8 @@ class BuildUserIdentityHandlerTest {
         var jwtBuilder =
                 new PactJwtBuilder(VC_HEADER, CIMIT_VC_NO_CIS_BODY, CIMIT_VC_NO_CIS_SIGNATURE);
         var cimitVc = VerifiableCredential.fromValidJwt(null, null, jwtBuilder.buildSignedJwt());
-        when(mockCimitService.getContraIndicatorsVc(
-                        "dummyOAuthUserId", "dummySigninJourneyId", null))
-                .thenReturn(cimitVc);
 
-        when(mockCimitService.getContraIndicatorsFromVc(cimitVc)).thenReturn(List.of());
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(cimitVc)).thenReturn(List.of());
 
         // Configure the config service
         when(mockConfigService.getParameter(CORE_VTM_CLAIM)).thenReturn("dummyVtmClaim");
@@ -141,7 +136,6 @@ class BuildUserIdentityHandlerTest {
                         mockConfigService,
                         mockAuditService,
                         clientOAuthSessionDetailsService,
-                        mockCimitService,
                         mockCimitUtilityService,
                         sessionCredentialService);
 

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CORE_VTM_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CIMIT_VC_NO_CI;
 
 // To run these tests locally you need to:
 // - Obtain the relevant pact file (from the pact broker or another team) and put it in
@@ -160,6 +161,7 @@ class BuildUserIdentityHandlerTest {
         ipvSession.setClientOAuthSessionId("dummyClientOAuthSessionId");
         ipvSession.setVot(Vot.P2);
         ipvSession.setTargetVot(Vot.P2);
+        ipvSession.setSecurityCheckCredential(SIGNED_CIMIT_VC_NO_CI);
         ipvSession.setAccessTokenMetadata(new AccessTokenMetadata());
 
         var oAuthSession = new ClientOAuthSessionItem();

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
@@ -127,7 +127,7 @@ class CallTicfCriHandlerTest {
                         List.of());
 
         verify(mockCimitService)
-                .getContraIndicators(
+                .getContraIndicatorsVc(
                         TEST_USER_ID, "a-govuk-journey-id", "an-ip-address", ipvSessionItem);
 
         InOrder inOrder = inOrder(mockIpvSessionService);
@@ -149,7 +149,7 @@ class CallTicfCriHandlerTest {
 
         verify(mockCriStoringService, never())
                 .storeVcs(any(), any(), any(), any(), any(), any(), any());
-        verify(mockCimitService, never()).getContraIndicators(any(), any(), any(), any());
+        verify(mockCimitService, never()).getContraIndicatorsVc(any(), any(), any(), any());
 
         InOrder inOrder = inOrder(mockIpvSessionService);
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
@@ -221,7 +221,7 @@ class CallTicfCriHandlerTest {
                         reverificationClientSessionItem,
                         ipvSessionItem,
                         List.of());
-        verify(mockCimitService, never()).getContraIndicators(any(), any(), any(), any());
+        verify(mockCimitService, never()).getContraIndicatorsVc(any(), any(), any(), any());
     }
 
     @Test
@@ -315,7 +315,7 @@ class CallTicfCriHandlerTest {
                 .thenReturn(CLIENT_OAUTH_SESSION_ITEM);
         when(mockTicfCriService.getTicfVc(any(), any()))
                 .thenReturn(List.of(mockVerifiableCredential));
-        when(mockCimitService.getContraIndicators(any(), any(), any(), any()))
+        when(mockCimitService.getContraIndicatorsVc(any(), any(), any(), any()))
                 .thenThrow(new CiRetrievalException("Oh dear"));
 
         Map<String, Object> lambdaResult = callTicfCriHandler.handleRequest(INPUT, mockContext);

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
+import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -275,12 +276,15 @@ public class CheckExistingIdentityHandler
             ipvSessionItem.setTargetVot(lowestGpg45ConfidenceRequested);
             ipvSessionService.updateIpvSession(ipvSessionItem);
 
-            var contraIndicators =
-                    cimitService.getContraIndicators(
+            var contraIndicatorsVc =
+                    cimitService.getContraIndicatorsVc(
                             clientOAuthSessionItem.getUserId(),
                             govukSigninJourneyId,
                             ipAddress,
                             ipvSessionItem);
+
+            var contraIndicators =
+                    cimitUtilityService.getContraIndicatorsFromVc(contraIndicatorsVc);
 
             var reproveIdentity = TRUE.equals(clientOAuthSessionItem.getReproveIdentity());
             // Only skip starting a new reprove identity journey if the user is returning from a F2F
@@ -392,6 +396,8 @@ public class CheckExistingIdentityHandler
             return buildErrorResponse(ErrorResponse.FAILED_TO_FIND_MITIGATION_ROUTE, e);
         } catch (IpvSessionNotFoundException e) {
             return buildErrorResponse(ErrorResponse.IPV_SESSION_NOT_FOUND, e);
+        } catch (CiExtractionException e) {
+            return buildErrorResponse(ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC, e);
         }
     }
 

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1039,9 +1039,7 @@ class CheckExistingIdentityHandlerTest {
         var testJourneyResponse = "/journey/test-response";
 
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(cimitService.getContraIndicators(
-                        TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
-                .thenReturn(List.of());
+        when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
         when(cimitUtilityService.getMitigationJourneyIfBreaching(any(), eq(TEST_VOT)))
                 .thenReturn(Optional.of(new JourneyResponse(testJourneyResponse)));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -1061,9 +1059,7 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnFailWithCiJourneyResponseForCiBreach() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(cimitService.getContraIndicators(
-                        TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
-                .thenReturn(List.of());
+        when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
         when(cimitUtilityService.getMitigationJourneyIfBreaching(any(), eq(TEST_VOT)))
                 .thenReturn(Optional.of(JOURNEY_FAIL_WITH_CI));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -1083,7 +1079,7 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturn500IfFailedToRetrieveCisFromStorageSystem() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(cimitService.getContraIndicators(anyString(), anyString(), anyString(), any()))
+        when(cimitService.getContraIndicatorsVc(anyString(), anyString(), anyString(), any()))
                 .thenThrow(CiRetrievalException.class);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -1124,7 +1120,7 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturn500IfUnrecognisedCiReceived() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(cimitService.getContraIndicators(
+        when(cimitService.getContraIndicatorsVc(
                         TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
                 .thenThrow(new UnrecognisedCiException("Unrecognised CI"));
 
@@ -1151,9 +1147,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                 .thenReturn(emptyAsyncCriStatus);
-        when(cimitService.getContraIndicators(
-                        TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
-                .thenReturn(List.of());
+        when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
         when(cimitUtilityService.getMitigationJourneyIfBreaching(any(), eq(TEST_VOT)))
                 .thenReturn(Optional.of(JOURNEY_FAIL_WITH_CI));
 
@@ -1270,9 +1264,7 @@ class CheckExistingIdentityHandlerTest {
 
         @Test
         void shouldReturnReproveP2JourneyStepResponseIfResetIdentityTrue() throws Exception {
-            when(cimitService.getContraIndicators(
-                            TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
             when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
 
             var journeyResponse =
@@ -1288,9 +1280,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldReturnReproveP1JourneyStepResponseIfResetIdentityTrueAndP1InVtr()
                 throws Exception {
             clientOAuthSessionItem.setVtr(List.of(P2.name(), P1.name()));
-            when(cimitService.getContraIndicators(
-                            TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
             when(configService.enabled(RESET_IDENTITY)).thenReturn(true);
             when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
 
@@ -1318,9 +1308,7 @@ class CheckExistingIdentityHandlerTest {
         when(mockEvcsService.getVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
-        when(cimitService.getContraIndicators(
-                        TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
-                .thenReturn(testContraIndicators);
+        when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(testContraIndicators);
         when(cimitUtilityService.getMitigationJourneyIfBreaching(testContraIndicators, TEST_VOT))
                 .thenReturn(Optional.empty());
         when(cimitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
@@ -1354,9 +1342,7 @@ class CheckExistingIdentityHandlerTest {
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
                 .thenReturn(
                         new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
-        when(cimitService.getContraIndicators(
-                        TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
-                .thenReturn(testContraIndicators);
+        when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(testContraIndicators);
         when(cimitUtilityService.getMitigationJourneyIfBreaching(testContraIndicators, TEST_VOT))
                 .thenReturn(Optional.empty());
         when(cimitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
@@ -1390,9 +1376,7 @@ class CheckExistingIdentityHandlerTest {
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
                 .thenReturn(
                         new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
-        when(cimitService.getContraIndicators(
-                        TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
-                .thenReturn(testContraIndicators);
+        when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(testContraIndicators);
         when(cimitUtilityService.getMitigationJourneyIfBreaching(testContraIndicators, TEST_VOT))
                 .thenReturn(Optional.empty());
         when(cimitUtilityService.hasMitigatedContraIndicator(testContraIndicators))
@@ -1429,9 +1413,7 @@ class CheckExistingIdentityHandlerTest {
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
                 .thenReturn(
                         new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
-        when(cimitService.getContraIndicators(
-                        TEST_USER_ID, TEST_JOURNEY_ID, TEST_CLIENT_SOURCE_IP, ipvSessionItem))
-                .thenReturn(testContraIndicators);
+        when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(testContraIndicators);
         when(cimitUtilityService.getMitigationJourneyIfBreaching(testContraIndicators, TEST_VOT))
                 .thenReturn(Optional.empty());
         when(cimitUtilityService.hasMitigatedContraIndicator(testContraIndicators))

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exception.InvalidCriResponseException;
+import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -132,6 +133,11 @@ public class CheckMobileAppVcReceiptHandler
         } catch (CiRetrievalException e) {
             return buildErrorResponse(
                     e, HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_GET_STORED_CIS);
+        } catch (CiExtractionException e) {
+            return buildErrorResponse(
+                    e,
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC);
         } catch (Exception e) {
             LOGGER.error(LogHelper.buildErrorMessage("Unhandled lambda exception", e));
             throw e;
@@ -150,7 +156,7 @@ public class CheckMobileAppVcReceiptHandler
             throws IpvSessionNotFoundException, HttpResponseExceptionWithErrorBody,
                     InvalidCriResponseException, CredentialParseException,
                     VerifiableCredentialException, ConfigException, CiRetrievalException,
-                    EvcsServiceException {
+                    EvcsServiceException, CiExtractionException {
         // Validate callback sessions
         validateSessionId(request);
 

--- a/lambdas/evaluate-gpg45-scores/build.gradle
+++ b/lambdas/evaluate-gpg45-scores/build.gradle
@@ -12,8 +12,7 @@ dependencies {
 			project(":libs:audit-service"),
 			project(":libs:gpg45-evaluator"),
 			project(":libs:verifiable-credentials"),
-			project(":libs:user-identity-service"),
-			project(":libs:cimit-service")
+			project(":libs:user-identity-service")
 
 	testImplementation libs.hamcrest,
 			libs.junitJupiter,

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -37,7 +37,6 @@ import uk.gov.di.ipv.core.library.journeys.JourneyUris;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
-import uk.gov.di.ipv.core.library.service.CimitService;
 import uk.gov.di.ipv.core.library.service.CimitUtilityService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -74,7 +73,6 @@ public class EvaluateGpg45ScoresHandler
     private final Gpg45ProfileEvaluator gpg45ProfileEvaluator;
     private final ConfigService configService;
     private final AuditService auditService;
-    private final CimitService cimitService;
     private final CimitUtilityService cimitUtilityService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     private final SessionCredentialsService sessionCredentialsService;
@@ -91,7 +89,6 @@ public class EvaluateGpg45ScoresHandler
             AuditService auditService,
             ClientOAuthSessionDetailsService clientOAuthSessionDetailsService,
             SessionCredentialsService sessionCredentialsService,
-            CimitService cimitService,
             CimitUtilityService cimitUtilityService) {
         this.userIdentityService = userIdentityService;
         this.ipvSessionService = ipvSessionService;
@@ -100,7 +97,6 @@ public class EvaluateGpg45ScoresHandler
         this.auditService = auditService;
         this.clientOAuthSessionDetailsService = clientOAuthSessionDetailsService;
         this.sessionCredentialsService = sessionCredentialsService;
-        this.cimitService = cimitService;
         this.cimitUtilityService = cimitUtilityService;
         VcHelper.setConfigService(this.configService);
     }
@@ -120,7 +116,6 @@ public class EvaluateGpg45ScoresHandler
         this.auditService = AuditService.create(configService);
         this.clientOAuthSessionDetailsService = new ClientOAuthSessionDetailsService(configService);
         this.sessionCredentialsService = new SessionCredentialsService(configService);
-        this.cimitService = new CimitService(configService);
         this.cimitUtilityService = new CimitUtilityService(configService);
         VcHelper.setConfigService(this.configService);
     }

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -534,7 +534,7 @@ class EvaluateGpg45ScoresHandlerTest {
                 .thenReturn(Optional.of(M1A));
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(P1_PROFILES)))
                 .thenReturn(Optional.of(L1A));
-        when(cimitService.getContraIndicators(any(), any(), any(), any()))
+        when(cimitUtilityService.getContraIndicatorsFromVc(any(), any()))
                 .thenReturn(CONTRAINDICATORS);
         when(cimitUtilityService.isBreachingCiThreshold(CONTRAINDICATORS, Vot.P2)).thenReturn(true);
         when(cimitUtilityService.isBreachingCiThreshold(CONTRAINDICATORS, Vot.P1)).thenReturn(true);
@@ -561,7 +561,7 @@ class EvaluateGpg45ScoresHandlerTest {
                 .thenReturn(Optional.of(M1A));
         when(gpg45ProfileEvaluator.getFirstMatchingProfile(any(), eq(P1_PROFILES)))
                 .thenReturn(Optional.of(L1A));
-        when(cimitService.getContraIndicators(any(), any(), any(), any()))
+        when(cimitUtilityService.getContraIndicatorsFromVc(any(), any()))
                 .thenReturn(CONTRAINDICATORS);
         when(cimitUtilityService.isBreachingCiThreshold(CONTRAINDICATORS, Vot.P2)).thenReturn(true);
         when(cimitUtilityService.isBreachingCiThreshold(CONTRAINDICATORS, Vot.P1))

--- a/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
+++ b/lambdas/evaluate-gpg45-scores/src/test/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandlerTest.java
@@ -33,7 +33,6 @@ import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
-import uk.gov.di.ipv.core.library.service.CimitService;
 import uk.gov.di.ipv.core.library.service.CimitUtilityService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -102,7 +101,6 @@ class EvaluateGpg45ScoresHandlerTest {
     @Mock private AuditService auditService;
     @Mock private ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
     @Mock private SessionCredentialsService sessionCredentialsService;
-    @Mock private CimitService cimitService;
     @Mock private CimitUtilityService cimitUtilityService;
     @InjectMocks private EvaluateGpg45ScoresHandler evaluateGpg45ScoresHandler;
 

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.processcandidateidentity;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -73,6 +74,7 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.ERROR_PROCESSING_T
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_SECURITY_CHECK_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNEXPECTED_PROCESS_IDENTITY_TYPE;
 import static uk.gov.di.ipv.core.library.enums.CandidateIdentityType.EXISTING;
 import static uk.gov.di.ipv.core.library.enums.CandidateIdentityType.NEW;
@@ -379,6 +381,12 @@ public class ProcessCandidateIdentityHandler
             AuditEventUser auditEventUser)
             throws HttpResponseExceptionWithErrorBody, ParseException, CredentialParseException,
                     CiExtractionException {
+        if (StringUtils.isBlank(ipvSessionItem.getSecurityCheckCredential())) {
+            return new JourneyErrorResponse(
+                    JOURNEY_ERROR_PATH,
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    MISSING_SECURITY_CHECK_CREDENTIAL);
+        }
 
         var areVcsCorrelated = userIdentityService.areVcsCorrelated(sessionVcs);
 

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -33,7 +33,6 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
-import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.UnknownProcessIdentityTypeException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -70,7 +69,6 @@ import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CREDENTIAL_ISSUER_ENABLED;
 import static uk.gov.di.ipv.core.library.domain.Cri.TICF;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.ERROR_PROCESSING_TICF_CRI_RESPONSE;
-import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL_ISSUER_FOR_VC;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_STORED_CIS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
@@ -265,13 +263,6 @@ public class ProcessCandidateIdentityHandler
                             HttpStatus.SC_INTERNAL_SERVER_ERROR,
                             FAILED_TO_PARSE_ISSUED_CREDENTIALS)
                     .toObjectMap();
-        } catch (NoCriForIssuerException e) {
-            LOGGER.error(LogHelper.buildErrorMessage("Failed to get credential issuer for VC", e));
-            return new JourneyErrorResponse(
-                            JOURNEY_ERROR_PATH,
-                            HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                            FAILED_TO_GET_CREDENTIAL_ISSUER_FOR_VC)
-                    .toObjectMap();
         } catch (Exception e) {
             LOGGER.error(LogHelper.buildErrorMessage("Unhandled lambda exception", e));
             throw e;
@@ -302,7 +293,7 @@ public class ProcessCandidateIdentityHandler
             List<VerifiableCredential> sessionVcs,
             AuditEventUser auditEventUser)
             throws EvcsServiceException, HttpResponseExceptionWithErrorBody, CiRetrievalException,
-                    CredentialParseException, ParseException, NoCriForIssuerException {
+                    CredentialParseException, ParseException {
         if (COI_CHECK_TYPES.contains(processIdentityType)) {
             var coiCheckType = getCoiCheckType(processIdentityType, clientOAuthSessionItem);
             LOGGER.info(
@@ -385,7 +376,7 @@ public class ProcessCandidateIdentityHandler
             List<VerifiableCredential> sessionVcs,
             AuditEventUser auditEventUser)
             throws HttpResponseExceptionWithErrorBody, CiRetrievalException, ParseException,
-                    NoCriForIssuerException, CredentialParseException {
+                    CredentialParseException {
 
         var areVcsCorrelated = userIdentityService.areVcsCorrelated(sessionVcs);
 

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -430,8 +430,7 @@ public class ProcessCandidateIdentityHandler
             ClientOAuthSessionItem clientOAuthSessionItem,
             String deviceInformation,
             String ipAddress,
-            AuditEventUser auditEventUser)
-            throws ParseException, NoCriForIssuerException, CredentialParseException {
+            AuditEventUser auditEventUser) {
         try {
             var ticfVcs = ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem);
 

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -451,9 +451,11 @@ public class ProcessCandidateIdentityHandler
                     auditEventUser);
 
             var cis =
-                    cimitService.getContraIndicatorsFromVc(
-                            ipvSessionItem.getSecurityCheckCredential(),
-                            clientOAuthSessionItem.getUserId());
+                    cimitService.getContraIndicators(
+                            clientOAuthSessionItem.getUserId(),
+                            clientOAuthSessionItem.getGovukSigninJourneyId(),
+                            ipAddress,
+                            ipvSessionItem);
 
             var thresholdVot = ipvSessionItem.getThresholdVot();
 

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -259,7 +259,7 @@ public class ProcessCandidateIdentityHandler
                             FAILED_TO_GET_STORED_CIS)
                     .toObjectMap();
         } catch (ParseException e) {
-            LOGGER.error(LogHelper.buildErrorMessage("Failed to get VOT from operational VC", e));
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to parse issued credentials", e));
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH,
                             HttpStatus.SC_INTERNAL_SERVER_ERROR,

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -17,6 +17,7 @@ import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.enums.CandidateIdentityType;
 import uk.gov.di.ipv.core.library.exception.EvcsServiceException;
+import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -57,8 +58,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CREDENTIAL_ISSUER_ENABLED;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.ERROR_PROCESSING_TICF_CRI_RESPONSE;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
-import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_STORED_CIS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_PROCESS_IDENTITY_TYPE;
@@ -159,7 +161,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
@@ -215,9 +217,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
 
             var request =
                     requestBuilder
@@ -274,8 +274,8 @@ class ProcessCandidateIdentityHandlerTest {
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.of(cimitResponse));
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
+            when(cimitUtilityService.getContraIndicatorsFromVc(any()))
+                    .thenReturn(List.of())
                     .thenReturn(List.of());
 
             var request =
@@ -333,9 +333,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
 
             var request =
                     requestBuilder
@@ -374,7 +372,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
@@ -413,9 +411,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
 
             var request =
                     requestBuilder
@@ -457,7 +453,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
@@ -632,10 +628,8 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(ticfCis);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(ticfCis);
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(ticfCis);
+            when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(ticfCis);
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             ticfCis, ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)));
@@ -679,7 +673,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(reproveIdentityClientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
@@ -741,7 +735,7 @@ class ProcessCandidateIdentityHandlerTest {
         }
 
         @Test
-        void shouldReturnJourneyErrorForFailedCiRetrieval() throws Exception {
+        void shouldReturnJourneyErrorForFailedCiExtraction() throws Exception {
             // Arrange
             when(checkCoiService.isCoiCheckSuccessful(
                             eq(ipvSessionItem),
@@ -752,7 +746,48 @@ class ProcessCandidateIdentityHandlerTest {
                             any(AuditEventUser.class)))
                     .thenReturn(true);
             when(userIdentityService.areVcsCorrelated(List.of())).thenReturn(true);
-            when(cimitService.getContraIndicatorsFromVc(any(), any()))
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any()))
+                    .thenThrow(new CiExtractionException("Could not extract CIs"));
+
+            var request =
+                    requestBuilder
+                            .lambdaInput(
+                                    Map.of(PROCESS_IDENTITY_TYPE, CandidateIdentityType.NEW.name()))
+                            .build();
+
+            // Act
+            var response = processCandidateIdentityHandler.handleRequest(request, context);
+
+            // Assert
+            assertEquals(JOURNEY_ERROR_PATH, response.get("journey"));
+            assertEquals(500, response.get("statusCode"));
+            assertEquals(FAILED_TO_EXTRACT_CIS_FROM_VC.getMessage(), response.get("message"));
+
+            verify(storeIdentityService, times(0))
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any());
+        }
+
+        @Test
+        void shouldReturnJourneyErrorForFailedCiRetrieval() throws Exception {
+            // Arrange
+            var ticfVcs = List.of(vcTicf());
+            when(checkCoiService.isCoiCheckSuccessful(
+                            eq(ipvSessionItem),
+                            eq(clientOAuthSessionItem),
+                            eq(STANDARD),
+                            eq(DEVICE_INFORMATION),
+                            eq(List.of()),
+                            any(AuditEventUser.class)))
+                    .thenReturn(true);
+            when(votMatcher.matchFirstVot(anyList(), eq(List.of()), eq(List.of()), eq(true)))
+                    .thenReturn(Optional.of(new VotMatchingResult(P2, M1A, M1A.getScores())));
+            when(userIdentityService.areVcsCorrelated(List.of())).thenReturn(true);
+            when(configService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, Cri.TICF.getId()))
+                    .thenReturn(true);
+            when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
+                    .thenReturn(ticfVcs);
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
+            when(cimitService.getContraIndicatorsVc(any(), any(), any(), any()))
                     .thenThrow(new CiRetrievalException("Could not retrieve CIs"));
 
             var request =
@@ -767,7 +802,7 @@ class ProcessCandidateIdentityHandlerTest {
             // Assert
             assertEquals(JOURNEY_ERROR_PATH, response.get("journey"));
             assertEquals(500, response.get("statusCode"));
-            assertEquals(FAILED_TO_GET_STORED_CIS.getMessage(), response.get("message"));
+            assertEquals(ERROR_PROCESSING_TICF_CRI_RESPONSE.getMessage(), response.get("message"));
 
             verify(storeIdentityService, times(0))
                     .storeIdentity(any(), any(), any(), any(), anyList(), any());
@@ -792,7 +827,9 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any()))
+                    .thenReturn(List.of())
+                    .thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -214,10 +214,12 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
+            when(cimitService.getContraIndicators(
+                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
+                    .thenReturn(List.of());
 
             var request =
                     requestBuilder
@@ -271,10 +273,12 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.of(cimitResponse));
+            when(cimitService.getContraIndicators(
+                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
+                    .thenReturn(List.of());
 
             var request =
                     requestBuilder
@@ -328,10 +332,12 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
+            when(cimitService.getContraIndicators(
+                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
+                    .thenReturn(List.of());
 
             var request =
                     requestBuilder
@@ -406,10 +412,12 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
+            when(cimitService.getContraIndicators(
+                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
+                    .thenReturn(List.of());
 
             var request =
                     requestBuilder
@@ -661,10 +669,12 @@ class ProcessCandidateIdentityHandlerTest {
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
             when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(ticfCis);
+            when(cimitService.getContraIndicators(
+                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
+                    .thenReturn(ticfCis);
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             ticfCis, ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)));
-
             var request =
                     requestBuilder
                             .lambdaInput(

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -149,9 +149,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
@@ -204,9 +202,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
@@ -263,9 +259,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.of(cimitResponse));
@@ -322,9 +316,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
@@ -366,16 +358,11 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
             when(votMatcher.matchFirstVot(List.of(P2), List.of(), List.of(), true))
                     .thenReturn(Optional.of(new VotMatchingResult(P2, M1A, M1A.getScores())));
 
@@ -407,9 +394,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
@@ -454,9 +439,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());
@@ -624,16 +607,14 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(List.of()),
                             any(AuditEventUser.class)))
                     .thenReturn(true);
-            when(votMatcher.matchFirstVot(anyList(), eq(List.of()), eq(List.of()), eq(true)))
+            when(votMatcher.matchFirstVot(anyList(), eq(List.of()), eq(ticfCis), eq(true)))
                     .thenReturn(Optional.of(new VotMatchingResult(P2, M1A, M1A.getScores())));
             when(userIdentityService.areVcsCorrelated(List.of())).thenReturn(true);
             when(configService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, Cri.TICF.getId()))
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(ticfCis);
+            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(ticfCis);
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             ticfCis, ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)));
@@ -678,9 +659,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(reproveIdentityClientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitService.getContraIndicators(
-                            USER_ID, SIGNIN_JOURNEY_ID, IP_ADDRESS, ipvSessionItem))
-                    .thenReturn(List.of());
+            when(cimitService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
             when(cimitUtilityService.getMitigationJourneyIfBreaching(
                             List.of(), ipvSessionItem.getThresholdVot()))
                     .thenReturn(Optional.empty());

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
+import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
@@ -218,6 +219,11 @@ public class ProcessCriCallbackHandler
                         HttpStatus.SC_OK, JOURNEY_NOT_FOUND);
             }
             return buildErrorResponse(e, e.getHttpStatusCode(), e.getErrorResponse());
+        } catch (CiExtractionException e) {
+            return buildErrorResponse(
+                    e,
+                    HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC);
         } catch (IpvSessionNotFoundException e) {
             return buildErrorResponse(
                     e, HttpStatus.SC_INTERNAL_SERVER_ERROR, ErrorResponse.IPV_SESSION_NOT_FOUND);
@@ -248,7 +254,7 @@ public class ProcessCriCallbackHandler
             throws JsonProcessingException, HttpResponseExceptionWithErrorBody, ConfigException,
                     CiRetrievalException, CriApiException, VerifiableCredentialException,
                     CiPostMitigationsException, CiPutException, InvalidCriCallbackRequestException,
-                    UnrecognisedVotException, IpvSessionNotFoundException {
+                    UnrecognisedVotException, IpvSessionNotFoundException, CiExtractionException {
         // Validate callback sessions
         criCheckingService.validateSessionIds(callbackRequest);
 

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.core.library.domain.ReverificationFailureCode;
 import uk.gov.di.ipv.core.library.domain.ScopeConstants;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.dto.CriCallbackRequest;
+import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -232,16 +233,18 @@ public class CriCheckingService {
             ClientOAuthSessionItem clientOAuthSessionItem,
             IpvSessionItem ipvSessionItem,
             List<VerifiableCredential> sessionVcs)
-            throws CiRetrievalException, ConfigException, HttpResponseExceptionWithErrorBody {
+            throws CiRetrievalException, ConfigException, HttpResponseExceptionWithErrorBody,
+                    CiExtractionException {
         var scopeClaims = clientOAuthSessionItem.getScopeClaims();
         var isReverification = scopeClaims.contains(ScopeConstants.REVERIFICATION);
         if (!isReverification) {
-            var cis =
-                    cimitService.getContraIndicators(
+            var contraIndicatorsVc =
+                    cimitService.getContraIndicatorsVc(
                             clientOAuthSessionItem.getUserId(),
                             clientOAuthSessionItem.getGovukSigninJourneyId(),
                             ipAddress,
                             ipvSessionItem);
+            var cis = cimitUtilityService.getContraIndicatorsFromVc(contraIndicatorsVc);
 
             // Check CIs only against the target Vot so we don't send the user on an unnecessary
             // mitigation journey.

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -473,7 +473,7 @@ class CriCheckingServiceTest {
         var sessionVcs = List.of(M1B_DCMAW_VC);
         var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
         var ipvSessionItem = buildValidIpvSessionItem();
-        when(mockCimitService.getContraIndicators(any(), any(), any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any()))
                 .thenReturn(TEST_CONTRA_INDICATORS);
         when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), any()))
                 .thenReturn(Optional.empty());
@@ -502,7 +502,7 @@ class CriCheckingServiceTest {
         var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
         var ipvSessionItem = buildValidIpvSessionItem();
         ipvSessionItem.setTargetVot(Vot.P1);
-        when(mockCimitService.getContraIndicators(any(), any(), any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any()))
                 .thenReturn(TEST_CONTRA_INDICATORS);
         when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), eq(Vot.P1)))
                 .thenReturn(Optional.empty());
@@ -550,7 +550,7 @@ class CriCheckingServiceTest {
         var callbackRequest = buildValidCallbackRequest();
         var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
         var ipvSessionItem = buildValidIpvSessionItem();
-        when(mockCimitService.getContraIndicators(any(), any(), any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any()))
                 .thenReturn(TEST_CONTRA_INDICATORS);
         when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), any()))
                 .thenReturn(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)));
@@ -588,7 +588,7 @@ class CriCheckingServiceTest {
 
         // Assert
         assertEquals(new JourneyResponse(JOURNEY_VCS_NOT_CORRELATED), result);
-        verify(mockCimitService, never()).getContraIndicators(any(), any(), any(), any());
+        verify(mockCimitService, never()).getContraIndicatorsVc(any(), any(), any(), any());
         verify(mockCimitUtilityService, never()).getMitigationJourneyIfBreaching(any(), any());
         verify(mockIpvSessionService, times(1)).updateIpvSession(ipvSessionItem);
     }
@@ -599,7 +599,7 @@ class CriCheckingServiceTest {
         var callbackRequest = buildValidCallbackRequest();
         var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
         var ipvSessionItem = buildValidIpvSessionItem();
-        when(mockCimitService.getContraIndicators(any(), any(), any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any()))
                 .thenReturn(TEST_CONTRA_INDICATORS);
         when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), any()))
                 .thenReturn(Optional.of(new JourneyResponse("/journey/mitigation-journey")));
@@ -623,7 +623,7 @@ class CriCheckingServiceTest {
         var callbackRequest = buildValidCallbackRequest();
         var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
         var ipvSessionItem = buildValidIpvSessionItem();
-        when(mockCimitService.getContraIndicators(any(), any(), any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any()))
                 .thenReturn(TEST_CONTRA_INDICATORS);
         when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), any()))
                 .thenReturn(Optional.empty());
@@ -650,7 +650,7 @@ class CriCheckingServiceTest {
         var sessionVcs = List.of(M1B_DCMAW_VC);
         var clientOAuthSessionItem = buildValidClientOAuthSessionItem();
         var ipvSessionItem = buildValidIpvSessionItem();
-        when(mockCimitService.getContraIndicators(any(), any(), any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any()))
                 .thenReturn(TEST_CONTRA_INDICATORS);
         when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), any()))
                 .thenReturn(Optional.empty());
@@ -679,7 +679,7 @@ class CriCheckingServiceTest {
 
         when(mockConfigService.enabled(DL_AUTH_SOURCE_CHECK)).thenReturn(true);
         mockedVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true);
-        when(mockCimitService.getContraIndicators(any(), any(), any(), any()))
+        when(mockCimitUtilityService.getContraIndicatorsFromVc(any()))
                 .thenReturn(TEST_CONTRA_INDICATORS);
         when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), any()))
                 .thenReturn(Optional.of(new JourneyResponse(JOURNEY_ENHANCED_VERIFICATION_PATH)));

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CimitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CimitService.java
@@ -23,7 +23,6 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
-import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -138,8 +137,7 @@ public class CimitService {
     }
 
     public List<ContraIndicator> getContraIndicatorsFromVc(String vcString, String userId)
-            throws ParseException, NoCriForIssuerException, CredentialParseException,
-                    CiRetrievalException {
+            throws ParseException, CredentialParseException, CiRetrievalException {
         var jwt = SignedJWT.parse(vcString);
         var credential = VerifiableCredential.fromValidJwt(userId, Cri.CIMIT, jwt);
         return getContraIndicatorsFromVc(credential);

--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CimitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/service/CimitService.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.cimit.exception.CimitHttpRequestException;
 import uk.gov.di.ipv.core.library.cimit.exception.PostApiException;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
@@ -140,8 +141,7 @@ public class CimitService {
             throws ParseException, NoCriForIssuerException, CredentialParseException,
                     CiRetrievalException {
         var jwt = SignedJWT.parse(vcString);
-        var cri = configService.getCriByIssuer(jwt.getJWTClaimsSet().getIssuer());
-        var credential = VerifiableCredential.fromValidJwt(userId, cri, jwt);
+        var credential = VerifiableCredential.fromValidJwt(userId, Cri.CIMIT, jwt);
         return getContraIndicatorsFromVc(credential);
     }
 

--- a/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/pact/ContractTest.java
+++ b/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/pact/ContractTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.core.library.cimit.exception.CiPutException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.CimitService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.testhelpers.pact.PactJwtBuilder;
@@ -104,17 +105,19 @@ class ContractTest {
         when(mockConfigService.getParameter(CIMIT_API_BASE_URL))
                 .thenReturn(getMockApiBaseUrl(mockServer));
         var underTest = new CimitService(mockConfigService);
+        var ipvSessionItem =
+                IpvSessionItem.builder().securityCheckCredential(VALID_CI_VC_JWT).build();
 
         // Act
-        var contraIndicator =
+        var contraIndicatorVc =
                 underTest.getContraIndicatorsVc(
-                        MOCK_USER_ID, MOCK_GOVUK_SIGNIN_ID, MOCK_IP_ADDRESS);
+                        MOCK_USER_ID, MOCK_GOVUK_SIGNIN_ID, MOCK_IP_ADDRESS, ipvSessionItem);
 
         // Assert
-        assertEquals(MOCK_USER_ID, contraIndicator.getUserId());
-        assertInstanceOf(SecurityCheckCredential.class, contraIndicator.getCredential());
+        assertEquals(MOCK_USER_ID, contraIndicatorVc.getUserId());
+        assertInstanceOf(SecurityCheckCredential.class, contraIndicatorVc.getCredential());
 
-        var securityCheckCredential = (SecurityCheckCredential) contraIndicator.getCredential();
+        var securityCheckCredential = (SecurityCheckCredential) contraIndicatorVc.getCredential();
         var evidence = (SecurityCheck) securityCheckCredential.getEvidence().get(0);
 
         assertEquals(2, evidence.getContraIndicator().size());
@@ -169,17 +172,19 @@ class ContractTest {
         when(mockConfigService.getParameter(CIMIT_API_BASE_URL))
                 .thenReturn(getMockApiBaseUrl(mockServer));
         var underTest = new CimitService(mockConfigService);
+        var ipvSessionItem =
+                IpvSessionItem.builder().securityCheckCredential(VALID_NO_CI_VC_JWT).build();
 
         // Act
-        var contraIndicator =
+        var contraIndicatorsVc =
                 underTest.getContraIndicatorsVc(
-                        MOCK_USER_ID, MOCK_GOVUK_SIGNIN_ID, MOCK_IP_ADDRESS);
+                        MOCK_USER_ID, MOCK_GOVUK_SIGNIN_ID, MOCK_IP_ADDRESS, ipvSessionItem);
 
         // Assert
-        assertEquals(MOCK_USER_ID, contraIndicator.getUserId());
-        assertInstanceOf(SecurityCheckCredential.class, contraIndicator.getCredential());
+        assertEquals(MOCK_USER_ID, contraIndicatorsVc.getUserId());
+        assertInstanceOf(SecurityCheckCredential.class, contraIndicatorsVc.getCredential());
 
-        var securityCheckCredential = (SecurityCheckCredential) contraIndicator.getCredential();
+        var securityCheckCredential = (SecurityCheckCredential) contraIndicatorsVc.getCredential();
         var evidence = (SecurityCheck) securityCheckCredential.getEvidence().get(0);
 
         assertEquals(0, evidence.getContraIndicator().size());

--- a/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CimitServiceTest.java
+++ b/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CimitServiceTest.java
@@ -20,7 +20,6 @@ import uk.gov.di.ipv.core.library.cimit.exception.CiPostMitigationsException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiPutException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
-import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -384,9 +383,6 @@ class CimitServiceTest {
 
     @Test
     void getContraIndicatorsFromVcReturnsNoCIsFromVcStringWhenNoCIs() throws Exception {
-        // Arrange
-        when(configService.getCriByIssuer(any())).thenReturn(Cri.CIMIT);
-
         // Act
         var cis = cimitService.getContraIndicatorsFromVc(SIGNED_CIMIT_VC_NO_CI, "mock-user-id");
 
@@ -396,9 +392,6 @@ class CimitServiceTest {
 
     @Test
     void getContraIndicatorsFromVcReturnsCIsFromVcStringIfPresent() throws Exception {
-        // Arrange
-        when(configService.getCriByIssuer(any())).thenReturn(Cri.CIMIT);
-
         // Act
         var cis =
                 cimitService.getContraIndicatorsFromVc(

--- a/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CimitServiceTest.java
+++ b/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CimitServiceTest.java
@@ -45,11 +45,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CIMIT_API_KEY;
-import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CIMIT_VC_NO_CI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_2;
-import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_INVALID_EVIDENCE;
-import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_NO_EVIDENCE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.TEST_EC_PUBLIC_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.PASSPORT_NON_DCMAW_SUCCESSFUL_VC;
 import static uk.gov.di.ipv.core.library.service.CimitService.FAILED_RESPONSE;
@@ -192,7 +189,7 @@ class CimitServiceTest {
                                 vcs, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP));
     }
 
-    private static Stream<Arguments> provideArgumentsForGetContraIndicators() throws Exception {
+    private static Stream<Arguments> provideArgumentsForGetContraIndicatorsVc() throws Exception {
         var contraIndicatorVc =
                 VerifiableCredential.fromValidJwt(
                         TEST_USER_ID, null, SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC_1));
@@ -222,7 +219,7 @@ class CimitServiceTest {
     }
 
     @ParameterizedTest
-    @MethodSource("provideArgumentsForGetContraIndicators")
+    @MethodSource("provideArgumentsForGetContraIndicatorsVc")
     void sendsHttpRequestToCimitApiAndStoresInSession(
             IpvSessionItem ipvSessionItem,
             VerifiableCredential vcFromCimit,
@@ -252,9 +249,8 @@ class CimitServiceTest {
                 .thenReturn(TEST_EC_PUBLIC_JWK);
 
         // Act
-        var cis =
-                cimitService.getContraIndicators(
-                        TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP, ipvSessionItem);
+        cimitService.getContraIndicatorsVc(
+                TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP, ipvSessionItem);
 
         // Assert
         verify(mockHttpClient).send(httpRequestCaptor.capture(), any());
@@ -268,17 +264,14 @@ class CimitServiceTest {
                         .map()
                         .containsKey(CimitService.GOVUK_SIGNIN_JOURNEY_ID_HEADER));
 
-        assertEquals(
-                "[{\"code\":\"D01\",\"document\":\"passport/GBR/824159121\",\"incompleteMitigation\":[{\"code\":\"M02\",\"mitigatingCredential\":[{\"id\":\"urn:uuid:f5c9ff40-1dcd-4a8b-bf92-9456047c132f\",\"issuer\":\"https://another-credential-issuer.example/\",\"txn\":\"cdeef\",\"validFrom\":1663862090000}]}],\"issuanceDate\":1663689290000,\"issuers\":[\"https://issuing-cri.example\"],\"mitigation\":[{\"code\":\"M01\",\"mitigatingCredential\":[{\"id\":\"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"issuer\":\"https://credential-issuer.example/\",\"txn\":\"ghij\",\"validFrom\":1663775690000}]}],\"txn\":[\"abcdef\"]}]",
-                OBJECT_MAPPER.writeValueAsString(cis));
-
         assertEquals(expectedStoredVc, ipvSessionItem.getSecurityCheckCredential());
         verify(ipvSessionService, times(hasSecurityCheckCredentialBeenUpdated ? 1 : 0))
                 .updateIpvSession(any());
     }
 
     @Test
-    void getContraIndicatorsVCThrowsExceptionIfHttpRequestReturnsFailedResponse() throws Exception {
+    void getContraIndicatorsVcVCThrowsExceptionIfHttpRequestReturnsFailedResponse()
+            throws Exception {
         // Arrange
         when(configService.getParameter(ConfigurationVariable.CIMIT_API_BASE_URL))
                 .thenReturn(CIMIT_API_BASE_URL);
@@ -294,11 +287,14 @@ class CimitServiceTest {
                 CiRetrievalException.class,
                 () ->
                         cimitService.getContraIndicatorsVc(
-                                TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP));
+                                TEST_USER_ID,
+                                GOVUK_SIGNIN_JOURNEY_ID,
+                                CLIENT_SOURCE_IP,
+                                new IpvSessionItem()));
     }
 
     @Test
-    void getContraIndicatorsVCThrowsExceptionIfHttpRequestIsInterrupted() throws Exception {
+    void getContraIndicatorsVcVCThrowsExceptionIfHttpRequestIsInterrupted() throws Exception {
         // Arrange
         when(configService.getParameter(ConfigurationVariable.CIMIT_API_BASE_URL))
                 .thenReturn(CIMIT_API_BASE_URL);
@@ -311,11 +307,14 @@ class CimitServiceTest {
                 CiRetrievalException.class,
                 () ->
                         cimitService.getContraIndicatorsVc(
-                                TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP));
+                                TEST_USER_ID,
+                                GOVUK_SIGNIN_JOURNEY_ID,
+                                CLIENT_SOURCE_IP,
+                                new IpvSessionItem()));
     }
 
     @Test
-    void getContraIndicatorsVCThrowsExceptionIfHttpRequestThrowsIOException() throws Exception {
+    void getContraIndicatorsVcVCThrowsExceptionIfHttpRequestThrowsIOException() throws Exception {
         // Arrange
         when(configService.getParameter(ConfigurationVariable.CIMIT_API_BASE_URL))
                 .thenReturn(CIMIT_API_BASE_URL);
@@ -328,11 +327,14 @@ class CimitServiceTest {
                 CiRetrievalException.class,
                 () ->
                         cimitService.getContraIndicatorsVc(
-                                TEST_USER_ID, GOVUK_SIGNIN_JOURNEY_ID, CLIENT_SOURCE_IP));
+                                TEST_USER_ID,
+                                GOVUK_SIGNIN_JOURNEY_ID,
+                                CLIENT_SOURCE_IP,
+                                new IpvSessionItem()));
     }
 
     @Test
-    void getContraIndicatorThrowsErrorForInvalidJWT() throws Exception {
+    void getContraIndicatorsVcVcThrowsErrorForInvalidJWT() throws Exception {
         when(configService.getParameter(ConfigurationVariable.CIMIT_API_BASE_URL))
                 .thenReturn(CIMIT_API_BASE_URL);
         when(configService.getSecret(CIMIT_API_KEY)).thenReturn(MOCK_CIMIT_API_KEY);
@@ -350,55 +352,10 @@ class CimitServiceTest {
         assertThrows(
                 CiRetrievalException.class,
                 () ->
-                        cimitService.getContraIndicators(
+                        cimitService.getContraIndicatorsVc(
                                 TEST_USER_ID,
                                 GOVUK_SIGNIN_JOURNEY_ID,
                                 CLIENT_SOURCE_IP,
                                 new IpvSessionItem()));
-    }
-
-    @Test
-    void getContraIndicatorsReturnEmptyCIIfInvalidEvidenceWithNoCI() throws Exception {
-        var contraIndicators =
-                cimitService.getContraIndicatorsFromVc(
-                        VerifiableCredential.fromValidJwt(
-                                TEST_USER_ID,
-                                null,
-                                SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC_INVALID_EVIDENCE)));
-
-        assertTrue(contraIndicators.isEmpty());
-    }
-
-    @Test
-    void getContraIndicatorsThrowsErrorIfNoEvidence() {
-        assertThrows(
-                CiRetrievalException.class,
-                () ->
-                        cimitService.getContraIndicatorsFromVc(
-                                VerifiableCredential.fromValidJwt(
-                                        TEST_USER_ID,
-                                        null,
-                                        SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC_NO_EVIDENCE))));
-    }
-
-    @Test
-    void getContraIndicatorsFromVcReturnsNoCIsFromVcStringWhenNoCIs() throws Exception {
-        // Act
-        var cis = cimitService.getContraIndicatorsFromVc(SIGNED_CIMIT_VC_NO_CI, "mock-user-id");
-
-        // Assert
-        assertTrue(cis.isEmpty());
-    }
-
-    @Test
-    void getContraIndicatorsFromVcReturnsCIsFromVcStringIfPresent() throws Exception {
-        // Act
-        var cis =
-                cimitService.getContraIndicatorsFromVc(
-                        SIGNED_CONTRA_INDICATOR_VC_1, "mock-user-id");
-
-        assertEquals(
-                "[{\"code\":\"D01\",\"document\":\"passport/GBR/824159121\",\"incompleteMitigation\":[{\"code\":\"M02\",\"mitigatingCredential\":[{\"id\":\"urn:uuid:f5c9ff40-1dcd-4a8b-bf92-9456047c132f\",\"issuer\":\"https://another-credential-issuer.example/\",\"txn\":\"cdeef\",\"validFrom\":1663862090000}]}],\"issuanceDate\":1663689290000,\"issuers\":[\"https://issuing-cri.example\"],\"mitigation\":[{\"code\":\"M01\",\"mitigatingCredential\":[{\"id\":\"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"issuer\":\"https://credential-issuer.example/\",\"txn\":\"ghij\",\"validFrom\":1663775690000}]}],\"txn\":[\"abcdef\"]}]",
-                OBJECT_MAPPER.writeValueAsString(cis));
     }
 }

--- a/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CimitServiceTest.java
+++ b/libs/cimit-service/src/test/java/uk/gov/di/ipv/core/library/service/CimitServiceTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.ipv.core.library.cimit.exception.CiPostMitigationsException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiPutException;
 import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -45,6 +46,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CIMIT_API_KEY;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CIMIT_VC_NO_CI;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_2;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_INVALID_EVIDENCE;
@@ -378,5 +380,32 @@ class CimitServiceTest {
                                         TEST_USER_ID,
                                         null,
                                         SignedJWT.parse(SIGNED_CONTRA_INDICATOR_VC_NO_EVIDENCE))));
+    }
+
+    @Test
+    void getContraIndicatorsFromVcReturnsNoCIsFromVcStringWhenNoCIs() throws Exception {
+        // Arrange
+        when(configService.getCriByIssuer(any())).thenReturn(Cri.CIMIT);
+
+        // Act
+        var cis = cimitService.getContraIndicatorsFromVc(SIGNED_CIMIT_VC_NO_CI, "mock-user-id");
+
+        // Assert
+        assertTrue(cis.isEmpty());
+    }
+
+    @Test
+    void getContraIndicatorsFromVcReturnsCIsFromVcStringIfPresent() throws Exception {
+        // Arrange
+        when(configService.getCriByIssuer(any())).thenReturn(Cri.CIMIT);
+
+        // Act
+        var cis =
+                cimitService.getContraIndicatorsFromVc(
+                        SIGNED_CONTRA_INDICATOR_VC_1, "mock-user-id");
+
+        assertEquals(
+                "[{\"code\":\"D01\",\"document\":\"passport/GBR/824159121\",\"incompleteMitigation\":[{\"code\":\"M02\",\"mitigatingCredential\":[{\"id\":\"urn:uuid:f5c9ff40-1dcd-4a8b-bf92-9456047c132f\",\"issuer\":\"https://another-credential-issuer.example/\",\"txn\":\"cdeef\",\"validFrom\":1663862090000}]}],\"issuanceDate\":1663689290000,\"issuers\":[\"https://issuing-cri.example\"],\"mitigation\":[{\"code\":\"M01\",\"mitigatingCredential\":[{\"id\":\"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"issuer\":\"https://credential-issuer.example/\",\"txn\":\"ghij\",\"validFrom\":1663775690000}]}],\"txn\":[\"abcdef\"]}]",
+                OBJECT_MAPPER.writeValueAsString(cis));
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -117,7 +117,8 @@ public enum ErrorResponse {
     INVALID_VTR_CLAIM(1102, "Invalid VTR claim"),
     MISSING_PROCESS_IDENTITY_TYPE(1103, "Process identity type missing"),
     UNEXPECTED_PROCESS_IDENTITY_TYPE(1104, "Unexpected process identity type"),
-    FAILED_TO_GET_CREDENTIAL_ISSUER_FOR_VC(1105, "Failed to get credential issuer for VC");
+    FAILED_TO_GET_CREDENTIAL_ISSUER_FOR_VC(1105, "Failed to get credential issuer for VC"),
+    FAILED_TO_EXTRACT_CIS_FROM_VC(1106, "Failed to extract contra-indicators from VC");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -118,7 +118,8 @@ public enum ErrorResponse {
     MISSING_PROCESS_IDENTITY_TYPE(1103, "Process identity type missing"),
     UNEXPECTED_PROCESS_IDENTITY_TYPE(1104, "Unexpected process identity type"),
     FAILED_TO_GET_CREDENTIAL_ISSUER_FOR_VC(1105, "Failed to get credential issuer for VC"),
-    FAILED_TO_EXTRACT_CIS_FROM_VC(1106, "Failed to extract contra-indicators from VC");
+    FAILED_TO_EXTRACT_CIS_FROM_VC(1106, "Failed to extract contra-indicators from VC"),
+    MISSING_SECURITY_CHECK_CREDENTIAL(1107, "Missing security check credential");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -116,7 +116,8 @@ public enum ErrorResponse {
     MISSING_TARGET_VOT(1101, "Target VOT missing from session"),
     INVALID_VTR_CLAIM(1102, "Invalid VTR claim"),
     MISSING_PROCESS_IDENTITY_TYPE(1103, "Process identity type missing"),
-    UNEXPECTED_PROCESS_IDENTITY_TYPE(1104, "Unexpected process identity type");
+    UNEXPECTED_PROCESS_IDENTITY_TYPE(1104, "Unexpected process identity type"),
+    FAILED_TO_GET_CREDENTIAL_ISSUER_FOR_VC(1105, "Failed to get credential issuer for VC");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/CiExtractionException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/CiExtractionException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+public class CiExtractionException extends Exception {
+    public CiExtractionException(String message) {
+        super(message);
+    }
+}

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/TestFixtures.java
@@ -170,6 +170,9 @@ public interface TestFixtures {
     String SIGNED_CONTRA_INDICATOR_NO_VC =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.JEB0XsBplsmqz18ntjz_0hpDhjBus1HNvU280S7Mcjo"; // pragma: allowlist secret
 
+    String SIGNED_CIMIT_VC_NO_CI =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ1cm46dXVpZDowYWI1NWQ1Ny1hYmJmLTQ0YWEtOTVmMy1lN2Y1YzMwMTZkMTUiLCJuYmYiOjE3Mzg5MTgzMjgsImlzcyI6Imh0dHBzOi8vY2ltaXQuc3R1YnMuYWNjb3VudC5nb3YudWsiLCJleHAiOjE3Mzg5MTkyMjgsInZjIjp7ImV2aWRlbmNlIjpbeyJjb250cmFJbmRpY2F0b3IiOltdLCJ0eXBlIjoiU2VjdXJpdHlDaGVjayJ9XSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIlNlY3VyaXR5Q2hlY2tDcmVkZW50aWFsIl19fQ.6fAqnjlaU0VoUMhhw6JxnZ2mrwSiHp0kpjpMudRf0VS3fteAN1K_JWIl7-2vJnSMWMlIj1vPmuCpQ2W2VtGcqQ"; // pragma: allowlist secret
+
     String EXAMPLE_GENERATED_SECURE_TOKEN =
             "ScnF4dGXthZYXS_5k85ObEoSU04W-H3qa_p6npv2ZUY"; // pragma: allowlist secret
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CimitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CimitUtilityServiceTest.java
@@ -42,6 +42,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CIMIT_VC_N
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_1;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_INVALID_EVIDENCE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_NO_EVIDENCE;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_RESIDENCE_PERMIT_DCMAW;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 
 @ExtendWith(MockitoExtension.class)
@@ -613,6 +614,26 @@ class CimitUtilityServiceTest {
         assertEquals(
                 "[{\"code\":\"D01\",\"document\":\"passport/GBR/824159121\",\"incompleteMitigation\":[{\"code\":\"M02\",\"mitigatingCredential\":[{\"id\":\"urn:uuid:f5c9ff40-1dcd-4a8b-bf92-9456047c132f\",\"issuer\":\"https://another-credential-issuer.example/\",\"txn\":\"cdeef\",\"validFrom\":1663862090000}]}],\"issuanceDate\":1663689290000,\"issuers\":[\"https://issuing-cri.example\"],\"mitigation\":[{\"code\":\"M01\",\"mitigatingCredential\":[{\"id\":\"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"issuer\":\"https://credential-issuer.example/\",\"txn\":\"ghij\",\"validFrom\":1663775690000}]}],\"txn\":[\"abcdef\"]}]",
                 OBJECT_MAPPER.writeValueAsString(cis));
+    }
+
+    @Test
+    void getContraIndicatorsFromVcThrowsErrorIfVcHasNoEvidence() {
+        // Act/Assert
+        assertThrows(
+                CiExtractionException.class,
+                () ->
+                        cimitUtilityService.getContraIndicatorsFromVc(
+                                SIGNED_CONTRA_INDICATOR_VC_NO_EVIDENCE, "mock-user-id"));
+    }
+
+    @Test
+    void getContraIndicatorsFromVcThrowsErrorIfInvalidVc() {
+        // Act/Assert
+        assertThrows(
+                CiExtractionException.class,
+                () ->
+                        cimitUtilityService.getContraIndicatorsFromVc(
+                                VC_RESIDENCE_PERMIT_DCMAW, "mock-user-id"));
     }
 
     private static ContraIndicator createCi(String code) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Use in-session security check credential instead of fetching from CIMIT again in 
- process-candidate-identity lambda
- build-user-identity lambda
Moves `getContraIndicatorsVc` into CimitUtilityService

### Why did it change
Reduce unnecessary calls to CIMIT

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7984](https://govukverify.atlassian.net/browse/PYIC-7984)


[PYIC-7984]: https://govukverify.atlassian.net/browse/PYIC-7984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ