### PR TITLE
PYIC-8058 Rethrow IOExceptions on EVCS requests

### DIFF
--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java
@@ -27,6 +27,7 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.tracing.TracingHttpClient;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -236,7 +237,15 @@ public class EvcsClient {
                                             evcsHttpRequest, HttpResponse.BodyHandlers.ofString());
                             checkResponseStatusCode(res);
                             return res;
-                        } catch (EvcsServiceException | IOException e) {
+                        } catch (IOException e) {
+                            LOGGER.error(
+                                    LogHelper.buildErrorMessage(
+                                            "HTTP request failed with IOException", e));
+                            // Rethrow IOException as unchecked exception for now to force lambda to
+                            // crash (see
+                            // PYIC-8058 and linked incident INC0014124)
+                            throw new UncheckedIOException(e);
+                        } catch (EvcsServiceException e) {
                             throw new NonRetryableException(e);
                         } catch (InterruptedException e) {
                             // This should never happen running in Lambda as it's single


### PR DESCRIPTION
## Proposed changes

### What changed

Re-throw IOExceptions wrapped in an unchecked exception to let the lambda instance crash, which will force a new healthy instance to be spawned so subsequent requests are served without error. For now we'll just do this for EVCS requests because the approach needs some more thought before we can apply it more broadly to all HTTP requests.

### Why did it change

We handle IOExceptions on HTTP requests and return a graceful error response, rather than re-throwing wrapped in an unchecked exception to let the lambda crash. In the last few weeks we’ve seen two instances of lambda check-existing-identity (one integration and one prod) spawned with apparently no network connectivity, raising IOExceptions on the HTTP request to EVCS. Every invocation of the instances failed with the same error. (See P2 incident INC0014124.)

### Issue tracking
- [PYIC-8058](https://govukverify.atlassian.net/browse/PYIC-8058)



[PYIC-8058]: https://govukverify.atlassian.net/browse/PYIC-8058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ