### PR TITLE
Revert "PYIC-7888 Detailed DT logging in build"

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -126,7 +126,6 @@ Conditions:
     - !Equals [ !Ref AWS::AccountId, "175872367215" ]
   IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670" ]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
-  IsBuild: !Equals [ !Ref Environment, "build" ]
   IsProduction: !Equals [ !Ref Environment, "production" ]
   IsSubscriptionEnviroment: !Or
     - !Equals [ !Ref Environment, staging ]
@@ -752,15 +751,6 @@ Resources:
           IPV_SESSIONS_TABLE_NAME: !Ref SessionsTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           CLIENT_OAUTH_SESSIONS_TABLE_NAME: !Ref ClientOAuthSessionsTable
-          # PYIC-7888 Turn on debug logging in build
-          DT_LOGGING_DESTINATION: !If
-            - IsBuild
-            - "stdout"
-            - !Ref AWS::NoValue
-          DT_LOGGING_JAVA_FLAGS: !If
-            - IsBuild
-            - "log-Transformer=true,log-OpenTelemetryUtils=true,log-AsyncClassRetransformer=true,log-ClassValue=true"
-            - !Ref AWS::NoValue
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA


### PR DESCRIPTION
This reverts commit b23cf0b09aebacd2fb80acd41e5d0f6458c2a1e0.

The additional logging seems to be preventing the segfaults from triggering. Reverting this change to help confirm that this is the case.