### PR TITLE
PYIC-8069: use app doc check nested journey for reverification

### DIFF
--- a/api-tests/data/audit-events/reverification-failed-journey.json
+++ b/api-tests/data/audit-events/reverification-failed-journey.json
@@ -70,7 +70,7 @@
     "event_name": "IPV_SUBJOURNEY_START",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "journey_type": "FAILED"
+      "journey_type": "INELIGIBLE"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -116,7 +116,7 @@ Feature: MFA reset journey
         | context   | "check_details" |
       Then I get a 'uk-driving-licence-details-not-correct' page response
       When I submit a 'end' event
-      Then I get a 'prove-identity-another-way' page response
+      Then I get a 'prove-identity-another-way' page response with context 'noF2f'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my MFA reset result

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -24,6 +24,22 @@ Feature: MFA reset journey
       When I use the OAuth response to get my MFA reset result
       Then I get a successful MFA reset result
 
+    Scenario: Successful MFA reset journey - with DL auth source check
+      When I submit a 'next' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'we-matched-you-to-your-one-login' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my MFA reset result
+      Then I get an successful MFA reset result
+
     Scenario: Failed MFA reset journey with breaching CI - user can still reuse existing identity
       When I submit a 'next' event
       Then I get a 'page-ipv-identity-document-start' page response
@@ -75,7 +91,6 @@ Feature: MFA reset journey
       Then I get an unsuccessful MFA reset result with failure code 'identity_did_not_match'
 
     Scenario: Failed MFA reset journey - failed DL auth source check
-      Given I activate the 'drivingLicenceAuthCheck' feature set
       When I submit a 'next' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
@@ -88,6 +103,38 @@ Feature: MFA reset journey
       Then I get an OAuth response
       When I use the OAuth response to get my MFA reset result
       Then I get an unsuccessful MFA reset result with failure code 'identity_check_failed'
+
+    Scenario: Failed MFA reset journey - incorrect DL details from DL auth source check - prove identity another way
+      When I submit a 'next' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'uk-driving-licence-details-not-correct' page response
+      When I submit a 'end' event
+      Then I get a 'prove-identity-another-way' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my MFA reset result
+      Then I get an unsuccessful MFA reset result with failure code 'identity_check_incomplete'
+
+    Scenario: Incorrect DL details from DL auth source check - allowed retry through the app
+      When I submit a 'next' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'uk-driving-licence-details-not-correct' page response
+      When I submit a 'next' event
+      Then I get a 'dcmaw' CRI response
 
   Rule: The user has no existing identity
     Scenario: Attempted MFA reset journey

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -164,42 +164,6 @@ states:
       returnToRp:
         targetState: RETURN_TO_RP
 
-  CRI_DCMAW:
-    response:
-      type: cri
-      criId: dcmaw
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CHECK_COI
-        checkFeatureFlag:
-          processCandidateIdentity:
-            targetState: PROCESS_REVERIFICATION_IDENTITY
-      not-found:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-      access-denied:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-      temporarily-unavailable:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-      dl-auth-source-check:
-        targetState: CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK
-
-  CRI_DRIVING_LICENCE_AUTH_SOURCE_CHECK:
-    response:
-      type: cri
-      criId: drivingLicence
-      context: check_details
-    parent: CRI_STATE
-    events:
-      next:
-        targetState: CHECK_COI
-        checkFeatureFlag:
-          processCandidateIdentity:
-            targetState: PROCESS_REVERIFICATION_IDENTITY
-
   PROCESS_REVERIFICATION_IDENTITY:
     response:
       type: process

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -105,7 +105,8 @@ states:
       pageId: page-ipv-identity-document-start
     events:
       appTriage:
-        targetState: CRI_DCMAW
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
         checkFeatureFlag:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE
@@ -131,6 +132,35 @@ states:
       anotherWay:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
+      returnToRp:
+        targetState: RETURN_TO_RP
+
+  APP_DOC_CHECK:
+    nestedJourney: APP_DOC_CHECK
+    exitEvents:
+      next:
+        targetState: CHECK_COI
+        checkFeatureFlag:
+          processCandidateIdentity:
+            targetState: PROCESS_REVERIFICATION_IDENTITY
+      incomplete:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+      alternate-doc-invalid-dl:
+        targetJourney: FAILED
+        targetState: FAILED_SKIP_MESSAGE
+      incomplete-invalid-dl:
+        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK
+
+  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK:
+    response:
+      type: page
+      pageId: prove-identity-another-way
+      context: noF2f
+    events:
+      anotherTypePhotoId:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       returnToRp:
         targetState: RETURN_TO_RP
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- use nested journey for the reverification journey map
- should now allow users to retry scanning their DL details if they're incorrect
- add more api tests

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8069](https://govukverify.atlassian.net/browse/PYIC-8069)


[PYIC-8069]: https://govukverify.atlassian.net/browse/PYIC-8069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ