### PR TITLE
PYIC-8063: omit journey id from audit events if null or empty

### DIFF
--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.auditing;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import lombok.EqualsAndHashCode;
@@ -20,6 +21,7 @@ public class AuditEventUser {
     private final String sessionId;
 
     @JsonProperty(value = "govuk_signin_journey_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final String govukSigninJourneyId;
 
     @JsonProperty(value = "ip_address")

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -20,7 +20,7 @@ import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_
 
 @ExcludeFromGeneratedCoverageReport
 public class LogHelper {
-    public static final String GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE = "unknown";
+    public static final String GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE = null;
 
     public enum LogField {
         LOG_ACCESS_TOKEN("accessToken"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Don't record journey id in audit event if not provided.

### Why did it change
We were previously setting the journey id to "unknown" if we didn't have access to it e.g. when processing an async VC. This was causing enrichment to fail as data were looking for whether `user.govuk_signin_journey_id` had a value or not

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8063](https://govukverify.atlassian.net/browse/PYIC-8063)


[PYIC-8063]: https://govukverify.atlassian.net/browse/PYIC-8063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ