### PR TITLE
PYIC-6402: Update back event handler

### DIFF
--- a/api-tests/features/p2-strategic-app.feature
+++ b/api-tests/features/p2-strategic-app.feature
@@ -322,3 +322,16 @@ Feature: M2B Strategic App Journeys
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P0' identity
+
+  Scenario: Strategic app uk address user wants to go back over identify-device page
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'back' event
+    Then I get a 'page-ipv-identity-document-start' page response

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -323,7 +323,8 @@ public class ProcessJourneyEventHandler
                                 "Found state machine for journey type: %s",
                                 initialJourneyState.subJourney())));
 
-        State backEventState = handleBackEvent(initialJourneyState, ipvSessionItem, journeyEvent);
+        State backEventState =
+                handleBackEvent(initialJourneyState, ipvSessionItem, journeyEvent, stateMachine);
         if (backEventState != null) {
             return backEventState;
         }
@@ -389,15 +390,16 @@ public class ProcessJourneyEventHandler
     }
 
     private State handleBackEvent(
-            JourneyState initialJourneyState, IpvSessionItem ipvSessionItem, String journeyEvent)
+            JourneyState initialJourneyState,
+            IpvSessionItem ipvSessionItem,
+            String journeyEvent,
+            StateMachine stateMachine)
             throws UnknownEventException, StateMachineNotFoundException, UnknownStateException {
         if (BACK_EVENT.equals(journeyEvent) && !isBackEventDefinedOnState(initialJourneyState)) {
             var previousJourneyState = ipvSessionItem.getPreviousState();
 
             if (previousJourneyState != null
-                    && previousJourneyState
-                            .state()
-                            .equals("STRATEGIC_APP_TRIAGE/IDENTIFY_DEVICE")) {
+                    && stateMachine.isSkipBackPageState(previousJourneyState)) {
                 ipvSessionItem.popState();
                 previousJourneyState = ipvSessionItem.getPreviousState();
             }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -397,7 +397,7 @@ public class ProcessJourneyEventHandler
             var skipBackResponse =
                     ((PageStepResponse) ((BasicState) state).getResponse()).getSkipBack();
 
-            if (skipBackResponse != null && Boolean.TRUE.equals(skipBackResponse)) {
+            if (Boolean.TRUE.equals(skipBackResponse)) {
                 ipvSessionItem.popState();
                 previousJourneyState = ipvSessionItem.getPreviousState();
             }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
@@ -81,23 +81,6 @@ public class StateMachine {
                 && basicState.getResponse() instanceof PageStepResponse;
     }
 
-    public boolean isSkipBackPageState(JourneyState journeyState) throws UnknownStateException {
-        var state = getState(journeyState.state());
-        if (state == null) {
-            throw new UnknownStateException(
-                    String.format(
-                            "Unknown state provided to state machine: '%s'", journeyState.state()));
-        }
-
-        if (state instanceof BasicState basicState
-                && basicState.getResponse() instanceof PageStepResponse) {
-            PageStepResponse pageStepResponse = (PageStepResponse) basicState.getResponse();
-            return Boolean.TRUE.equals(pageStepResponse.getSkipBack());
-        }
-
-        return false;
-    }
-
     public State getState(String state) {
         return recurseToState(
                 states, new ArrayList<>(Arrays.asList(state.split(JOURNEY_STATE_DELIMITER))));

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
@@ -81,6 +81,23 @@ public class StateMachine {
                 && basicState.getResponse() instanceof PageStepResponse;
     }
 
+    public boolean isSkipBackPageState(JourneyState journeyState) throws UnknownStateException {
+        var state = getState(journeyState.state());
+        if (state == null) {
+            throw new UnknownStateException(
+                    String.format(
+                            "Unknown state provided to state machine: '%s'", journeyState.state()));
+        }
+
+        if (state instanceof BasicState basicState
+                && basicState.getResponse() instanceof PageStepResponse) {
+            PageStepResponse pageStepResponse = (PageStepResponse) basicState.getResponse();
+            return Boolean.TRUE.equals(pageStepResponse.getSkipBack());
+        }
+
+        return false;
+    }
+
     public State getState(String state) {
         return recurseToState(
                 states, new ArrayList<>(Arrays.asList(state.split(JOURNEY_STATE_DELIMITER))));

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponse.java
@@ -14,11 +14,13 @@ public class PageStepResponse implements StepResponse {
 
     private String pageId;
     private String context;
+    private Boolean skipBack;
 
     public Map<String, Object> value() {
         Map<String, Object> response = new HashMap<>();
         response.put("page", pageId);
         response.put("context", context);
+        response.put("skipBack", skipBack);
 
         return response;
     }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -11,6 +11,7 @@ nestedJourneyStates:
     response:
       type: page
       pageId: identify-device
+      skipBack: true
     events:
       appTriage:
         targetState: SELECT_DEVICE_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -30,6 +30,8 @@ states:
         targetState: TICF_CRI_STATE
       eventSeven:
         targetState: COI_CHECK
+      eventEight:
+        targetState: STRATEGIC_APP_TRIAGE
 
   CRI_STATE:
     response:
@@ -154,6 +156,12 @@ states:
         targetState: ANOTHER_PAGE_STATE
       exitEventFromDoublyNestedInvokeState:
         targetState: ERROR_STATE
+
+  STRATEGIC_APP_TRIAGE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      exitEventFromNestedStateOne:
+        targetState: ANOTHER_PAGE_STATE
 
   ANOTHER_PAGE_STATE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/strategic-app-triage.yaml
@@ -1,0 +1,22 @@
+name: Identify device response definition
+description: >-
+  A test identify device journey
+entryEvents:
+  eventEight:
+    targetState: IDENTIFY_DEVICE
+nestedJourneyStates:
+  IDENTIFY_DEVICE:
+    response:
+      type: page
+      pageId: identify-device
+    parent: PARENT_STATE
+    events:
+      eventOne:
+        targetState: NESTED_STATE_TWO
+  NESTED_STATE_TWO:
+    response:
+      type: page
+      pageId: page-id-nested-state-two
+    events:
+      eventOne:
+        exitEventToEmit: exitEventFromNestedStateOne

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/strategic-app-triage.yaml
@@ -9,6 +9,7 @@ nestedJourneyStates:
     response:
       type: page
       pageId: identify-device
+      skipBack: true
     parent: PARENT_STATE
     events:
       eventOne:

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -27,7 +27,10 @@ import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_
 
 class StateMachineInitializerTest {
     private static final List<String> TEST_NESTED_JOURNEY_TYPES =
-            List.of("nested-journey-definition", "doubly-nested-definition");
+            List.of(
+                    "nested-journey-definition",
+                    "doubly-nested-definition",
+                    "strategic-app-triage");
 
     @ParameterizedTest
     @EnumSource

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/BasicStateTest.java
@@ -24,7 +24,7 @@ class BasicStateTest {
     @Test
     void transitionShouldReturnAStateWithAResponse() throws Exception {
         BasicState targetState = new BasicState();
-        PageStepResponse stepResponse = new PageStepResponse("stepId", "context");
+        PageStepResponse stepResponse = new PageStepResponse("stepId", "context", false);
         targetState.setResponse(stepResponse);
 
         BasicState currentState = new BasicState();

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PageStepResponseTest {
 
     public static final PageStepResponse PAGE_RESPONSE =
-            new PageStepResponse("aPageId", "testContext");
+            new PageStepResponse("aPageId", "testContext", false);
 
     @Test
     void valueReturnsCorrectPageResponse() {

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/PageStepResponseTest.java
@@ -13,6 +13,8 @@ public class PageStepResponseTest {
 
     @Test
     void valueReturnsCorrectPageResponse() {
-        assertEquals(Map.of("page", "aPageId", "context", "testContext"), PAGE_RESPONSE.value());
+        assertEquals(
+                Map.of("page", "aPageId", "context", "testContext", "skipBack", false),
+                PAGE_RESPONSE.value());
     }
 }


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Check previous states until its another page event Manually add back event for SELECT_DEVICE_PAGE as the previous step is a unqiue IDENTIFY_DEVICE where its a page event which doesnt respond with a page

### Why did it change

We can allow users a degree of flexibility to return to previous screens in the journey using a ‘back’ link on the mobile triage page if they want to

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-6402](https://govukverify.atlassian.net/browse/PYIC-6402)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-6402]: https://govukverify.atlassian.net/browse/PYIC-6402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ