### PR TITLE
PYIC-8019 Use TracingHttpClient with automatic recreation for JWKS

### DIFF
--- a/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
+++ b/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
@@ -15,6 +15,7 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.oauthkeyservice.domain.CachedJWKSet;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.tracing.TracingHttpClient;
 
 import java.io.IOException;
 import java.net.URI;
@@ -51,7 +52,7 @@ public class OAuthKeyService {
     @ExcludeFromGeneratedCoverageReport
     public OAuthKeyService(ConfigService configService) {
         this.configService = configService;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpClient = TracingHttpClient.newHttpClient();
     }
 
     @ExcludeFromGeneratedCoverageReport


### PR DESCRIPTION
## Proposed changes

### What changed

Use `TracingHttpClient` for JWKS requests

### Why did it change

We want tracing for all requests we make. The `TracingHttpClient` also includes logic to retry IOExceptions (once) and recreate the underlying client after a certain amount of time, which should mitigate some of the errors we're seeing.

See https://github.com/govuk-one-login/ipv-core-back/blob/main/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClient.java#L54

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8109](https://govukverify.atlassian.net/browse/PYIC-8109)


[PYIC-8109]: https://govukverify.atlassian.net/browse/PYIC-8109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ