### PR TITLE
PYIC-8109: Add Connection: keep-alive to GET stubs well-known jwks

### DIFF
--- a/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
+++ b/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
@@ -154,7 +154,12 @@ public class OAuthKeyService {
     private JWKSet getJWKSetFromJwksEndpoint(URI jwksEndpoint) {
         try {
             LOGGER.info(LogHelper.buildLogMessage("Retrieving JWKSet from well-known endpoint"));
-            var request = HttpRequest.newBuilder().uri(jwksEndpoint).GET().build();
+            var request =
+                    HttpRequest.newBuilder()
+                            .uri(jwksEndpoint)
+                            .header("Connection", "keep-alive")
+                            .GET()
+                            .build();
             var httpResponse = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
             if (httpResponse.statusCode() != SC_OK) {


### PR DESCRIPTION
## Proposed changes

### What changed

- Add Connection: keep-alive to GET stubs well-known jwks

### Why did it change

- **Attempt** to prevent the connection to stubs well-known jwks endpoint from being killed by load balancers

### Issue tracking

- [PYIC-8109](https://govukverify.atlassian.net/browse/PYIC-8109)

[PYIC-8109]: https://govukverify.atlassian.net/browse/PYIC-8109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ