### PR TITLE
PYIC-8127 Rethrow fatal IOExceptions on all HTTP requests

### DIFF
--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/client/EvcsClient.java
@@ -26,7 +26,6 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.tracing.TracingHttpClient;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -233,15 +232,7 @@ public class EvcsClient {
                                             evcsHttpRequest, HttpResponse.BodyHandlers.ofString());
                             checkResponseStatusCode(res);
                             return res;
-                        } catch (IOException e) {
-                            LOGGER.error(
-                                    LogHelper.buildErrorMessage(
-                                            "HTTP request failed with IOException", e));
-                            // Rethrow IOException as unchecked exception for now to force lambda to
-                            // crash (see
-                            // PYIC-8058 and linked incident INC0014124)
-                            throw new UncheckedIOException(e);
-                        } catch (EvcsServiceException e) {
+                        } catch (EvcsServiceException | IOException e) {
                             throw new NonRetryableException(e);
                         } catch (InterruptedException e) {
                             // This should never happen running in Lambda as it's single

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/client/EvcsClientTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/client/EvcsClientTest.java
@@ -27,8 +27,6 @@ import uk.gov.di.ipv.core.library.fixtures.VcFixtures;
 import uk.gov.di.ipv.core.library.retry.Sleeper;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -260,21 +258,6 @@ class EvcsClientTest {
         // Assert
         assertThrows(
                 EvcsServiceException.class,
-                () ->
-                        evcsClient.getUserVcs(
-                                TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_FOR_QUERY));
-    }
-
-    @Test
-    void testGetUserVCs_shouldRethrowUncheckedException_ifIOException() throws Exception {
-        // Arrange
-        when(mockHttpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
-                .thenThrow(new IOException("I/O error"));
-
-        // Act
-        // Assert
-        assertThrows(
-                UncheckedIOException.class,
                 () ->
                         evcsClient.getUserVcs(
                                 TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_FOR_QUERY));


### PR DESCRIPTION
## Proposed changes

### What changed

Throw unchecked exception for 'fatal' IOExceptions on all HTTP requests to force lambda instance to crash. If timeout exception, just rethrow. If "Connection reset" exception or HttpRetryException, retry once and then throw unchecked exception.

### Why did it change

We've seen a further instance in prod of a lambda spawned with apparently no network connectivity, raising IOExceptions on HTTP requests, this time in process-cri-callback, and again eventually crashing with a seg fault. As a further mitigation, we should rethrow fatal IOExceptions on all HTTP requests, not just EVCS requests as previously.

### Issue tracking
- [PYIC-8127](https://govukverify.atlassian.net/browse/PYIC-8127)



[PYIC-8127]: https://govukverify.atlassian.net/browse/PYIC-8127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ