### PR TITLE
BAU: Update AWS SDK

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-awsSdk = "2.30.5"
+awsSdk = "2.30.31"
 jackson = "2.18.0"
 log4j = "2.24.0"
 mockito = "5.15.2"


### PR DESCRIPTION
## Proposed changes

### What changed

Update AWS SDK

### Why did it change

Dependabot will ignore patch versions, but this means we're missing some transitive dependency updates that we'd quite like to pick up.