### PR TITLE
PYIC-7918: Check Unavailable Fraud Check for RFC

### DIFF
--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -1,15 +1,5 @@
 @Build
 Feature: MFA reset journey
-  Scenario: User is sent on reverification journey to remedy unavailable fraud check
-    Given the subject already has the following credentials
-      | CRI     | scenario               |
-      | dcmaw   | kenneth-passport-valid |
-      | address | kenneth-current        |
-      | fraud   | kenneth-unavailable    |
-
-    When I start a new 'medium-confidence' journey
-    Then I get a 'confirm-your-details' page response
-
   Rule: User has an existing identity
     Background: There is an existing user and they start an MFA reset journey
       Given the subject already has the following credentials

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -1,5 +1,15 @@
 @Build
 Feature: MFA reset journey
+  Scenario: User is sent on reverification journey to remedy unavailable fraud check
+    Given the subject already has the following credentials
+      | CRI     | scenario               |
+      | dcmaw   | kenneth-passport-valid |
+      | address | kenneth-current        |
+      | fraud   | kenneth-unavailable    |
+
+    When I start a new 'medium-confidence' journey
+    Then I get a 'confirm-your-details' page response
+
   Rule: User has an existing identity
     Background: There is an existing user and they start an MFA reset journey
       Given the subject already has the following credentials

--- a/api-tests/features/p2-reuse-journey.feature
+++ b/api-tests/features/p2-reuse-journey.feature
@@ -1,7 +1,7 @@
 @Build
-@TrafficGeneration
 Feature: P2 Reuse journey
 
+  @TrafficGeneration
   Scenario: Successful P2 reuse journey
     # First identity proving journey
     Given I start a new 'medium-confidence' journey
@@ -35,3 +35,13 @@ Feature: P2 Reuse journey
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
+
+  Scenario: User with M1C is sent on reuse journey when no applicable fraud check
+    Given the subject already has the following credentials
+      | CRI     | scenario               |
+      | dcmaw   | kenneth-passport-valid |
+      | address | kenneth-current        |
+      | fraud   | kenneth-no-applicable  |
+
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-reuse' page response

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
@@ -1,6 +1,16 @@
 @Build
 Feature: Repeat fraud check journeys
 
+  Scenario: User is sent on RFC journey to remedy unavailable fraud check
+    Given the subject already has the following credentials
+      | CRI     | scenario               |
+      | dcmaw   | kenneth-passport-valid |
+      | address | kenneth-current        |
+      | fraud   | kenneth-unavailable    |
+
+    When I start a new 'medium-confidence' journey
+    Then I get a 'confirm-your-details' page response
+
   Rule: Match M1B
 
     Background:

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -380,7 +380,7 @@ public class BuildCriOauthRequestHandler
     private EvidenceRequest getEvidenceRequestForF2F(
             List<VerifiableCredential> vcs, Vot requestedVot) {
         var gpg45Scores = gpg45ProfileEvaluator.buildScore(vcs);
-        var isFraudScoreRequired = !VcHelper.isFraudCheckUnavailable(vcs);
+        var isFraudScoreRequired = !VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
         var requiredEvidences =
                 gpg45Scores.calculateGpg45ScoresRequiredToMeetAProfile(
                         requestedVot.getSupportedGpg45Profiles(isFraudScoreRequired));

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -215,7 +215,7 @@ public class EvaluateGpg45ScoresHandler
                             .filter(vot -> vot.getProfileType() == ProfileType.GPG45)
                             .toList();
 
-            var isFraudScoreRequired = !VcHelper.isFraudCheckUnavailable(vcs);
+            var isFraudScoreRequired = !VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
 
             for (Vot requestedVot : gpg45Vots) {
                 var profiles = requestedVot.getSupportedGpg45Profiles(isFraudScoreRequired);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -716,7 +716,7 @@ public interface VcFixtures {
                 Instant.ofEpochSecond(1658829758));
     }
 
-    static VerifiableCredential vcFraudApplicableAuthoritativeAvailableFailed() {
+    static VerifiableCredential vcFraudAvailableAuthoritativeFailed() {
         TestVc.TestCredentialSubject credentialSubject =
                 TestVc.TestCredentialSubject.builder()
                         .address(List.of(ADDRESS_3))

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/VotMatcher.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/VotMatcher.java
@@ -64,7 +64,7 @@ public class VotMatcher {
             Gpg45Scores gpg45Scores,
             List<ContraIndicator> contraIndicators) {
 
-        var isFraudScoreRequired = !VcHelper.isFraudCheckUnavailable(gpg45Vcs);
+        var isFraudScoreRequired = !VcHelper.hasUnavailableOrNotApplicableFraudCheck(gpg45Vcs);
         var achievableProfiles = requestedVot.getSupportedGpg45Profiles(isFraudScoreRequired);
 
         Optional<Gpg45Profile> matchedGpg45Profile =

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/VotMatcherTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/VotMatcherTest.java
@@ -26,8 +26,8 @@ import static uk.gov.di.ipv.core.library.enums.Vot.PCL200;
 import static uk.gov.di.ipv.core.library.enums.Vot.PCL250;
 import static uk.gov.di.ipv.core.library.enums.Vot.SUPPORTED_VOTS_BY_DESCENDING_STRENGTH;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreTwo;
-import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudApplicableAuthoritativeAvailableFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudApplicableAuthoritativeSourceFailed;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudAvailableAuthoritativeFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL200;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL250;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcVerificationM1a;
@@ -168,7 +168,7 @@ class VotMatcherTest {
     @Test
     void shouldMatchM1cIfFraudCheckAuthoritativeUnavailable() throws Exception {
         // Arrange
-        var vcs = List.of(vcVerificationM1a(), vcFraudApplicableAuthoritativeAvailableFailed());
+        var vcs = List.of(vcVerificationM1a(), vcFraudAvailableAuthoritativeFailed());
         var expectedProfiles =
                 List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B, Gpg45Profile.M1C);
         when(mockUseridentityService.checkRequiresAdditionalEvidence(vcs)).thenReturn(false);

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -38,8 +38,8 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermit;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudEvidenceFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreOne;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcF2fM1a;
-import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudApplicableAuthoritativeAvailableFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudApplicableAuthoritativeSourceFailed;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudAvailableAuthoritativeFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudExpired;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcFraudNotExpired;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL200;
@@ -251,7 +251,8 @@ class VcHelperTest {
     }
 
     @Test
-    void isFraudCheckUnavailableShouldReturnTrueForApplicableAuthoritativeSourceFailedFraudCheck() {
+    void
+            hasUnavailableOrNotApplicableFraudCheckShouldReturnTrueForApplicableAuthoritativeSourceFailedFraudCheck() {
 
         // Arrange
         var vcs =
@@ -262,32 +263,33 @@ class VcHelperTest {
                         vcVerificationM1a());
 
         // Act
-        var result = VcHelper.isFraudCheckUnavailable(vcs);
+        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
 
         // Assert
         assertTrue(result);
     }
 
     @Test
-    void isFraudCheckUnavailableShouldReturnTrueForAuthoritativeAvailableSourceFailedFraudCheck() {
+    void
+            hasUnavailableOrNotApplicableFraudCheckShouldReturnTrueForAuthoritativeAvailableSourceFailedFraudCheck() {
 
         // Arrange
         var vcs =
                 List.of(
                         DCMAW_PASSPORT_VC,
                         M1A_ADDRESS_VC,
-                        vcFraudApplicableAuthoritativeAvailableFailed(),
+                        vcFraudAvailableAuthoritativeFailed(),
                         vcVerificationM1a());
 
         // Act
-        var result = VcHelper.isFraudCheckUnavailable(vcs);
+        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
 
         // Assert
         assertTrue(result);
     }
 
     @Test
-    void isFraudCheckUnavailableShouldReturnFalseForOtherFailedFraudCheck() {
+    void hasUnavailableOrNotApplicableFraudCheckShouldReturnFalseForOtherFailedFraudCheck() {
 
         // Arrange
         var vcs =
@@ -298,14 +300,14 @@ class VcHelperTest {
                         vcVerificationM1a());
 
         // Act
-        var result = VcHelper.isFraudCheckUnavailable(vcs);
+        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
 
         // Assert
         assertFalse(result);
     }
 
     @Test
-    void isFraudCheckUnavailableShouldReturnFalseForSuccessfulFraudCheck() {
+    void hasUnavailableOrNotApplicableFraudCheckShouldReturnFalseForSuccessfulFraudCheck() {
 
         // Arrange
         var vcs =
@@ -316,20 +318,53 @@ class VcHelperTest {
                         vcVerificationM1a());
 
         // Act
-        var result = VcHelper.isFraudCheckUnavailable(vcs);
+        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
 
         // Assert
         assertFalse(result);
     }
 
     @Test
-    void isFraudCheckUnavailableShouldReturnFalseForMissingFraudCheck() {
+    void hasUnavailableOrNotApplicableFraudCheckShouldReturnFalseForMissingFraudCheck() {
 
         // Arrange
         var vcs = List.of(DCMAW_PASSPORT_VC, M1A_ADDRESS_VC, vcVerificationM1a());
 
         // Act
-        var result = VcHelper.isFraudCheckUnavailable(vcs);
+        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
+
+        // Assert
+        assertFalse(result);
+    }
+
+    @Test
+    void hasUnavailableFraudCheckShouldReturnTrueForUnavailableFraudCheck() {
+
+        // Arrange
+        var vc = vcFraudApplicableAuthoritativeSourceFailed();
+
+        // Act
+        var result = VcHelper.hasUnavailableFraudCheck(vc);
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    void hasUnavailableFraudCheckShouldReturnFalseForSuccessfulFraudCheck() {
+
+        // Act
+        var result = VcHelper.hasUnavailableFraudCheck(vcExperianFraudScoreOne());
+
+        // Assert
+        assertFalse(result);
+    }
+
+    @Test
+    void hasUnavailableFraudCheckShouldReturnFalseForMissingFraudCheck() {
+
+        // Act
+        var result = VcHelper.hasUnavailableFraudCheck(DCMAW_PASSPORT_VC);
 
         // Assert
         assertFalse(result);

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -341,7 +341,7 @@ class VcHelperTest {
     void hasUnavailableFraudCheckShouldReturnTrueForUnavailableFraudCheck() {
 
         // Arrange
-        var vc = vcFraudApplicableAuthoritativeSourceFailed();
+        var vc = vcFraudAvailableAuthoritativeFailed();
 
         // Act
         var result = VcHelper.hasUnavailableFraudCheck(vc);


### PR DESCRIPTION
## Proposed changes

### What changed

- Add check for unavailable authoritative source fraud check in the RFC check logic.
- Some refactors for readability.

### Why did it change

- To put the user on a RFC journey if they had an unavailable fraud check before.

### Issue tracking

- [PYIC-7918](https://govukverify.atlassian.net/browse/PYIC-7918)

[PYIC-7918]: https://govukverify.atlassian.net/browse/PYIC-7918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ