### PR TITLE
BAU: Remove target vot from session now it's not used

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -262,11 +262,6 @@ public class CheckExistingIdentityHandler
 
             var targetVot = VotHelper.getThresholdVot(ipvSessionItem, clientOAuthSessionItem);
 
-            // As almost all of our journeys are proving or mitigating a GPG45 vot we set the
-            // target vot here as a default value. It will be overridden for identity reuse.
-            ipvSessionItem.setTargetVot(targetVot);
-            ipvSessionService.updateIpvSession(ipvSessionItem);
-
             var contraIndicatorsVc =
                     cimitService.getContraIndicatorsVc(
                             clientOAuthSessionItem.getUserId(),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -38,7 +38,6 @@ public class IpvSessionItem implements PersistenceItem {
     private String errorCode;
     private String errorDescription;
     private Vot vot;
-    private Vot targetVot;
     private long ttl;
     private String emailAddress;
     private ReverificationStatus reverificationStatus;


### PR DESCRIPTION
## Proposed changes

### What changed

Part 2 of the previous https://github.com/govuk-one-login/ipv-core-back/pull/3046

To be merged once that has propagated and no sessions require the target vot to be present