### PR TITLE
PYIC-8127 Retry on HTTP/2 GOAWAY

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClient.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClient.java
@@ -58,9 +58,12 @@ public class TracingHttpClient extends HttpClient {
             if (e instanceof HttpTimeoutException) {
                 throw e;
             }
-            // In the build environment we see connection resets for idle connections in the
-            // pool. Retrying uses a different connection.
-            if (e.getMessage().contains("Connection reset") || e instanceof HttpRetryException) {
+            // We occasionally see HTTP/2 GOAWAY messages and in build we occasionally see
+            // connection resets for idle connections in the pool. Retrying uses a different
+            // connection.
+            if (e.getMessage().contains("GOAWAY received")
+                    || e.getMessage().contains("Connection reset")
+                    || e instanceof HttpRetryException) {
                 LOGGER.warn(
                         LogHelper.buildErrorMessage("Retrying after non-fatal HTTP IOException", e)
                                 .with("host", request.uri().getHost()));


### PR DESCRIPTION
## Proposed changes

### What changed

Add HTTP/2 GOAWAY to the class of errors we want to retry rather than throwing an unchecked exception

### Why did it change

We've seen a few instances of unhandled `java.io.UncheckedIOException: java.io.IOException: /169.254.76.1:55700: GOAWAY received` in both build and prod - we expect these to recover on a retry so we don't want to throw and hard fail

### Issue tracking
- addendum to [PYIC-8127](https://govukverify.atlassian.net/browse/PYIC-8127)


[PYIC-8127]: https://govukverify.atlassian.net/browse/PYIC-8127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ