### PR TITLE
PYIC-8024: Fallback to secondary key for decryption if primary fails

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -9,10 +9,14 @@ import com.nimbusds.jose.crypto.impl.AlgorithmSupportMessage;
 import com.nimbusds.jose.crypto.impl.ContentCryptoProvider;
 import com.nimbusds.jose.jca.JWEJCAContext;
 import com.nimbusds.jose.util.Base64URL;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
+import software.amazon.awssdk.services.kms.model.DecryptResponse;
+import software.amazon.awssdk.services.kms.model.IncorrectKeyException;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
@@ -24,13 +28,15 @@ import java.util.Set;
 import static com.nimbusds.jose.JWEAlgorithm.RSA_OAEP_256;
 import static software.amazon.awssdk.regions.Region.EU_WEST_2;
 import static software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256;
-import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JAR_KMS_ENCRYPTION_KEY_ID;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_PRIMARY;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_SECONDARY;
 
 @ExcludeFromGeneratedCoverageReport
 public class KmsRsaDecrypter implements JWEDecrypter {
     private static final Set<JWEAlgorithm> SUPPORTED_ALGORITHMS = Set.of(JWEAlgorithm.RSA_OAEP_256);
     private static final Set<EncryptionMethod> SUPPORTED_ENCRYPTION_METHODS =
             Set.of(EncryptionMethod.A256GCM);
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private final ConfigService configService;
     private final KmsClient kmsClient;
@@ -73,16 +79,36 @@ public class KmsRsaDecrypter implements JWEDecrypter {
                     AlgorithmSupportMessage.unsupportedJWEAlgorithm(alg, supportedJWEAlgorithms()));
         }
 
-        var keyId = configService.getParameter(JAR_KMS_ENCRYPTION_KEY_ID);
+        var primaryKeyAlias = configService.getParameter(CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_PRIMARY);
+        var secondaryKeyAlias = configService.getParameter(CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_SECONDARY);
 
-        var encryptedKeyDecryptRequest =
+        var encryptedKeyDecryptRequestPrimary =
                 DecryptRequest.builder()
                         .ciphertextBlob(SdkBytes.fromByteArray(encryptedKey.decode()))
                         .encryptionAlgorithm(RSAES_OAEP_SHA_256)
-                        .keyId(keyId)
+                        .keyId("alias/" + primaryKeyAlias)
                         .build();
 
-        var decryptResponse = kmsClient.decrypt(encryptedKeyDecryptRequest);
+        var encryptedKeyDecryptRequestSecondary =
+                DecryptRequest.builder()
+                        .ciphertextBlob(SdkBytes.fromByteArray(encryptedKey.decode()))
+                        .encryptionAlgorithm(RSAES_OAEP_SHA_256)
+                        .keyId("alias/" + secondaryKeyAlias)
+                        .build();
+
+        // During a key rotation we might receive JWTs encrypted with either the old or new key.
+        DecryptResponse decryptResponse;
+        try {
+            decryptResponse = kmsClient.decrypt(encryptedKeyDecryptRequestPrimary);
+        }
+        catch (IncorrectKeyException e) {
+            decryptResponse = kmsClient.decrypt(encryptedKeyDecryptRequestSecondary);
+        }
+        catch (Exception e) {
+            // We only expect to get IncorrectKeyExceptions, but if we get another error we should still try the secondary key
+            LOGGER.warn("Unexpected exception decrypting JWT key with primary key. Trying secondary key. %s".formatted(e.getMessage()));
+            decryptResponse = kmsClient.decrypt(encryptedKeyDecryptRequestSecondary);
+        }
 
         SecretKeySpec contentEncryptionKey =
                 new SecretKeySpec(decryptResponse.plaintext().asByteArray(), "AES");

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -31,7 +31,6 @@ import static software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec.
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_PRIMARY;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_SECONDARY;
 
-@ExcludeFromGeneratedCoverageReport
 public class KmsRsaDecrypter implements JWEDecrypter {
     private static final Set<JWEAlgorithm> SUPPORTED_ALGORITHMS = Set.of(JWEAlgorithm.RSA_OAEP_256);
     private static final Set<EncryptionMethod> SUPPORTED_ENCRYPTION_METHODS =
@@ -42,6 +41,7 @@ public class KmsRsaDecrypter implements JWEDecrypter {
     private final KmsClient kmsClient;
     private final JWEJCAContext jwejcaContext = new JWEJCAContext();
 
+    @ExcludeFromGeneratedCoverageReport
     public KmsRsaDecrypter(ConfigService configService) {
         this.configService = configService;
         this.kmsClient =
@@ -49,6 +49,11 @@ public class KmsRsaDecrypter implements JWEDecrypter {
                         .region(EU_WEST_2)
                         .httpClientBuilder(UrlConnectionHttpClient.builder())
                         .build();
+    }
+
+    public KmsRsaDecrypter(ConfigService configService, KmsClient kmsClient) {
+        this.configService = configService;
+        this.kmsClient = kmsClient;
     }
 
     @Override

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -79,8 +79,10 @@ public class KmsRsaDecrypter implements JWEDecrypter {
                     AlgorithmSupportMessage.unsupportedJWEAlgorithm(alg, supportedJWEAlgorithms()));
         }
 
-        var primaryKeyAlias = configService.getParameter(CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_PRIMARY);
-        var secondaryKeyAlias = configService.getParameter(CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_SECONDARY);
+        var primaryKeyAlias =
+                configService.getParameter(CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_PRIMARY);
+        var secondaryKeyAlias =
+                configService.getParameter(CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_SECONDARY);
 
         var encryptedKeyDecryptRequestPrimary =
                 DecryptRequest.builder()
@@ -100,13 +102,14 @@ public class KmsRsaDecrypter implements JWEDecrypter {
         DecryptResponse decryptResponse;
         try {
             decryptResponse = kmsClient.decrypt(encryptedKeyDecryptRequestPrimary);
-        }
-        catch (IncorrectKeyException e) {
+        } catch (IncorrectKeyException e) {
             decryptResponse = kmsClient.decrypt(encryptedKeyDecryptRequestSecondary);
-        }
-        catch (Exception e) {
-            // We only expect to get IncorrectKeyExceptions, but if we get another error we should still try the secondary key
-            LOGGER.warn("Unexpected exception decrypting JWT key with primary key. Trying secondary key. %s".formatted(e.getMessage()));
+        } catch (Exception e) {
+            // We only expect to get IncorrectKeyExceptions, but if we get another error we should
+            // still try the secondary key
+            LOGGER.warn(
+                    "Unexpected exception decrypting JWT key with primary key. Trying secondary key. %s"
+                            .formatted(e.getMessage()));
             decryptResponse = kmsClient.decrypt(encryptedKeyDecryptRequestSecondary);
         }
 

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypterTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypterTest.java
@@ -1,0 +1,214 @@
+package uk.gov.di.ipv.core.initialiseipvsession.service;
+
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.crypto.impl.ContentCryptoProvider;
+import com.nimbusds.jose.util.Base64URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.DecryptRequest;
+import software.amazon.awssdk.services.kms.model.DecryptResponse;
+import software.amazon.awssdk.services.kms.model.IncorrectKeyException;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+
+import static com.nimbusds.jose.JWEAlgorithm.RSA_OAEP_256;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_PRIMARY;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_SECONDARY;
+
+@ExtendWith(MockitoExtension.class)
+class KmsRsaDecrypterTest {
+
+    @Mock private KmsClient mockKmsClient;
+
+    @Mock private ConfigService mockConfigService;
+
+    @InjectMocks private KmsRsaDecrypter underTest;
+
+    @BeforeEach
+    void setup() {
+        lenient()
+                .when(mockConfigService.getParameter(CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_PRIMARY))
+                .thenReturn("primaryKeyAlias");
+        lenient()
+                .when(mockConfigService.getParameter(CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_SECONDARY))
+                .thenReturn("secondaryKeyAlias");
+    }
+
+    @Test
+    void decrypt_whenGivenNoEncryptedKey_shouldThrowAnException() {
+        // Arrange
+        JWEHeader header = new JWEHeader(RSA_OAEP_256, EncryptionMethod.A256GCM);
+        Base64URL encryptedKey = null;
+        Base64URL iv = new Base64URL("iv");
+        Base64URL cypherText = new Base64URL("cypherText");
+        Base64URL authTag = new Base64URL("authTag");
+        byte[] aad = new byte[] {};
+
+        // Act
+        var thrown =
+                assertThrows(
+                        Exception.class,
+                        () -> underTest.decrypt(header, encryptedKey, iv, cypherText, authTag, aad),
+                        "Expected decrypt() to throw, but it didn't");
+
+        // Assert
+        assertThat(thrown, instanceOf(JOSEException.class));
+        assertThat(thrown.getMessage(), containsString("encrypted key"));
+    }
+
+    @Test
+    void decrypt_whenGivenNoIv_shouldThrowAnException() {
+        // Arrange
+        JWEHeader header = new JWEHeader(RSA_OAEP_256, EncryptionMethod.A256GCM);
+        Base64URL encryptedKey = new Base64URL("encryptedKey");
+        Base64URL iv = null;
+        Base64URL cypherText = new Base64URL("cypherText");
+        Base64URL authTag = new Base64URL("authTag");
+        byte[] aad = new byte[] {};
+
+        // Act
+        var thrown =
+                assertThrows(
+                        Exception.class,
+                        () -> underTest.decrypt(header, encryptedKey, iv, cypherText, authTag, aad),
+                        "Expected decrypt() to throw, but it didn't");
+
+        // Assert
+        assertThat(thrown, instanceOf(JOSEException.class));
+        assertThat(thrown.getMessage(), containsString("IV"));
+    }
+
+    @Test
+    void decrypt_whenGivenNoAuthTag_shouldThrowAnException() {
+        // Arrange
+        JWEHeader header = new JWEHeader(RSA_OAEP_256, EncryptionMethod.A256GCM);
+        Base64URL encryptedKey = new Base64URL("encryptedKey");
+        Base64URL iv = new Base64URL("iv");
+        Base64URL cypherText = new Base64URL("cypherText");
+        Base64URL authTag = null;
+        byte[] aad = new byte[] {};
+
+        // Act
+        var thrown =
+                assertThrows(
+                        Exception.class,
+                        () -> underTest.decrypt(header, encryptedKey, iv, cypherText, authTag, aad),
+                        "Expected decrypt() to throw, but it didn't");
+
+        // Assert
+        assertThat(thrown, instanceOf(JOSEException.class));
+        assertThat(thrown.getMessage(), containsString("authentication tag"));
+    }
+
+    @Test
+    void decrypt_whenPrimaryKeyIsWrong_shouldTrySecondaryKey() throws JOSEException {
+        // Arrange
+        try (var staticMock = Mockito.mockStatic(ContentCryptoProvider.class)) {
+            var expectedResult = new byte[] {};
+            Mockito.when(
+                            ContentCryptoProvider.decrypt(
+                                    any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(expectedResult);
+            JWEHeader header = new JWEHeader(RSA_OAEP_256, EncryptionMethod.A256GCM);
+            Base64URL encryptedKey = new Base64URL("ZW5jcnlwdGVkS2V5");
+            Base64URL iv = new Base64URL("iv");
+            Base64URL cypherText = new Base64URL("cypherText");
+            Base64URL authTag = new Base64URL("authTag");
+            byte[] aad = new byte[] {};
+
+            when(mockKmsClient.decrypt(
+                            argThat(
+                                    (DecryptRequest dr) ->
+                                            dr != null && dr.keyId().contains("primary"))))
+                    .thenThrow(IncorrectKeyException.builder().message("test").build());
+            when(mockKmsClient.decrypt(
+                            argThat(
+                                    (DecryptRequest dr) ->
+                                            dr != null && dr.keyId().contains("secondary"))))
+                    .thenReturn(
+                            DecryptResponse.builder()
+                                    .plaintext(SdkBytes.fromByteArray(new byte[] {1}))
+                                    .build());
+
+            // Act
+            var result = underTest.decrypt(header, encryptedKey, iv, cypherText, authTag, aad);
+
+            // Assert
+            ArgumentCaptor<DecryptRequest> decryptRequestCaptor =
+                    ArgumentCaptor.forClass(DecryptRequest.class);
+            verify(mockKmsClient, times(2)).decrypt(decryptRequestCaptor.capture());
+            assertThat(
+                    decryptRequestCaptor.getAllValues().get(0).keyId(), containsString("primary"));
+            assertThat(
+                    decryptRequestCaptor.getAllValues().get(1).keyId(),
+                    containsString("secondary"));
+            assertThat(result, equalTo(expectedResult));
+        }
+    }
+
+    @Test
+    void decrypt_whenPrimaryKeyFails_shouldTrySecondaryKey() throws JOSEException {
+        // Arrange
+        try (var staticMock = Mockito.mockStatic(ContentCryptoProvider.class)) {
+            var expectedResult = new byte[] {};
+            Mockito.when(
+                            ContentCryptoProvider.decrypt(
+                                    any(), any(), any(), any(), any(), any(), any()))
+                    .thenReturn(expectedResult);
+            JWEHeader header = new JWEHeader(RSA_OAEP_256, EncryptionMethod.A256GCM);
+            Base64URL encryptedKey = new Base64URL("ZW5jcnlwdGVkS2V5");
+            Base64URL iv = new Base64URL("iv");
+            Base64URL cypherText = new Base64URL("cypherText");
+            Base64URL authTag = new Base64URL("authTag");
+            byte[] aad = new byte[] {};
+
+            when(mockKmsClient.decrypt(
+                            argThat(
+                                    (DecryptRequest dr) ->
+                                            dr != null && dr.keyId().contains("primary"))))
+                    .thenThrow(new RuntimeException("test"));
+            when(mockKmsClient.decrypt(
+                            argThat(
+                                    (DecryptRequest dr) ->
+                                            dr != null && dr.keyId().contains("secondary"))))
+                    .thenReturn(
+                            DecryptResponse.builder()
+                                    .plaintext(SdkBytes.fromByteArray(new byte[] {1}))
+                                    .build());
+
+            // Act
+            var result = underTest.decrypt(header, encryptedKey, iv, cypherText, authTag, aad);
+
+            // Assert
+            ArgumentCaptor<DecryptRequest> decryptRequestCaptor =
+                    ArgumentCaptor.forClass(DecryptRequest.class);
+            verify(mockKmsClient, times(2)).decrypt(decryptRequestCaptor.capture());
+            assertThat(
+                    decryptRequestCaptor.getAllValues().get(0).keyId(), containsString("primary"));
+            assertThat(
+                    decryptRequestCaptor.getAllValues().get(1).keyId(),
+                    containsString("secondary"));
+            assertThat(result, equalTo(expectedResult));
+        }
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -38,7 +38,8 @@ public enum ConfigurationVariable {
             "self/govUkNotify/emailTemplates/UserTriggeredIdentityResetConfirmationF2f"),
     GOV_UK_NOTIFY_TEMPLATE_ID_USER_TRIGGERED_IDENTITY_RESET_CONFIRMATION(
             "self/govUkNotify/emailTemplates/UserTriggeredIdentityResetConfirmation"),
-    JAR_KMS_ENCRYPTION_KEY_ID("self/jarKmsEncryptionKeyId"),
+    CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_PRIMARY("self/clientJarKmsEncryptionKeyAliasPrimary"),
+    CLIENT_JAR_KMS_ENCRYPTION_KEY_ALIAS_SECONDARY("self/clientJarKmsEncryptionKeyAliasSecondary"),
     JAR_ENCRYPTION_KEY_JWK("self/jarEncryptionKey"),
     JWT_TTL_SECONDS("self/jwtTtlSeconds"),
     MAX_ALLOWED_AUTH_CLIENT_TTL("self/maxAllowedAuthClientTtl"),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Switch to using key alias config, and fallback to secondary value if the primary doesn't work.

### Why did it change

To support key rotation.

This should be safe to merge as https://github.com/govuk-one-login/ipv-core-common-infra/pull/1188 has already been merged.

I have also tested this in my dev environment

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8024](https://govukverify.atlassian.net/browse/PYIC-8024)


[PYIC-8024]: https://govukverify.atlassian.net/browse/PYIC-8024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ