### PR TITLE
PYIC-8088: Change noisy logging log levels

### DIFF
--- a/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
+++ b/lambdas/check-coi/src/main/java/uk/gov/di/ipv/core/checkcoi/CheckCoiHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedCheckCoi;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
 import uk.gov.di.ipv.core.library.auditing.restricted.DeviceInformation;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.IdentityClaim;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
@@ -195,7 +196,12 @@ public class CheckCoiHandler implements RequestHandler<ProcessRequest, Map<Strin
         } catch (HttpResponseExceptionWithErrorBody
                 | EvcsServiceException
                 | VerifiableCredentialException e) {
-            LOGGER.error(LogHelper.buildErrorMessage("Received exception", e));
+            var errorMessage = LogHelper.buildErrorMessage("Received exception", e);
+            if (ErrorResponse.FAILED_NAME_CORRELATION.equals(e.getErrorResponse())) {
+                LOGGER.info(errorMessage);
+            } else {
+                LOGGER.error(errorMessage);
+            }
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.http.HttpStatusCode;
@@ -112,6 +113,10 @@ public class CheckMobileAppVcReceiptHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.NOT_FOUND, "No VC found");
         } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
+            if (ErrorResponse.FAILED_NAME_CORRELATION.equals(e.getErrorResponse())) {
+                return buildErrorResponse(
+                        e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.INFO);
+            }
             return buildErrorResponse(e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse());
         } catch (IpvSessionNotFoundException e) {
             return buildErrorResponse(
@@ -224,11 +229,16 @@ public class CheckMobileAppVcReceiptHandler
     }
 
     private APIGatewayProxyResponseEvent buildErrorResponse(
-            Exception e, int status, ErrorResponse errorResponse) {
-        LOGGER.error(LogHelper.buildErrorMessage(errorResponse.getMessage(), e));
+            Exception e, int status, ErrorResponse errorResponse, Level level) {
+        LOGGER.log(level, LogHelper.buildErrorMessage(errorResponse.getMessage(), e));
         return ApiGatewayResponseGenerator.proxyJsonResponse(
                 status,
                 new JourneyErrorResponse(
                         JOURNEY_ERROR_PATH, status, errorResponse, e.getMessage()));
+    }
+
+    private APIGatewayProxyResponseEvent buildErrorResponse(
+            Exception e, int status, ErrorResponse errorResponse) {
+        return buildErrorResponse(e, status, errorResponse, Level.ERROR);
     }
 }

--- a/lambdas/check-reverification-identity/src/main/java/uk/gov/di/ipv/core/checkreverificationidentity/CheckReverificationIdentityHandler.java
+++ b/lambdas/check-reverification-identity/src/main/java/uk/gov/di/ipv/core/checkreverificationidentity/CheckReverificationIdentityHandler.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyRequest;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
@@ -127,7 +128,12 @@ public class CheckReverificationIdentityHandler
             return FOUND_RESPONSE;
 
         } catch (HttpResponseExceptionWithErrorBody | EvcsServiceException e) {
-            LOGGER.error(LogHelper.buildErrorMessage(e.getErrorResponse()));
+            var errorMessage = LogHelper.buildErrorMessage(e.getErrorResponse());
+            if (ErrorResponse.FAILED_NAME_CORRELATION.equals(e.getErrorResponse())) {
+                LOGGER.info(errorMessage);
+            } else {
+                LOGGER.error(errorMessage);
+            }
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();

--- a/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
+++ b/lambdas/evaluate-gpg45-scores/src/main/java/uk/gov/di/ipv/core/evaluategpg45scores/EvaluateGpg45ScoresHandler.java
@@ -167,7 +167,12 @@ public class EvaluateGpg45ScoresHandler
             logLambdaResponse("A GPG45 profile has been met", JOURNEY_MET);
             return JOURNEY_MET.toObjectMap();
         } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
-            LOGGER.error(LogHelper.buildErrorMessage("Received exception", e));
+            var errorMessage = LogHelper.buildErrorMessage("Received exception", e);
+            if (ErrorResponse.FAILED_NAME_CORRELATION.equals(e.getErrorResponse())) {
+                LOGGER.info(errorMessage);
+            } else {
+                LOGGER.error(errorMessage);
+            }
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.ipv.core.library.cimit.service.CimitService;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.cristoringservice.CriStoringService;
 import uk.gov.di.ipv.core.library.domain.Cri;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
@@ -219,7 +220,12 @@ public class ProcessCandidateIdentityHandler
                     auditEventUser);
 
         } catch (HttpResponseExceptionWithErrorBody e) {
-            LOGGER.error(LogHelper.buildErrorMessage("Failed to process identity", e));
+            var errorMessage = LogHelper.buildErrorMessage("Failed to process identity", e);
+            if (ErrorResponse.FAILED_NAME_CORRELATION.equals(e.getErrorResponse())) {
+                LOGGER.info(errorMessage);
+            } else {
+                LOGGER.error(errorMessage);
+            }
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -191,7 +191,6 @@ public class ProcessCriCallbackHandler
                                     PYI_ATTEMPT_RECOVERY_PAGE_ID));
                 }
                 case MISSING_IPV_SESSION_ID -> {
-                    LOGGER.warn(LogHelper.buildErrorMessage(e.getErrorResponse()));
                     return buildErrorResponse(
                             e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.WARN);
                 }

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.http.HttpStatusCode;
@@ -155,61 +156,86 @@ public class ProcessCriCallbackHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.OK, journeyResponse);
         } catch (ParseCriCallbackRequestException e) {
-
             return buildErrorResponse(
                     e,
                     HttpStatusCode.BAD_REQUEST,
-                    ErrorResponse.FAILED_TO_PARSE_CRI_CALLBACK_REQUEST);
+                    ErrorResponse.FAILED_TO_PARSE_CRI_CALLBACK_REQUEST,
+                    Level.ERROR);
         } catch (InvalidCriCallbackRequestException e) {
-            if (e.getErrorResponse() == ErrorResponse.NO_IPV_FOR_CRI_OAUTH_SESSION) {
-                LOGGER.error(LogHelper.buildErrorMessage(e.getErrorResponse()));
-                var pageOutput =
-                        StepFunctionHelpers.generatePageOutputMap(
-                                "error",
-                                HttpStatusCode.UNAUTHORIZED,
-                                PYI_TIMEOUT_RECOVERABLE_PAGE_ID);
-                var criOAuthSessionItem =
-                        criOAuthSessionService.getCriOauthSessionItem(callbackRequest.getState());
-                if (criOAuthSessionItem != null) {
-                    pageOutput.put(
-                            "clientOAuthSessionId", criOAuthSessionItem.getClientOAuthSessionId());
+            switch (e.getErrorResponse()) {
+                case NO_IPV_FOR_CRI_OAUTH_SESSION -> {
+                    LOGGER.warn(LogHelper.buildErrorMessage(e.getErrorResponse()));
+                    var pageOutput =
+                            StepFunctionHelpers.generatePageOutputMap(
+                                    "error",
+                                    HttpStatusCode.UNAUTHORIZED,
+                                    PYI_TIMEOUT_RECOVERABLE_PAGE_ID);
+                    var criOAuthSessionItem =
+                            criOAuthSessionService.getCriOauthSessionItem(
+                                    callbackRequest.getState());
+                    if (criOAuthSessionItem != null) {
+                        pageOutput.put(
+                                "clientOAuthSessionId",
+                                criOAuthSessionItem.getClientOAuthSessionId());
+                    }
+                    return ApiGatewayResponseGenerator.proxyJsonResponse(
+                            HttpStatusCode.UNAUTHORIZED, pageOutput);
                 }
-                return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        HttpStatusCode.UNAUTHORIZED, pageOutput);
+                case INVALID_OAUTH_STATE -> {
+                    LOGGER.warn(LogHelper.buildErrorMessage(e.getErrorResponse()));
+                    return ApiGatewayResponseGenerator.proxyJsonResponse(
+                            HttpStatusCode.BAD_REQUEST,
+                            StepFunctionHelpers.generatePageOutputMap(
+                                    "error",
+                                    HttpStatusCode.BAD_REQUEST,
+                                    PYI_ATTEMPT_RECOVERY_PAGE_ID));
+                }
+                case MISSING_IPV_SESSION_ID -> {
+                    LOGGER.warn(LogHelper.buildErrorMessage(e.getErrorResponse()));
+                    return buildErrorResponse(
+                            e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.WARN);
+                }
+                default -> {
+                    return buildErrorResponse(
+                            e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.ERROR);
+                }
             }
-            if (e.getErrorResponse() == ErrorResponse.INVALID_OAUTH_STATE) {
-                LOGGER.error(LogHelper.buildErrorMessage(e.getErrorResponse()));
-                return ApiGatewayResponseGenerator.proxyJsonResponse(
-                        HttpStatusCode.BAD_REQUEST,
-                        StepFunctionHelpers.generatePageOutputMap(
-                                "error", HttpStatusCode.BAD_REQUEST, PYI_ATTEMPT_RECOVERY_PAGE_ID));
-            }
-            return buildErrorResponse(e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse());
         } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
-            return buildErrorResponse(e, e.getResponseCode(), e.getErrorResponse());
+            if (ErrorResponse.FAILED_NAME_CORRELATION.equals(e.getErrorResponse())) {
+                return buildErrorResponse(
+                        e, e.getResponseCode(), ErrorResponse.FAILED_NAME_CORRELATION, Level.INFO);
+            }
+            return buildErrorResponse(e, e.getResponseCode(), e.getErrorResponse(), Level.ERROR);
         } catch (JsonProcessingException e) {
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT);
+                    ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT,
+                    Level.ERROR);
         } catch (UnrecognisedVotException e) {
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS);
+                    ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS,
+                    Level.ERROR);
         } catch (CiPutException | CiPostMitigationsException e) {
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_SAVE_CREDENTIAL);
+                    ErrorResponse.FAILED_TO_SAVE_CREDENTIAL,
+                    Level.ERROR);
         } catch (CiRetrievalException e) {
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_GET_STORED_CIS);
+                    ErrorResponse.FAILED_TO_GET_STORED_CIS,
+                    Level.ERROR);
         } catch (ConfigException e) {
             return buildErrorResponse(
-                    e, HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.FAILED_TO_PARSE_CONFIG);
+                    e,
+                    HttpStatusCode.INTERNAL_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_PARSE_CONFIG,
+                    Level.ERROR);
         } catch (CriApiException e) {
             if (DCMAW.equals(callbackRequest.getCredentialIssuer())
                     && e.getHttpStatusCode() == HTTPResponse.SC_NOT_FOUND) {
@@ -219,15 +245,19 @@ public class ProcessCriCallbackHandler
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         HttpStatusCode.OK, JOURNEY_NOT_FOUND);
             }
-            return buildErrorResponse(e, e.getHttpStatusCode(), e.getErrorResponse());
+            return buildErrorResponse(e, e.getHttpStatusCode(), e.getErrorResponse(), Level.ERROR);
         } catch (CiExtractionException e) {
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC);
+                    ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC,
+                    Level.ERROR);
         } catch (IpvSessionNotFoundException e) {
             return buildErrorResponse(
-                    e, HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.IPV_SESSION_NOT_FOUND);
+                    e,
+                    HttpStatusCode.INTERNAL_SERVER_ERROR,
+                    ErrorResponse.IPV_SESSION_NOT_FOUND,
+                    Level.ERROR);
         } catch (Exception e) {
             LOGGER.error(LogHelper.buildErrorMessage("Unhandled lambda exception", e));
             throw e;
@@ -365,8 +395,8 @@ public class ProcessCriCallbackHandler
     }
 
     private APIGatewayProxyResponseEvent buildErrorResponse(
-            Exception e, int status, ErrorResponse errorResponse) {
-        LOGGER.error(LogHelper.buildErrorMessage(errorResponse.getMessage(), e));
+            Exception e, int status, ErrorResponse errorResponse, Level level) {
+        LOGGER.log(level, LogHelper.buildErrorMessage(errorResponse.getMessage(), e));
         return ApiGatewayResponseGenerator.proxyJsonResponse(
                 status,
                 new JourneyErrorResponse(

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -153,7 +153,10 @@ public class CriCheckingService {
             case OAuth2Error.INVALID_REQUEST_CODE -> JOURNEY_INVALID_REQUEST;
             default -> {
                 LOGGER.error(
-                        LogHelper.buildErrorMessage("Unacceptable callback error code", errorCode));
+                        LogHelper.buildErrorMessage(
+                                "Unexpected OAuth error received from CRI",
+                                errorDescription,
+                                errorCode));
                 yield JOURNEY_ERROR;
             }
         });

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingService.java
@@ -143,7 +143,7 @@ public class CriCheckingService {
             LOGGER.warn(LogHelper.buildLogMessage("Unknown Oauth error code received"));
         }
 
-        LOGGER.error(
+        LOGGER.info(
                 LogHelper.buildErrorMessage(
                         "OAuth error received from CRI", errorDescription, errorCode));
 
@@ -151,7 +151,11 @@ public class CriCheckingService {
             case OAuth2Error.ACCESS_DENIED_CODE -> JOURNEY_ACCESS_DENIED;
             case OAuth2Error.TEMPORARILY_UNAVAILABLE_CODE -> JOURNEY_TEMPORARILY_UNAVAILABLE;
             case OAuth2Error.INVALID_REQUEST_CODE -> JOURNEY_INVALID_REQUEST;
-            default -> JOURNEY_ERROR;
+            default -> {
+                LOGGER.error(
+                        LogHelper.buildErrorMessage("Unacceptable callback error code", errorCode));
+                yield JOURNEY_ERROR;
+            }
         });
     }
 
@@ -165,7 +169,7 @@ public class CriCheckingService {
                 throw new InvalidCriCallbackRequestException(
                         ErrorResponse.NO_IPV_FOR_CRI_OAUTH_SESSION);
             }
-            throw new InvalidCriCallbackRequestException(ErrorResponse.MISSING_OAUTH_STATE);
+            throw new InvalidCriCallbackRequestException(ErrorResponse.MISSING_IPV_SESSION_ID);
         }
     }
 

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.processjourneyevent;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -281,7 +282,8 @@ public class ProcessJourneyEventHandler
                     ipvSessionItem.getState());
             throw new JourneyEngineException();
         } catch (UnknownEventException e) {
-            logErrorWithCurrentJourneyDetails(
+            logWithCurrentJourneyDetails(
+                    Level.WARN,
                     "Invalid journey event provided, failed to execute journey engine step.",
                     e,
                     journeyEvent,
@@ -561,12 +563,22 @@ public class ProcessJourneyEventHandler
                 && basicState.getEvents().containsKey(BACK_EVENT);
     }
 
-    private void logErrorWithCurrentJourneyDetails(
-            String message, Exception e, String journeyEvent, JourneyState journeyState) {
-        LOGGER.error(
+    private void logWithCurrentJourneyDetails(
+            Level level,
+            String message,
+            Exception e,
+            String journeyEvent,
+            JourneyState journeyState) {
+        LOGGER.log(
+                level,
                 LogHelper.buildErrorMessage(message, e)
                         .with(LOG_JOURNEY_EVENT.getFieldName(), journeyEvent)
                         .with(LOG_USER_STATE.getFieldName(), journeyState.state())
                         .with(LOG_JOURNEY_TYPE.getFieldName(), journeyState.subJourney().name()));
+    }
+
+    private void logErrorWithCurrentJourneyDetails(
+            String message, Exception e, String journeyEvent, JourneyState journeyState) {
+        logWithCurrentJourneyDetails(Level.ERROR, message, e, journeyEvent, journeyState);
     }
 }

--- a/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
+++ b/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.http.HttpStatusCode;
@@ -37,6 +38,7 @@ import uk.gov.di.ipv.core.processmobileappcallback.dto.MobileAppCallbackRequest;
 import uk.gov.di.ipv.core.processmobileappcallback.exception.InvalidMobileAppCallbackRequestException;
 
 import java.util.Objects;
+import java.util.Set;
 
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
@@ -91,14 +93,26 @@ public class ProcessMobileAppCallbackHandler
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.OK, Objects.requireNonNullElse(response, JOURNEY_NEXT));
-        } catch (InvalidMobileAppCallbackRequestException | ClientOauthSessionNotFoundException e) {
-            return buildErrorResponse(e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse());
+        } catch (InvalidMobileAppCallbackRequestException e) {
+            if (Set.of(ErrorResponse.INVALID_OAUTH_STATE, ErrorResponse.MISSING_IPV_SESSION_ID)
+                    .contains(e.getErrorResponse())) {
+                return buildErrorResponse(
+                        e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.WARN);
+            }
+            return buildErrorResponse(
+                    e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.ERROR);
+        } catch (ClientOauthSessionNotFoundException e) {
+            return buildErrorResponse(
+                    e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.ERROR);
         } catch (IpvSessionNotFoundException e) {
             return buildErrorResponse(
-                    e, HttpStatusCode.BAD_REQUEST, ErrorResponse.IPV_SESSION_NOT_FOUND);
+                    e,
+                    HttpStatusCode.BAD_REQUEST,
+                    ErrorResponse.IPV_SESSION_NOT_FOUND,
+                    Level.ERROR);
         } catch (InvalidCriResponseException e) {
             return buildErrorResponse(
-                    e, HttpStatusCode.INTERNAL_SERVER_ERROR, e.getErrorResponse());
+                    e, HttpStatusCode.INTERNAL_SERVER_ERROR, e.getErrorResponse(), Level.ERROR);
         } catch (Exception e) {
             LOGGER.error(LogHelper.buildErrorMessage("Unhandled lambda exception", e));
             throw e;
@@ -186,8 +200,8 @@ public class ProcessMobileAppCallbackHandler
     }
 
     private APIGatewayProxyResponseEvent buildErrorResponse(
-            Exception e, int status, ErrorResponse errorResponse) {
-        LOGGER.error(LogHelper.buildErrorMessage(errorResponse.getMessage(), e));
+            Exception e, int status, ErrorResponse errorResponse, Level level) {
+        LOGGER.log(level, LogHelper.buildErrorMessage(errorResponse.getMessage(), e));
         return ApiGatewayResponseGenerator.proxyJsonResponse(
                 status,
                 new JourneyErrorResponse(

--- a/libs/ticf-cri-service/src/main/java/uk/gov/di/ipv/core/library/ticf/TicfCriService.java
+++ b/libs/ticf-cri-service/src/main/java/uk/gov/di/ipv/core/library/ticf/TicfCriService.java
@@ -147,7 +147,7 @@ public class TicfCriService {
                 LOGGER.warn(LogHelper.buildLogMessage("Request to TICF CRI has timed out"));
             }
             // In the case of unavailability, the TICF CRI is deemed optional.
-            LOGGER.error(
+            LOGGER.warn(
                     LogHelper.buildErrorMessage(
                             "Request to TICF CRI failed. Allowing user journey to continue", e));
             return List.of();

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -177,15 +177,14 @@ public class UserIdentityService {
             return false;
         }
 
+        var identityClaimsForNameCorrelation = getIdentityClaimsForNameCorrelation(successfulVcs);
         if (!checkNamesForCorrelation(
-                getGivenNamesWithCharAllowanceForCoiCheck(
-                        getIdentityClaimsForNameCorrelation(successfulVcs)))) {
+                getGivenNamesWithCharAllowanceForCoiCheck(identityClaimsForNameCorrelation))) {
             return false;
         }
 
         return checkNamesForCorrelation(
-                getFamilyNameWithCharAllowanceForCoiCheck(
-                        getIdentityClaimsForNameCorrelation(successfulVcs)));
+                getFamilyNameWithCharAllowanceForCoiCheck(identityClaimsForNameCorrelation));
     }
 
     public boolean areVcsCorrelated(List<VerifiableCredential> vcs)
@@ -193,7 +192,7 @@ public class UserIdentityService {
         var successfulVcs = getSuccessfulVcs(vcs);
 
         if (!checkNameAndFamilyNameCorrelationInCredentials(successfulVcs)) {
-            LOGGER.error(LogHelper.buildErrorMessage(ErrorResponse.FAILED_NAME_CORRELATION));
+            LOGGER.info(LogHelper.buildErrorMessage(ErrorResponse.FAILED_NAME_CORRELATION));
             return false;
         }
 
@@ -207,17 +206,18 @@ public class UserIdentityService {
     public boolean areNamesAndDobCorrelated(List<VerifiableCredential> vcs)
             throws HttpResponseExceptionWithErrorBody {
         var successfulVcs = getSuccessfulVcs(vcs);
+        var identityClaimsForNameCorrelation = getIdentityClaimsForNameCorrelation(successfulVcs);
 
         var areGivenNamesCorrelated =
                 checkNamesForCorrelation(
                         getNameProperty(
-                                getIdentityClaimsForNameCorrelation(successfulVcs),
+                                identityClaimsForNameCorrelation,
                                 NamePart.NamePartType.GIVEN_NAME));
 
         var isFamilyNameCorrelated =
                 checkNamesForCorrelation(
                         getFamilyNameWithCharAllowanceForCoiCheck(
-                                getIdentityClaimsForNameCorrelation(successfulVcs)));
+                                identityClaimsForNameCorrelation));
 
         // Given names AND family name cannot both be changed
         if (!areGivenNamesCorrelated && !isFamilyNameCorrelated) {


### PR DESCRIPTION
## Proposed changes

### What changed

- Change noisy logging log levels
- I updated the "Missing oauth state" log, which was misleading for the actual issue, to: "Missing ipv session id". And handled that one case only.

### Why did it change

- To reduce noise in logs, enabling us to better-identify issues

### Issue tracking

- [PYIC-8088](https://govukverify.atlassian.net/browse/PYIC-8088)

[PYIC-8088]: https://govukverify.atlassian.net/browse/PYIC-8088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ