### PR TITLE
PYIC-7983: match cri checking service logic

### DIFF
--- a/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
+++ b/lambdas/call-ticf-cri/src/main/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandler.java
@@ -43,6 +43,7 @@ import static uk.gov.di.ipv.core.library.domain.Cri.TICF;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.ERROR_PROCESSING_TICF_CRI_RESPONSE;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_NEXT_PATH;
 
 public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<String, Object>> {
@@ -193,8 +194,9 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
 
             var cis = cimitUtilityService.getContraIndicatorsFromVc(contraIndicatorVc);
 
+            // This lambda is unused and will be deleted so doesn't really matter what this is
             var journeyResponse =
-                    cimitUtilityService.getMitigationJourneyIfBreaching(
+                    cimitUtilityService.getMitigationEventIfBreachingOrActive(
                             cis, VotHelper.getThresholdVot(ipvSessionItem, clientOAuthSessionItem));
             if (journeyResponse.isPresent()) {
                 LOGGER.info(
@@ -202,7 +204,7 @@ public class CallTicfCriHandler implements RequestHandler<ProcessRequest, Map<St
                                 "CI score is breaching threshold - setting VOT to P0"));
                 ipvSessionItem.setVot(Vot.P0);
 
-                return journeyResponse.get().toObjectMap();
+                return new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH).toObjectMap();
             }
             LOGGER.info(LogHelper.buildLogMessage("CI score not breaching threshold"));
         }

--- a/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
+++ b/lambdas/call-ticf-cri/src/test/java/uk/gov/di/ipv/core/callticfcri/CallTicfCriHandlerTest.java
@@ -19,7 +19,6 @@ import uk.gov.di.ipv.core.library.cimit.exception.CiRetrievalException;
 import uk.gov.di.ipv.core.library.cimit.service.CimitService;
 import uk.gov.di.ipv.core.library.cristoringservice.CriStoringService;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
@@ -55,6 +54,7 @@ import static uk.gov.di.ipv.core.library.domain.ScopeConstants.OPENID;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.REVERIFICATION;
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
 import static uk.gov.di.ipv.core.library.enums.Vot.P2;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ENHANCED_VERIFICATION_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,9 +75,6 @@ class CallTicfCriHandlerTest {
                     .journey("a-journey")
                     .lambdaInput(Map.of("journeyType", "ipv"))
                     .build();
-    private static final String JOURNEY_ENHANCED_VERIFICATION = "/journey/enhanced-verification";
-    private static final JourneyResponse JOURNEY_FAIL_WITH_CI =
-            new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
 
     @Spy private IpvSessionItem ipvSessionItem;
     @Mock private Context mockContext;
@@ -165,8 +162,8 @@ class CallTicfCriHandlerTest {
                 .thenReturn(CLIENT_OAUTH_SESSION_ITEM);
         when(mockTicfCriService.getTicfVc(CLIENT_OAUTH_SESSION_ITEM, ipvSessionItem))
                 .thenReturn(List.of(mockVerifiableCredential));
-        when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), any()))
-                .thenReturn(Optional.of(JOURNEY_FAIL_WITH_CI));
+        when(mockCimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any()))
+                .thenReturn(Optional.of(JOURNEY_FAIL_WITH_CI_PATH));
 
         Map<String, Object> lambdaResult = callTicfCriHandler.handleRequest(INPUT, mockContext);
 
@@ -185,8 +182,8 @@ class CallTicfCriHandlerTest {
                 .thenReturn(CLIENT_OAUTH_SESSION_ITEM);
         when(mockTicfCriService.getTicfVc(CLIENT_OAUTH_SESSION_ITEM, ipvSessionItem))
                 .thenReturn(List.of(mockVerifiableCredential));
-        when(mockCimitUtilityService.getMitigationJourneyIfBreaching(any(), any()))
-                .thenReturn(Optional.of(new JourneyResponse(JOURNEY_ENHANCED_VERIFICATION)));
+        when(mockCimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any()))
+                .thenReturn(Optional.of(JOURNEY_ENHANCED_VERIFICATION_PATH));
 
         Map<String, Object> lambdaResult = callTicfCriHandler.handleRequest(INPUT, mockContext);
 
@@ -195,7 +192,7 @@ class CallTicfCriHandlerTest {
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
         inOrder.verifyNoMoreInteractions();
 
-        assertEquals(JOURNEY_ENHANCED_VERIFICATION, lambdaResult.get("journey"));
+        assertEquals(JOURNEY_FAIL_WITH_CI_PATH, lambdaResult.get("journey"));
     }
 
     @Test

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -291,7 +291,7 @@ public class CheckExistingIdentityHandler
             // though.
             if (cimitUtilityService.isBreachingCiThreshold(contraIndicators, targetVot)
                     && cimitUtilityService
-                            .getCiMitigationJourneyResponse(contraIndicators, targetVot)
+                            .getCiMitigationEvent(contraIndicators, targetVot)
                             .isEmpty()) {
                 return JOURNEY_FAIL_WITH_CI;
             }

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -127,9 +127,9 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcHmrcMigrationPCL2
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcVerificationM1a;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1A;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1B;
+import static uk.gov.di.ipv.core.library.journeys.Events.ENHANCED_VERIFICATION_EVENT;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DCMAW_ASYNC_VC_RECEIVED_LOW_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DCMAW_ASYNC_VC_RECEIVED_MEDIUM_PATH;
-import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ENHANCED_VERIFICATION_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_PENDING_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
@@ -867,8 +867,8 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(true);
-        when(cimitUtilityService.getCiMitigationJourneyResponse(any(), any()))
-                .thenReturn(Optional.of(new JourneyResponse(JOURNEY_ENHANCED_VERIFICATION_PATH)));
+        when(cimitUtilityService.getCiMitigationEvent(any(), any()))
+                .thenReturn(Optional.of(ENHANCED_VERIFICATION_EVENT));
 
         var journeyResponse =
                 toResponseClass(
@@ -1000,8 +1000,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
         when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(true);
-        when(cimitUtilityService.getCiMitigationJourneyResponse(any(), any()))
-                .thenReturn(Optional.empty());
+        when(cimitUtilityService.getCiMitigationEvent(any(), any())).thenReturn(Optional.empty());
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
@@ -1021,8 +1020,8 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
         when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(true);
-        when(cimitUtilityService.getCiMitigationJourneyResponse(any(), any()))
-                .thenReturn(Optional.of(new JourneyResponse(JOURNEY_ENHANCED_VERIFICATION_PATH)));
+        when(cimitUtilityService.getCiMitigationEvent(any(), any()))
+                .thenReturn(Optional.of(ENHANCED_VERIFICATION_EVENT));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
@@ -1050,8 +1049,8 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
         when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(true);
-        when(cimitUtilityService.getCiMitigationJourneyResponse(any(), any()))
-                .thenReturn(Optional.of(new JourneyResponse(JOURNEY_ENHANCED_VERIFICATION_PATH)));
+        when(cimitUtilityService.getCiMitigationEvent(any(), any()))
+                .thenReturn(Optional.of(ENHANCED_VERIFICATION_EVENT));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, List.of(), false))
@@ -1140,7 +1139,7 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(Boolean.TRUE);
-        when(cimitUtilityService.getCiMitigationJourneyResponse(any(), any()))
+        when(cimitUtilityService.getCiMitigationEvent(any(), any()))
                 .thenThrow(new ConfigException("Failed to get cimit config"));
 
         var response =

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -166,8 +166,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
             when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
-            when(cimitUtilityService.getMitigationJourneyIfBreaching(List.of(), P2))
-                    .thenReturn(Optional.empty());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
 
             var request =
                     requestBuilder
@@ -202,7 +201,9 @@ class ProcessCandidateIdentityHandlerTest {
         }
 
         @Test
-        void shouldHandleCandidateIdentityTypePendingAndReturnJourneyNext() throws Exception {
+        void
+                shouldHandleCandidateIdentityTypePendingAndReturnFailWithCiIfBreachingCimitVcWithNoAvailableMitigations()
+                        throws Exception {
             // Arrange
             var ticfVcs = List.of(vcTicf());
             when(checkCoiService.isCoiCheckSuccessful(
@@ -217,9 +218,16 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitUtilityService.getMitigationJourneyIfBreaching(List.of(), P2))
+            // The first time we call this, we get the mitigations for the old CIs
+            when(cimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any(), any()))
                     .thenReturn(Optional.empty());
-            when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
+            // The second time we call this, we get the mitigations for the new CIs
+            when(cimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any()))
+                    .thenReturn(Optional.empty());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(true);
+            when(cimitUtilityService.getContraIndicatorsFromVc(any()))
+                    .thenReturn(List.of())
+                    .thenReturn(List.of());
 
             var request =
                     requestBuilder
@@ -233,7 +241,7 @@ class ProcessCandidateIdentityHandlerTest {
             var response = processCandidateIdentityHandler.handleRequest(request, context);
 
             // Assert
-            assertEquals(JOURNEY_NEXT.getJourney(), response.get("journey"));
+            assertEquals(JOURNEY_FAIL_WITH_CI_PATH, response.get("journey"));
 
             verify(votMatcher, times(0)).matchFirstVot(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(1))
@@ -257,9 +265,8 @@ class ProcessCandidateIdentityHandlerTest {
         }
 
         @Test
-        void shouldHandleCandidateIdentityTypePendingAndReturnCimitResponse() throws Exception {
+        void shouldHandleCandidateIdentityTypePendingAndReturnJourneyNext() throws Exception {
             // Arrange
-            var cimitResponse = new JourneyResponse("dummy-response");
             var ticfVcs = List.of(vcTicf());
             when(checkCoiService.isCoiCheckSuccessful(
                             eq(ipvSessionItem),
@@ -273,11 +280,8 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitUtilityService.getMitigationJourneyIfBreaching(List.of(), P2))
-                    .thenReturn(Optional.of(cimitResponse));
-            when(cimitUtilityService.getContraIndicatorsFromVc(any()))
-                    .thenReturn(List.of())
-                    .thenReturn(List.of());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
+            when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
 
             var request =
                     requestBuilder
@@ -291,7 +295,7 @@ class ProcessCandidateIdentityHandlerTest {
             var response = processCandidateIdentityHandler.handleRequest(request, context);
 
             // Assert
-            assertEquals(cimitResponse.getJourney(), response.get("journey"));
+            assertEquals(JOURNEY_NEXT.getJourney(), response.get("journey"));
 
             verify(votMatcher, times(0)).matchFirstVot(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(1))
@@ -373,8 +377,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
             when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
-            when(cimitUtilityService.getMitigationJourneyIfBreaching(List.of(), P2))
-                    .thenReturn(Optional.empty());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
             when(votMatcher.matchFirstVot(List.of(P2), List.of(), List.of(), true))
                     .thenReturn(Optional.of(new VotMatchingResult(P2, M1A, M1A.getScores())));
@@ -407,8 +410,7 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(true);
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
-            when(cimitUtilityService.getMitigationJourneyIfBreaching(List.of(), P2))
-                    .thenReturn(Optional.empty());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
             when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(List.of());
 
             var request =
@@ -452,8 +454,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
             when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
-            when(cimitUtilityService.getMitigationJourneyIfBreaching(List.of(), P2))
-                    .thenReturn(Optional.empty());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
 
             var request =
                     requestBuilder
@@ -606,7 +607,7 @@ class ProcessCandidateIdentityHandlerTest {
         }
 
         @Test
-        void shouldHandleTicfBreachingContraindicator() throws Exception {
+        void shouldHandleTicfBreachingContraindicatorWithNoAvailableMitigations() throws Exception {
             // Arrange
             var ticfVcs = List.of(vcTicfWithCi());
             var ticfCis = List.of(new ContraIndicator());
@@ -627,8 +628,58 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(ticfVcs);
             when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(ticfCis);
             when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(ticfCis);
-            when(cimitUtilityService.getMitigationJourneyIfBreaching(ticfCis, P2))
-                    .thenReturn(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)));
+            // The first time we call this, we get the mitigations for the old CIs
+            when(cimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any(), any()))
+                    .thenReturn(Optional.empty());
+            // The second time we call this, we get the mitigations for the new CIs
+            when(cimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any()))
+                    .thenReturn(Optional.empty());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(true);
+            var request =
+                    requestBuilder
+                            .lambdaInput(
+                                    Map.of(PROCESS_IDENTITY_TYPE, CandidateIdentityType.NEW.name()))
+                            .build();
+
+            // Act
+            var response = processCandidateIdentityHandler.handleRequest(request, context);
+
+            // Assert
+            assertEquals(JOURNEY_FAIL_WITH_CI_PATH, response.get("journey"));
+
+            verify(storeIdentityService, times(0))
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any());
+        }
+
+        @Test
+        void shouldHandleTicfBreachingContraindicatorWithNewMitigation() throws Exception {
+            // Arrange
+            var ticfVcs = List.of(vcTicfWithCi());
+            var ticfCis = List.of(new ContraIndicator());
+            when(checkCoiService.isCoiCheckSuccessful(
+                            eq(ipvSessionItem),
+                            eq(clientOAuthSessionItem),
+                            eq(STANDARD),
+                            eq(DEVICE_INFORMATION),
+                            eq(List.of()),
+                            any(AuditEventUser.class)))
+                    .thenReturn(true);
+            when(votMatcher.matchFirstVot(anyList(), eq(List.of()), eq(ticfCis), eq(true)))
+                    .thenReturn(Optional.of(new VotMatchingResult(P2, M1A, M1A.getScores())));
+            when(userIdentityService.areVcsCorrelated(List.of())).thenReturn(true);
+            when(configService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, Cri.TICF.getId()))
+                    .thenReturn(true);
+            when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
+                    .thenReturn(ticfVcs);
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(ticfCis);
+            when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(ticfCis);
+            // The first time we call this, we get the mitigations for the old CIs
+            when(cimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any(), any()))
+                    .thenReturn(Optional.empty());
+            // The second time we call this, we get the mitigations for the new CIs
+            when(cimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any()))
+                    .thenReturn(Optional.of("a-new-mitigation"));
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(true);
             var request =
                     requestBuilder
                             .lambdaInput(
@@ -670,8 +721,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(ticfCriService.getTicfVc(reproveIdentityClientOAuthSessionItem, ipvSessionItem))
                     .thenReturn(ticfVcs);
             when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
-            when(cimitUtilityService.getMitigationJourneyIfBreaching(List.of(), P2))
-                    .thenReturn(Optional.empty());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
 
             var request =
                     requestBuilder
@@ -856,8 +906,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(cimitUtilityService.getContraIndicatorsFromVc(any(), any()))
                     .thenReturn(List.of())
                     .thenReturn(List.of());
-            when(cimitUtilityService.getMitigationJourneyIfBreaching(List.of(), P2))
-                    .thenReturn(Optional.empty());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
             doThrow(
                             new EvcsServiceException(
                                     SC_SERVER_ERROR, RECEIVED_NON_200_RESPONSE_STATUS_CODE))

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/service/CriCheckingServiceTest.java
@@ -641,7 +641,8 @@ class CriCheckingServiceTest {
         // Assert
         assertEquals(new JourneyResponse(JOURNEY_VCS_NOT_CORRELATED), result);
         verify(mockCimitService, never()).fetchContraIndicatorsVc(any(), any(), any(), any());
-        verify(mockCimitUtilityService, never()).getMitigationJourneyIfBreaching(any(), any());
+        verify(mockCimitUtilityService, never())
+                .getMitigationEventIfBreachingOrActive(any(), any());
         verify(mockIpvSessionService, times(1)).updateIpvSession(ipvSessionItem);
     }
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -119,14 +119,9 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      enhanced-verification:
-        targetState: CRI_F2F
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
+        checkMitigation:
+          enhanced-verification:
+            targetState: CRI_F2F
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -119,9 +119,6 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-        checkMitigation:
-          enhanced-verification:
-            targetState: CRI_F2F
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -132,12 +132,6 @@ states:
     events:
       next:
         targetState: NO_MATCH_PAGE
-      enhanced-verification:
-        targetState: NO_MATCH_PAGE
-      alternate-doc-invalid-dl:
-        targetState: NO_MATCH_PAGE
-      alternate-doc-invalid-passport:
-        targetState: NO_MATCH_PAGE
       fail-with-ci:
         targetState: NO_MATCH_PAGE
       error:
@@ -171,12 +165,6 @@ states:
         identityType: INCOMPLETE
     events:
       next:
-        targetState: RETURN_TO_RP
-      enhanced-verification:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-dl:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-passport:
         targetState: RETURN_TO_RP
       fail-with-ci:
         targetState: RETURN_TO_RP
@@ -212,14 +200,15 @@ states:
     events:
       next:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
-      enhanced-verification:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
-      alternate-doc-invalid-dl:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
-      alternate-doc-invalid-passport:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
+        checkMitigation:
+          enhanced-verification:
+            targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
+          alternate-doc-invalid-dl:
+            targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
+          alternate-doc-invalid-passport:
+            targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -251,12 +240,6 @@ states:
         identityType: INCOMPLETE
     events:
       next:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
-      enhanced-verification:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
-      alternate-doc-invalid-dl:
-        targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
-      alternate-doc-invalid-passport:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
@@ -292,14 +275,15 @@ states:
     events:
       next:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE
-      enhanced-verification:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
-      alternate-doc-invalid-dl:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
-      alternate-doc-invalid-passport:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE
       fail-with-ci:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
+        checkMitigation:
+          enhanced-verification:
+            targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+          alternate-doc-invalid-dl:
+            targetState: COULD_NOT_UPDATE_DETAILS_PAGE
+          alternate-doc-invalid-passport:
+            targetState: COULD_NOT_UPDATE_DETAILS_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -331,12 +315,6 @@ states:
         identityType: INCOMPLETE
     events:
       next:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
-      enhanced-verification:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
-      alternate-doc-invalid-dl:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
-      alternate-doc-invalid-passport:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
       fail-with-ci:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
@@ -372,12 +350,6 @@ states:
     events:
       next:
         targetState: NO_MATCH_PAGE_BAV
-      enhanced-verification:
-        targetState: NO_MATCH_PAGE_BAV
-      alternate-doc-invalid-dl:
-        targetState: NO_MATCH_PAGE_BAV
-      alternate-doc-invalid-passport:
-        targetState: NO_MATCH_PAGE_BAV
       fail-with-ci:
         targetState: NO_MATCH_PAGE_BAV
       error:
@@ -411,12 +383,6 @@ states:
         identityType: INCOMPLETE
     events:
       next:
-        targetState: NO_MATCH_PAGE_NINO
-      enhanced-verification:
-        targetState: NO_MATCH_PAGE_NINO
-      alternate-doc-invalid-dl:
-        targetState: NO_MATCH_PAGE_NINO
-      alternate-doc-invalid-passport:
         targetState: NO_MATCH_PAGE_NINO
       fail-with-ci:
         targetState: NO_MATCH_PAGE_NINO

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -202,13 +202,6 @@ states:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_INVALID_ID
-        checkMitigation:
-          enhanced-verification:
-            targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
-          alternate-doc-invalid-dl:
-            targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
-          alternate-doc-invalid-passport:
-            targetState: COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -277,13 +270,6 @@ states:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE
       fail-with-ci:
         targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
-        checkMitigation:
-          enhanced-verification:
-            targetState: COULD_NOT_UPDATE_DETAILS_PAGE
-          alternate-doc-invalid-dl:
-            targetState: COULD_NOT_UPDATE_DETAILS_PAGE
-          alternate-doc-invalid-passport:
-            targetState: COULD_NOT_UPDATE_DETAILS_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/ineligible.yaml
@@ -79,15 +79,16 @@ states:
     events:
       next:
         targetState: ANOTHER_WAY_PAGE
-      enhanced-verification:
-        targetState: ANOTHER_WAY_PAGE
-      alternate-doc-invalid-dl:
-        targetState: ANOTHER_WAY_PAGE
-      alternate-doc-invalid-passport:
-        targetState: ANOTHER_WAY_PAGE
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
+        checkMitigation:
+          enhanced-verification:
+            targetState: ANOTHER_WAY_PAGE
+          alternate-doc-invalid-dl:
+            targetState: ANOTHER_WAY_PAGE
+          alternate-doc-invalid-passport:
+            targetState: ANOTHER_WAY_PAGE
       coi-check-failed:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -110,15 +111,16 @@ states:
     events:
       next:
         targetState: RETURN_TO_RP
-      enhanced-verification:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-dl:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-passport:
-        targetState: RETURN_TO_RP
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
+        checkMitigation:
+          enhanced-verification:
+            targetState: RETURN_TO_RP
+          alternate-doc-invalid-dl:
+            targetState: RETURN_TO_RP
+          alternate-doc-invalid-passport:
+            targetState: RETURN_TO_RP
       coi-check-failed:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -945,15 +945,6 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -976,12 +967,6 @@ states:
       next:
         targetState: RETURN_TO_RP
       fail-with-ci:
-        targetState: RETURN_TO_RP
-      enhanced-verification:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-dl:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-passport:
         targetState: RETURN_TO_RP
       coi-check-failed:
         targetJourney: TECHNICAL_ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1122,15 +1122,6 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -1153,12 +1144,6 @@ states:
       next:
         targetState: RETURN_TO_RP
       fail-with-ci:
-        targetState: RETURN_TO_RP
-      enhanced-verification:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-dl:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-passport:
         targetState: RETURN_TO_RP
       coi-check-failed:
         targetJourney: TECHNICAL_ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-migration.yaml
@@ -24,15 +24,6 @@ states:
     events:
       next:
         targetState: RETURN_TO_RP
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/operational-profile-reuse.yaml
@@ -24,15 +24,6 @@ states:
     events:
       next:
         targetState: RETURN_TO_RP
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -297,15 +297,6 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reuse-existing-identity.yaml
@@ -84,15 +84,6 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -116,15 +107,6 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
       error:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -228,12 +228,6 @@ states:
         targetState: RETURN_TO_RP
       fail-with-ci:
         targetState: RETURN_TO_RP
-      enhanced-verification:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-dl:
-        targetState: RETURN_TO_RP
-      alternate-doc-invalid-passport:
-        targetState: RETURN_TO_RP
       coi-check-failed:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
@@ -59,13 +59,6 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-        checkMitigation:
-          enhanced-verification:
-            targetState: ERROR_PAGE
-          alternate-doc-invalid-dl:
-            targetState: ERROR_PAGE
-          alternate-doc-invalid-passport:
-            targetState: ERROR_PAGE
       error:
         targetState: ERROR_PAGE
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/technical-error.yaml
@@ -59,12 +59,13 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      enhanced-verification:
-        targetState: ERROR_PAGE
-      alternate-doc-invalid-dl:
-        targetState: ERROR_PAGE
-      alternate-doc-invalid-passport:
-        targetState: ERROR_PAGE
+        checkMitigation:
+          enhanced-verification:
+            targetState: ERROR_PAGE
+          alternate-doc-invalid-dl:
+            targetState: ERROR_PAGE
+          alternate-doc-invalid-passport:
+            targetState: ERROR_PAGE
       error:
         targetState: ERROR_PAGE
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -164,15 +164,6 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -433,15 +433,6 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      enhanced-verification:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
-      alternate-doc-invalid-passport:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/Events.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/Events.java
@@ -10,4 +10,10 @@ public class Events {
 
     // This event is a special value that is caught explicitly by the journey event handler
     public static final String BUILD_CLIENT_OAUTH_RESPONSE_EVENT = "build-client-oauth-response";
+
+    public static final String ENHANCED_VERIFICATION_EVENT = "enhanced-verification";
+    public static final String ALTERNATE_DOC_INVALID_DL_EVENT = "alternate-doc-invalid-dl";
+    public static final String ALTERNATE_DOC_INVALID_PASSPORT_EVENT =
+            "alternate-doc-invalid-passport";
+    public static final String FAIL_WITH_CI_EVENT = "fail-with-ci";
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CimitUtilityService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CimitUtilityService.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import static java.util.Objects.requireNonNullElse;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
+import static uk.gov.di.ipv.core.library.journeys.Events.FAIL_WITH_CI_EVENT;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 
 public class CimitUtilityService {
@@ -115,46 +116,26 @@ public class CimitUtilityService {
 
     public Optional<String> getMitigationEventIfBreachingOrActive(
             List<ContraIndicator> cis, Vot confidenceRequested) throws ConfigException {
-        var journeyResponse = getMitigationJourneyIfBreachingOrActive(cis, confidenceRequested);
-        if (journeyResponse.isPresent()) {
-            var journey = journeyResponse.get().getJourney();
-            return Optional.of(journey.substring(journey.lastIndexOf("/") + 1));
-        }
-        return Optional.empty();
-    }
-
-    private Optional<JourneyResponse> getMitigationJourneyIfBreachingOrActive(
-            List<ContraIndicator> cis, Vot confidenceRequested) throws ConfigException {
-        var breachingMitigationJourney = getMitigationJourneyIfBreaching(cis, confidenceRequested);
-
-        if (breachingMitigationJourney.isPresent()) {
-            return breachingMitigationJourney;
-        }
-
-        // If the user has a mitigated CI, return the mitigation to prevent
-        // them from going down routes to access CRIs they gained the CI from
-        var mitigatedCi = hasMitigatedContraIndicator(cis);
-        if (mitigatedCi.isPresent()) {
-            var cimitConfig = configService.getCimitConfig();
-
-            return getMitigationJourneyResponse(
-                    cimitConfig.get(mitigatedCi.get().getCode()), mitigatedCi.get().getDocument());
-        }
-
-        return Optional.empty();
-    }
-
-    public Optional<JourneyResponse> getMitigationJourneyIfBreaching(
-            List<ContraIndicator> cis, Vot confidenceRequested) throws ConfigException {
         if (isBreachingCiThreshold(cis, confidenceRequested)) {
             return Optional.of(
-                    getCiMitigationJourneyResponse(cis, confidenceRequested)
-                            .orElse(JOURNEY_FAIL_WITH_CI));
+                    getCiMitigationEvent(cis, confidenceRequested).orElse(FAIL_WITH_CI_EVENT));
+        } else {
+            // If the user has a mitigated CI, return the mitigation to prevent
+            // them from going down routes to access CRIs they gained the CI from
+            var mitigatedCi = hasMitigatedContraIndicator(cis);
+            if (mitigatedCi.isPresent()) {
+                var cimitConfig = configService.getCimitConfig();
+
+                return getMitigationEvent(
+                        cimitConfig.get(mitigatedCi.get().getCode()),
+                        mitigatedCi.get().getDocument());
+            }
         }
+
         return Optional.empty();
     }
 
-    public Optional<JourneyResponse> getCiMitigationJourneyResponse(
+    public Optional<String> getCiMitigationEvent(
             List<ContraIndicator> contraIndicators, Vot confidenceRequested)
             throws ConfigException {
         // Try to mitigate an unmitigated ci to resolve the threshold breach
@@ -168,8 +149,7 @@ public class CimitUtilityService {
                 if (hasMitigatedContraIndicator(contraIndicators).isPresent()) {
                     return Optional.empty();
                 }
-                return getMitigationJourneyResponse(
-                        cimitConfig.get(ci.getCode()), ci.getDocument());
+                return getMitigationEvent(cimitConfig.get(ci.getCode()), ci.getDocument());
             }
         }
         return Optional.empty();
@@ -180,14 +160,14 @@ public class CimitUtilityService {
         return contraIndicators.stream().filter(this::isMitigated).findFirst();
     }
 
-    private Optional<JourneyResponse> getMitigationJourneyResponse(
+    private Optional<String> getMitigationEvent(
             List<MitigationRoute> mitigationRoute, String document) {
         String documentType = document != null ? document.split("/")[0] : null;
         return mitigationRoute.stream()
                 .filter(mr -> (mr.document() == null || mr.document().equals(documentType)))
                 .findFirst()
                 .map(MitigationRoute::event)
-                .map(JourneyResponse::new);
+                .map(event -> event.substring(event.lastIndexOf("/") + 1));
     }
 
     private boolean isMitigated(ContraIndicator ci) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CimitUtilityService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CimitUtilityService.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.Cri;
-import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.MitigationRoute;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.Vot;
@@ -26,12 +25,9 @@ import java.util.Set;
 import static java.util.Objects.requireNonNullElse;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
 import static uk.gov.di.ipv.core.library.journeys.Events.FAIL_WITH_CI_EVENT;
-import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 
 public class CimitUtilityService {
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final JourneyResponse JOURNEY_FAIL_WITH_CI =
-            new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
     private final ConfigService configService;
 
     public CimitUtilityService(ConfigService configService) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CimitUtilityService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CimitUtilityService.java
@@ -24,7 +24,6 @@ import java.util.Set;
 
 import static java.util.Objects.requireNonNullElse;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CI_SCORING_THRESHOLD;
-import static uk.gov.di.ipv.core.library.journeys.Events.FAIL_WITH_CI_EVENT;
 
 public class CimitUtilityService {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -113,8 +112,7 @@ public class CimitUtilityService {
     public Optional<String> getMitigationEventIfBreachingOrActive(
             List<ContraIndicator> cis, Vot confidenceRequested) throws ConfigException {
         if (isBreachingCiThreshold(cis, confidenceRequested)) {
-            return Optional.of(
-                    getCiMitigationEvent(cis, confidenceRequested).orElse(FAIL_WITH_CI_EVENT));
+            return getCiMitigationEvent(cis, confidenceRequested);
         } else {
             // If the user has a mitigated CI, return the mitigation to prevent
             // them from going down routes to access CRIs they gained the CI from

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CimitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CimitUtilityServiceTest.java
@@ -42,7 +42,6 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_IND
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_INVALID_EVIDENCE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_NO_EVIDENCE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_RESIDENCE_PERMIT_DCMAW;
-import static uk.gov.di.ipv.core.library.journeys.Events.FAIL_WITH_CI_EVENT;
 
 @ExtendWith(MockitoExtension.class)
 class CimitUtilityServiceTest {
@@ -358,7 +357,7 @@ class CimitUtilityServiceTest {
 
     @Test
     void
-            getMitigationEventIfBreachingOrActive_ShouldReturnFailWithCi_IfCiIsMitigatableButDocTypeIsNotConfigured()
+            getMitigationEventIfBreachingOrActive_ShouldReturnEmpty_IfCiIsMitigatableButDocTypeIsNotConfigured()
                     throws Exception {
         // Arrange
         var code = "ci_code";
@@ -386,12 +385,12 @@ class CimitUtilityServiceTest {
                 cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // Assert
-        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
+        assertEquals(Optional.empty(), result);
     }
 
     @Test
     void
-            getMitigationEventIfBreachingOrActive_ShouldReturnFailWithCi_WhenBreachingAndCiIsNotMitigatable()
+            getMitigationEventIfBreachingOrActive_ShouldReturnEmpty_WhenBreachingAndCiIsNotMitigatable()
                     throws Exception {
         // arrange
         var code = "ci_code";
@@ -408,7 +407,7 @@ class CimitUtilityServiceTest {
         var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // assert
-        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
+        assertEquals(Optional.empty(), result);
     }
 
     @Test
@@ -437,7 +436,7 @@ class CimitUtilityServiceTest {
 
     @Test
     void
-            getMitigationEventIfBreachingOrActive_ShouldReturnFailWithCi_WhenMitigationDoesNotResolveBreach()
+            getMitigationEventIfBreachingOrActive_ShouldReturnEmpty_WhenMitigationDoesNotResolveBreach()
                     throws Exception {
         // arrange
         var code = "ci_code";
@@ -455,11 +454,11 @@ class CimitUtilityServiceTest {
         var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // assert
-        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
+        assertEquals(Optional.empty(), result);
     }
 
     @Test
-    void getCiMitigationEvent_ShouldReturnFailWithCi_WhenCiMitigationConfigNotFoundForDocType()
+    void getCiMitigationEvent_ShouldReturnEmpty_WhenCiMitigationConfigNotFoundForDocType()
             throws Exception {
         // Arrange
         var code = "ci_code";
@@ -478,12 +477,12 @@ class CimitUtilityServiceTest {
         var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // Assert
-        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
+        assertEquals(Optional.empty(), result);
     }
 
     @Test
     void
-            getMitigationEventIfBreachingOrActive_ShouldReturnFailWithCi_WhenCiCanBeMitigatedButHasAlreadyMitigatedContraIndicator()
+            getMitigationEventIfBreachingOrActive_ShouldReturnEmpty_WhenCiCanBeMitigatedButHasAlreadyMitigatedContraIndicator()
                     throws Exception {
         // arrange
         var code = "ci_code";
@@ -512,7 +511,7 @@ class CimitUtilityServiceTest {
         var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // assert
-        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
+        assertEquals(Optional.empty(), result);
     }
 
     @Test

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CimitUtilityServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CimitUtilityServiceTest.java
@@ -12,7 +12,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
-import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.MitigationRoute;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.Vot;
@@ -43,7 +42,7 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_IND
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_INVALID_EVIDENCE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_NO_EVIDENCE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.VC_RESIDENCE_PERMIT_DCMAW;
-import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
+import static uk.gov.di.ipv.core.library.journeys.Events.FAIL_WITH_CI_EVENT;
 
 @ExtendWith(MockitoExtension.class)
 class CimitUtilityServiceTest {
@@ -278,8 +277,9 @@ class CimitUtilityServiceTest {
 
     @ParameterizedTest
     @MethodSource("ciScoresAndUnsurpassedThresholds")
-    void getMitigationJourneyIfBreaching_ShouldReturnEmpty_IfCiScoreNotBreaching(
-            int ciScore1, int ciScore2, int ciScoreThreshold) throws ConfigException {
+    void
+            getMitigationEventIfBreachingOrActive_ShouldReturnEmpty_IfCiScoreNotBreachingAndNoExistingMitigations(
+                    int ciScore1, int ciScore2, int ciScoreThreshold) throws ConfigException {
         // Arrange
         when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, "P2"))
                 .thenReturn(String.valueOf(ciScoreThreshold));
@@ -296,7 +296,7 @@ class CimitUtilityServiceTest {
         var cis = List.of(createCi("ci_1"), createCi("ci_2"));
 
         // Act
-        var result = cimitUtilityService.getMitigationJourneyIfBreaching(cis, TEST_VOT);
+        var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // Assert
         assertTrue(
@@ -307,7 +307,7 @@ class CimitUtilityServiceTest {
     }
 
     @Test
-    void getMitigationJourneyIfBreaching_ShouldReturnMitigation_WhenCiCanBeMitigated()
+    void getMitigationEventIfBreachingOrActive_ShouldReturnMitigation_WhenCiCanBeMitigated()
             throws Exception {
         // arrange
         var code = "ci_code";
@@ -326,15 +326,16 @@ class CimitUtilityServiceTest {
         when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
 
         // act
-        var result = cimitUtilityService.getMitigationJourneyIfBreaching(cis, TEST_VOT);
+        var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // assert
-        assertEquals(Optional.of(new JourneyResponse(journey)), result);
+        assertEquals(Optional.of(journey), result);
     }
 
     @Test
-    void getMitigationJourneyIfBreaching_ShouldReturnMitigation_WhenCiCanBeMitigatedWithNoDocInCi()
-            throws Exception {
+    void
+            getMitigationEventIfBreachingOrActive_ShouldReturnMitigation_WhenCiCanBeMitigatedWithNoDocInCi()
+                    throws Exception {
         // arrange
         var code = "ci_code";
         var journey = "some_mitigation";
@@ -349,15 +350,15 @@ class CimitUtilityServiceTest {
         when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
 
         // act
-        var result = cimitUtilityService.getMitigationJourneyIfBreaching(cis, TEST_VOT);
+        var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // assert
-        assertEquals(Optional.of(new JourneyResponse(journey)), result);
+        assertEquals(Optional.of(journey), result);
     }
 
     @Test
     void
-            getMitigationJourneyIfBreaching_ShouldReturnFailWithCi_IfCiIsMitigatableButDocTypeIsNotConfigured()
+            getMitigationEventIfBreachingOrActive_ShouldReturnFailWithCi_IfCiIsMitigatableButDocTypeIsNotConfigured()
                     throws Exception {
         // Arrange
         var code = "ci_code";
@@ -381,16 +382,17 @@ class CimitUtilityServiceTest {
         when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
 
         // Act
-        Optional<JourneyResponse> result =
-                cimitUtilityService.getMitigationJourneyIfBreaching(cis, TEST_VOT);
+        Optional<String> result =
+                cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // Assert
-        assertEquals(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)), result);
+        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
     }
 
     @Test
-    void getMitigationJourneyIfBreaching_ShouldReturnFailWithCi_WhenCiIsNotMitigatable()
-            throws Exception {
+    void
+            getMitigationEventIfBreachingOrActive_ShouldReturnFailWithCi_WhenBreachingAndCiIsNotMitigatable()
+                    throws Exception {
         // arrange
         var code = "ci_code";
         var ci = createCi(code);
@@ -403,36 +405,40 @@ class CimitUtilityServiceTest {
         when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
 
         // act
-        var result = cimitUtilityService.getMitigationJourneyIfBreaching(cis, TEST_VOT);
+        var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // assert
-        assertEquals(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)), result);
+        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
     }
 
     @Test
-    void getMitigationJourneyIfBreaching_ShouldReturnEmpty_WhenCiIsAlreadyMitigated()
-            throws Exception {
+    void
+            getMitigationEventIfBreachingOrActive_ShouldReturnMitigation_WhenNotBreachingAndCiIsAlreadyMitigated()
+                    throws Exception {
         // arrange
         var code = "ci_code";
         var ci = createCi(code);
         ci.setMitigation(List.of(new Mitigation()));
         var cis = List.of(ci);
 
+        when(mockConfigService.getCimitConfig())
+                .thenReturn(Map.of(code, List.of(new MitigationRoute("some-event", null))));
         Map<String, ContraIndicatorConfig> ciConfigMap =
                 Map.of(code, new ContraIndicatorConfig(code, 7, -5, "X"));
         when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
         when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
 
         // act
-        var result = cimitUtilityService.getMitigationJourneyIfBreaching(cis, TEST_VOT);
+        var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // assert
-        assertEquals(Optional.empty(), result);
+        assertEquals(Optional.of("some-event"), result);
     }
 
     @Test
-    void getMitigationJourneyIfBreaching_ShouldReturnFailWithCi_WhenMitigationDoesNotResolveBreach()
-            throws Exception {
+    void
+            getMitigationEventIfBreachingOrActive_ShouldReturnFailWithCi_WhenMitigationDoesNotResolveBreach()
+                    throws Exception {
         // arrange
         var code = "ci_code";
         var ci = createCi(code);
@@ -446,16 +452,15 @@ class CimitUtilityServiceTest {
         when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
 
         // act
-        var result = cimitUtilityService.getMitigationJourneyIfBreaching(cis, TEST_VOT);
+        var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // assert
-        assertEquals(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)), result);
+        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
     }
 
     @Test
-    void
-            getCiMitigationJourneyResponse_ShouldReturnFailWithCi_WhenCiMitigationJourneyConfigNotFoundForDocType()
-                    throws Exception {
+    void getCiMitigationEvent_ShouldReturnFailWithCi_WhenCiMitigationConfigNotFoundForDocType()
+            throws Exception {
         // Arrange
         var code = "ci_code";
         var journey = "some_mitigation";
@@ -470,15 +475,15 @@ class CimitUtilityServiceTest {
         when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
 
         // Act
-        var result = cimitUtilityService.getMitigationJourneyIfBreaching(cis, TEST_VOT);
+        var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // Assert
-        assertEquals(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)), result);
+        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
     }
 
     @Test
     void
-            getMitigationJourneyIfBreaching_ShouldReturnFailWithCi_WhenCiCanBeMitigatedButHasAlreadyMitigatedContraIndicator()
+            getMitigationEventIfBreachingOrActive_ShouldReturnFailWithCi_WhenCiCanBeMitigatedButHasAlreadyMitigatedContraIndicator()
                     throws Exception {
         // arrange
         var code = "ci_code";
@@ -504,10 +509,10 @@ class CimitUtilityServiceTest {
         when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
 
         // act
-        var result = cimitUtilityService.getMitigationJourneyIfBreaching(cis, TEST_VOT);
+        var result = cimitUtilityService.getMitigationEventIfBreachingOrActive(cis, TEST_VOT);
 
         // assert
-        assertEquals(Optional.of(new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH)), result);
+        assertEquals(Optional.of(FAIL_WITH_CI_EVENT), result);
     }
 
     @Test
@@ -578,61 +583,7 @@ class CimitUtilityServiceTest {
     }
 
     @Test
-    void getMitigationJourneyEventReturnsBreachingMitigationJourneyEventIfBreachingOrActive()
-            throws Exception {
-        // Arrange
-        var code = "ci_code";
-        var journey = "some_mitigation";
-        String documentType = "passport";
-        var ci = createCi(code);
-        ci.setDocument("passport/some-document");
-
-        when(mockConfigService.getCimitConfig())
-                .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
-
-        Map<String, ContraIndicatorConfig> ciConfigMap =
-                Map.of(code, new ContraIndicatorConfig(code, 7, -5, "X"));
-
-        when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
-        when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
-
-        // act
-        var result =
-                cimitUtilityService.getMitigationEventIfBreachingOrActive(List.of(ci), TEST_VOT);
-
-        // assert
-        assertEquals(Optional.of(journey), result);
-    }
-
-    @Test
-    void
-            getMitigationJourneyEventReturnsMitigationJourneyEventIfBreachingOrActiveIfNotBreachingButCiIsMitigated()
-                    throws Exception {
-        // Arrange
-        var code = "ci_code";
-        var journey = "some_mitigation";
-        String documentType = "passport";
-        var ci = createCi(code, BASE_TIME.minusSeconds(1), List.of(new Mitigation()), documentType);
-
-        when(mockConfigService.getCimitConfig())
-                .thenReturn(Map.of(code, List.of(new MitigationRoute(journey, documentType))));
-
-        Map<String, ContraIndicatorConfig> ciConfigMap =
-                Map.of(code, new ContraIndicatorConfig(code, 4, -3, "X"));
-
-        when(mockConfigService.getContraIndicatorConfigMap()).thenReturn(ciConfigMap);
-        when(mockConfigService.getParameter(CI_SCORING_THRESHOLD, TEST_VOT.name())).thenReturn("5");
-
-        // act
-        var result =
-                cimitUtilityService.getMitigationEventIfBreachingOrActive(List.of(ci), TEST_VOT);
-
-        // assert
-        assertEquals(Optional.of(journey), result);
-    }
-
-    @Test
-    void getMitigationEventIfBreachingOrActiveReturnsEmptyIfNoCis() throws Exception {
+    void getMitigationEventIfBreachingOrActive_ReturnsEmpty_IfNoCis() throws Exception {
         // Arrange
         var code = "ci_code";
         Map<String, ContraIndicatorConfig> ciConfigMap =


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update process-candidate-identity handling of ticf VCs to match criCheckingService.checkVcResponse

### Why did it change
In response to these comments about making the logic more consistent:
https://github.com/govuk-one-login/ipv-core-back/pull/3056#discussion_r2006080715
https://github.com/govuk-one-login/ipv-core-back/pull/3056#discussion_r2002960219

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7983](https://govukverify.atlassian.net/browse/PYIC-7983)


[PYIC-7983]: https://govukverify.atlassian.net/browse/PYIC-7983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ