### PR TITLE
PYIC-7983: tidying journey map

### DIFF
--- a/api-tests/features/cimit/enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/enhanced-verification-mitigation-f2f.feature
@@ -54,6 +54,30 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
       Then I get a 'pyi-technical' page response
 
+    Scenario: Same session F2F enhanced verification mitigation - async queue error - dropout
+      When I submit an 'f2f' event
+      Then I get an 'f2f' CRI response
+      When I get an error from the async CRI stub
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start a new 'medium-confidence' journey and return to a 'pyi-f2f-technical' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity without a TICF VC
+
+    Scenario: Same session F2F enhanced verification mitigation - async queue error - continue from pyi-f2f-technical page
+      When I submit an 'f2f' event
+      Then I get an 'f2f' CRI response
+      When I get an error from the async CRI stub
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start a new 'medium-confidence' journey and return to a 'pyi-f2f-technical' page response
+      When I submit a 'next' event
+      Then I get a 'page-ipv-identity-document-start' page response
+
     Scenario: Same session F2F enhanced verification mitigation - user abandons DCMAW then mitigates with F2F
       When I submit a 'appTriage' event
       Then I get a 'dcmaw' CRI response
@@ -120,6 +144,28 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
         | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
       Then I get a 'pyi-technical' page response
+
+    Scenario: Separate session F2F enhanced verification mitigation - async queue error
+      When I start a new 'medium-confidence' journey
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get an 'f2f' CRI response
+      When I get an error from the async CRI stub
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start a new 'medium-confidence' journey and return to a 'pyi-f2f-technical' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity without a TICF VC
 
     Scenario: Separate session F2F enhanced verification mitigation - user abandons DCMAW and mitigates with F2F
       Given I start a new 'medium-confidence' journey

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -53,10 +53,6 @@ states:
       f2f-fail:
         targetJourney: F2F_FAILED
         targetState: FAILED
-        checkMitigation: # Will remove in future PR to handle this mitigation in F2F_FAILED
-          enhanced-verification:
-            targetJourney: NEW_P2_IDENTITY
-            targetState: ENHANCED_VERIFICATION_F2F_FAIL
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
@@ -23,14 +23,11 @@ nestedJourneyStates:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD_AFTER_PASSPORT
-#        checkMitigation:
-#          alternate-doc-invalid-dl:
-#            targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
       access-denied:
         targetState: PROVE_ANOTHER_WAY_AFTER_PASSPORT
-#        checkMitigation:
-#          alternate-doc-invalid-dl:
-#            targetState: PP_NO_OTHER_PHOTO_ID
+        checkMitigation:
+          alternate-doc-invalid-dl:
+            targetState: PP_NO_OTHER_PHOTO_ID
       alternate-doc-invalid-passport: # To delete - processCriCallback no longer emits this
         targetState: MITIGATION_PP_NO_MATCH_ANOTHER_WAY
         auditEvents:
@@ -52,7 +49,7 @@ nestedJourneyStates:
     exitEvents:
       next:
         exitEventToEmit: next-passport
-      enhanced-verification:
+      enhanced-verification: # To delete in clean up PR as address+fraud nested journey will no longer emit this
         exitEventToEmit: next-passport
       fraud-fail-with-no-ci:
         targetJourney: FAILED
@@ -77,14 +74,11 @@ nestedJourneyStates:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD_AFTER_DL
-#        checkMitigation:
-#          alternate-doc-invalid-passport:
-#            targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
       access-denied:
         targetState: PROVE_ANOTHER_WAY_AFTER_DL
-#        checkMitigation:
-#          alternate-doc-invalid-passport:
-#            targetState: DL_NO_OTHER_PHOTO_ID
+        checkMitigation:
+          alternate-doc-invalid-passport:
+            targetState: DL_NO_OTHER_PHOTO_ID
       alternate-doc-invalid-dl: # To delete - processCriCallback no longer emits this
         targetState: MITIGATION_DL_NO_MATCH_ANOTHER_WAY
         auditEvents:
@@ -106,7 +100,7 @@ nestedJourneyStates:
     exitEvents:
       next:
         exitEventToEmit: next-dl
-      enhanced-verification:
+      enhanced-verification: # To delete in clean up PR as address+fraud nested journey will no longer emit this
         exitEventToEmit: next-dl
       fraud-fail-with-no-ci:
         targetJourney: FAILED
@@ -142,7 +136,7 @@ nestedJourneyStates:
       pageId: pyi-continue-with-driving-licence
     events:
       next:
-        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
+        targetState: CRI_DRIVING_LICENCE
       end:
         exitEventToEmit: return-to-rp
   MITIGATION_PP_NO_MATCH_ANOTHER_WAY:
@@ -151,13 +145,10 @@ nestedJourneyStates:
       pageId: pyi-passport-no-match-another-way
     events:
       next:
-        targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
-#        checkMitigation:
-#          alternate-doc-invalid-passport:
-#            targetState: CRI_DRIVING_LICENCE
+        targetState: CRI_DRIVING_LICENCE
       end:
         exitEventToEmit: return-to-rp
-  MITIGATION_DL_CRI_DRIVING_LICENCE:
+  MITIGATION_DL_CRI_DRIVING_LICENCE: # To delete - now matches CRI_DRIVING_LICENCE
     response:
       type: cri
       criId: drivingLicence
@@ -167,17 +158,17 @@ nestedJourneyStates:
         targetState: MITIGATION_DL_ADDRESS_AND_FRAUD
       access-denied:
         targetState: MITIGATION_DL_PROVE_ANOTHER_WAY
-#  DL_NO_OTHER_PHOTO_ID:
-#    response:
-#      type: page
-#      pageId: prove-identity-no-other-photo-id
-#      context: drivingLicence
-#    events:
-#      back:
-#        targetState: CRI_DRIVING_LICENCE
-#      returnToRp:
-#        exitEventToEmit: return-to-rp
-  MITIGATION_DL_PROVE_ANOTHER_WAY:
+  DL_NO_OTHER_PHOTO_ID:
+    response:
+      type: page
+      pageId: prove-identity-no-other-photo-id
+      context: drivingLicence
+    events:
+      back:
+        targetState: CRI_DRIVING_LICENCE
+      returnToRp:
+        exitEventToEmit: return-to-rp
+  MITIGATION_DL_PROVE_ANOTHER_WAY: # To delete - renamed this to DL_NO_OTHER_PHOTO_ID (above)
     response:
       type: page
       pageId: prove-identity-no-other-photo-id
@@ -187,12 +178,12 @@ nestedJourneyStates:
         targetState: MITIGATION_DL_CRI_DRIVING_LICENCE
       returnToRp:
         exitEventToEmit: return-to-rp
-  MITIGATION_DL_ADDRESS_AND_FRAUD:
+  MITIGATION_DL_ADDRESS_AND_FRAUD: # To delete - now that ADDRESS_AND_FRAUD no longers emits enhanced-verification, this is identical to ADDRESS_AND_FRAUD_AFTER_DL and can combine the exitEvents
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
         exitEventToEmit: alternate-doc-next-dl
-      enhanced-verification:
+      enhanced-verification: # To delete in clean up PR as address+fraud nested journey will no longer emit this
         exitEventToEmit: failed
       fraud-fail-with-no-ci:
         targetJourney: FAILED
@@ -216,10 +207,7 @@ nestedJourneyStates:
       pageId: pyi-continue-with-passport
     events:
       next:
-        targetState: MITIGATION_PP_CRI_UK_PASSPORT
-#        checkMitigation:
-#          alternate-doc-invalid-dl:
-#            targetState: CRI_UK_PASSPORT
+        targetState: CRI_UK_PASSPORT
       end:
         exitEventToEmit: return-to-rp
   MITIGATION_DL_NO_MATCH_ANOTHER_WAY:
@@ -228,13 +216,10 @@ nestedJourneyStates:
       pageId: pyi-driving-licence-no-match-another-way
     events:
       next:
-        targetState: MITIGATION_PP_CRI_UK_PASSPORT
-#        checkMitigation:
-#          alternate-doc-invalid-dl:
-#            targetState: CRI_UK_PASSPORT
+        targetState: CRI_UK_PASSPORT
       end:
         exitEventToEmit: return-to-rp
-  MITIGATION_PP_CRI_UK_PASSPORT:
+  MITIGATION_PP_CRI_UK_PASSPORT: # To delete - now matches CRI_UK_PASSPORT
     response:
       type: cri
       criId: ukPassport
@@ -244,27 +229,27 @@ nestedJourneyStates:
         targetState: MITIGATION_PP_ADDRESS_AND_FRAUD
       access-denied:
         targetState: MITIGATION_PP_PROVE_ANOTHER_WAY
-  MITIGATION_PP_ADDRESS_AND_FRAUD:
+  MITIGATION_PP_ADDRESS_AND_FRAUD: # To delete - now that ADDRESS_AND_FRAUD no lonegr emits enhanced-verification, this is identical to ADDRESS_AND_FRAUD_AFTER_PASSPORT and can combine the exitEvents
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
       next:
         exitEventToEmit: alternate-doc-next-passport
-      enhanced-verification:
+      enhanced-verification: # To delete in clean up PR as address+fraud nested journey will no longer emit this
         exitEventToEmit: failed
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
-#  PP_NO_OTHER_PHOTO_ID:
-#    response:
-#      type: page
-#      pageId: prove-identity-no-other-photo-id
-#      context: passport
-#    events:
-#      back:
-#        targetState: CRI_UK_PASSPORT
-#      returnToRp:
-#        exitEventToEmit: return-to-rp
-  MITIGATION_PP_PROVE_ANOTHER_WAY:
+  PP_NO_OTHER_PHOTO_ID:
+    response:
+      type: page
+      pageId: prove-identity-no-other-photo-id
+      context: passport
+    events:
+      back:
+        targetState: CRI_UK_PASSPORT
+      returnToRp:
+        exitEventToEmit: return-to-rp
+  MITIGATION_PP_PROVE_ANOTHER_WAY: # To delete - renamed to PP_NO_OTHER_PHOTO_ID (above)
     response:
       type: page
       pageId: prove-identity-no-other-photo-id

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -337,10 +337,10 @@ states:
       next-passport:
         targetState: KBV_PHOTO_ID
         targetEntryEvent: next
-      alternate-doc-next-dl:
+      alternate-doc-next-dl: # To delete - can be combined with next-dl exitEvent
         targetState: KBV_PHOTO_ID
         targetEntryEvent: next
-      alternate-doc-next-passport:
+      alternate-doc-next-passport: # To delete - can be combined with next-passport exitEvent
         targetState: KBV_PHOTO_ID
         targetEntryEvent: next
       end:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -45,7 +45,7 @@ states:
         targetState: WEB_DL_OR_PASSPORT
         targetEntryEvent: alternate-doc-invalid-passport
 
-  ENHANCED_VERIFICATION_F2F_FAIL:
+  ENHANCED_VERIFICATION_F2F_FAIL: # To delete - have removed from initial-journey-selection journey map
     events:
       next:
         targetState: F2F_FAILED_MITIGATION_PAGE
@@ -954,7 +954,7 @@ states:
             targetJourney: FAILED
             targetState: FAILED
 
-  F2F_FAILED_MITIGATION_PAGE:
+  F2F_FAILED_MITIGATION_PAGE: # To delete - no longer needed as we're handling f2f fail w/ enhanced-verification with F2F_FAILED journey
     response:
       type: page
       pageId: pyi-f2f-technical

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -327,15 +327,11 @@ states:
       next-passport:
         targetState: KBV_PHOTO_ID
         targetEntryEvent: next
-      alternate-doc-next-dl:
-        targetState: MITIGATION_CHECK_FRAUD_AFTER_DL
-      alternate-doc-next-passport:
+      alternate-doc-next-dl: # To delete - can be combined with next-dl exitEvent
+        targetState: CHECK_FRAUD_AFTER_DL
+      alternate-doc-next-passport: # To delete - can be combined with next-passport exitEvent
         targetState: KBV_PHOTO_ID
         targetEntryEvent: next
-        checkMitigation:
-          alternate-doc-invalid-passport:
-            targetState: KBV_PHOTO_ID
-            targetEntryEvent: next
       end:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:
@@ -363,7 +359,7 @@ states:
         targetJourney: FAILED
         targetState: FAILED
 
-  MITIGATION_CHECK_FRAUD_AFTER_DL:
+  MITIGATION_CHECK_FRAUD_AFTER_DL: # To delete - identical to CHECK_FRAUD_AFTER_DL (above)
     response:
       type: process
       lambda: check-gpg45-score


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Simplified WEB_DL_OR_PASSPORT:
- reduced exitEvents emitted
- reduced duplicated states
Simplified handling of f2f_failed enhanced-verification by using F2F_FAILED journey map

### Why did it change
We now have a way of tidying up the journey map with checkMitigations. This is a follow-up PR to tidy up the journey map.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7983](https://govukverify.atlassian.net/browse/PYIC-7983)


[PYIC-7983]: https://govukverify.atlassian.net/browse/PYIC-7983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ