### PR TITLE
PYIC-8155: Use specific Signing Profile for Dev pipeline

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -106,6 +106,6 @@ jobs:
         uses: govuk-one-login/devplatform-upload-action@v3.9
         with:
           artifact-bucket-name: ${{ env.ENVIRONMENT == 'build' && secrets.ARTIFACT_BUCKET_NAME || secrets.ARTIFACT_BUCKET_NAME_DEV }}
-          signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
+          signing-profile-name: ${{ env.ENVIRONMENT == 'build' && secrets.SIGNING_PROFILE_NAME || secrets.SIGNING_PROFILE_NAME_DEV }}
           working-directory: ./deploy
           template-file: .aws-sam/build/template.yaml


### PR DESCRIPTION
## Proposed changes

### What changed

- Use specific Signing Profile for Dev pipeline

### Why did it change

- Devplatform-upload-action doesn't let me reference the build SigningProfile. So, despite it being used by all of the environments for signing, I will create a separate signing profile for Dev, in the dev01 account, which can be referenced by the GHA.

### Issue tracking

- [PYIC-8131](https://govukverify.atlassian.net/browse/PYIC-8131)

[PYIC-8131]: https://govukverify.atlassian.net/browse/PYIC-8131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ