### PR TITLE
PYIC-7983: remove unused entry states from new identity journey maps

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -24,27 +24,6 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
-  ENHANCED_VERIFICATION:
-    events:
-      next:
-        targetState: IDENTITY_START_PAGE
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-
-  ALTERNATE_DOC_PASSPORT:
-    events:
-      next:
-        targetState: WEB_DL_OR_PASSPORT
-        targetEntryEvent: alternate-doc-invalid-dl
-
-  ALTERNATE_DOC_DL:
-    events:
-      next:
-        targetState: WEB_DL_OR_PASSPORT
-        targetEntryEvent: alternate-doc-invalid-passport
-
   ENHANCED_VERIFICATION_F2F_FAIL:
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -24,27 +24,6 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
-  ENHANCED_VERIFICATION:
-    events:
-      next:
-        targetState: MITIGATION_01_IDENTITY_START_PAGE
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-
-  ALTERNATE_DOC_PASSPORT:
-    events:
-      next:
-        targetState: WEB_DL_OR_PASSPORT
-        targetEntryEvent: alternate-doc-invalid-dl
-
-  ALTERNATE_DOC_DL:
-    events:
-      next:
-        targetState: WEB_DL_OR_PASSPORT
-        targetEntryEvent: alternate-doc-invalid-passport
-
   REPROVE_IDENTITY:
     events:
       next:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Removing some unused entry states from the new p1/p2 journey maps

### Why did it change
I missed them the first time cleaning up 😅 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7983](https://govukverify.atlassian.net/browse/PYIC-7983)


[PYIC-7983]: https://govukverify.atlassian.net/browse/PYIC-7983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ