### PR TITLE
BAU: Remove state param from MAM client callback URL

### DIFF
--- a/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
+++ b/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriService.java
@@ -107,8 +107,7 @@ public class DcmawAsyncCriService {
             case DAD:
                 break;
             case MAM:
-                clientCallbackUrl =
-                        criConfig.getClientCallbackUrl().toString() + "?state=" + oauthState;
+                clientCallbackUrl = criConfig.getClientCallbackUrl().toString();
                 break;
             default:
                 throw new HttpResponseExceptionWithErrorBody(

--- a/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriServiceTest.java
+++ b/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriServiceTest.java
@@ -180,7 +180,7 @@ class DcmawAsyncCriServiceTest {
 
     private static Stream<Arguments> mobileAppJourneyTypesAndClientCallbackUrls() {
         return Stream.of(
-                Arguments.of(MobileAppJourneyType.MAM, REDIRECT_URL + "?state=" + CRI_OAUTH_STATE),
+                Arguments.of(MobileAppJourneyType.MAM, REDIRECT_URL),
                 Arguments.of(MobileAppJourneyType.DAD, null));
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Remove state param from MAM client callback URL

### Why did it change

- DCMAW put this state param in themselves