### PR TITLE
PYIC-8135: remove getting ipAddress + update AuditEventUser in user-reverification lambda

### DIFF
--- a/api-tests/data/audit-events/reverification-failed-journey.json
+++ b/api-tests/data/audit-events/reverification-failed-journey.json
@@ -89,9 +89,6 @@
     "extensions": {
       "success": false,
       "failure_code": "identity_check_failed"
-    },
-    "restricted": {
-      "device_information": {}
     }
   }
 ]

--- a/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
+++ b/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
@@ -124,7 +124,7 @@ public class UserReverificationHandler extends UserIdentityRequestHandler
                                     userId,
                                     ipvSessionItem.getIpvSessionId(),
                                     clientOAuthSessionItem.getGovukSigninJourneyId(),
-                                    RequestHelper.getIpAddress(input)),
+                                    null),
                             new AuditExtensionReverification(
                                     response.success(), response.failureCode()),
                             new AuditRestrictedDeviceInformation(

--- a/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
+++ b/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
@@ -16,7 +16,6 @@ import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionReverification;
-import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ReverificationFailureCode;
 import uk.gov.di.ipv.core.library.domain.ReverificationResponse;
@@ -29,7 +28,6 @@ import uk.gov.di.ipv.core.library.exceptions.RevokedAccessTokenException;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedCiException;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -117,7 +115,7 @@ public class UserReverificationHandler extends UserIdentityRequestHandler
             }
 
             var reverificationEndAuditEvent =
-                    AuditEvent.createWithDeviceInformation(
+                    AuditEvent.createWithoutDeviceInformation(
                             AuditEventTypes.IPV_REVERIFY_END,
                             configService.getParameter(ConfigurationVariable.COMPONENT_ID),
                             new AuditEventUser(
@@ -126,9 +124,7 @@ public class UserReverificationHandler extends UserIdentityRequestHandler
                                     clientOAuthSessionItem.getGovukSigninJourneyId(),
                                     null),
                             new AuditExtensionReverification(
-                                    response.success(), response.failureCode()),
-                            new AuditRestrictedDeviceInformation(
-                                    RequestHelper.getEncodedDeviceInformation(input)));
+                                    response.success(), response.failureCode()));
             auditService.sendAuditEvent(reverificationEndAuditEvent);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HTTPResponse.SC_OK, response);

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/AuditEventUser.java
@@ -25,6 +25,7 @@ public class AuditEventUser {
     private final String govukSigninJourneyId;
 
     @JsonProperty(value = "ip_address")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final String ipAddress;
 
     public AuditEventUser(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updates user-reverification lambda to not get the ipAddress as it's not available to it

### Why did it change
We were getting warning logs from `user-reverification` saying it had an empty ipAddress. This is expected as it's not available to the lambda so we remove the call to get it from the request headers.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8135](https://govukverify.atlassian.net/browse/PYIC-8135)


[PYIC-8135]: https://govukverify.atlassian.net/browse/PYIC-8135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ