### PR TITLE
BAU: remove evaluate_scores from type from journey map

### DIFF
--- a/journey-map/public/constants.mjs
+++ b/journey-map/public/constants.mjs
@@ -2,7 +2,6 @@ export const JOURNEY_TYPES = {
   INITIAL_JOURNEY_SELECTION: "Initial journey selection",
   NEW_P1_IDENTITY: "New P1 identity",
   NEW_P2_IDENTITY: "New P2 identity",
-  EVALUATE_SCORES: "Evaluate scores",
   REUSE_EXISTING_IDENTITY: "Reuse existing identity",
   UPDATE_NAME: "Update name",
   UPDATE_ADDRESS: "Update address",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Removes the EVALUATE_SCORES journey type from the journey map 

### Why did it change
We've recently removed the EVALUATE_SCORES journey map and so the journey map visualiser was having issues with loading ti

