### PR TITLE
PYIC-8191: update routing for new device sniffing events

### DIFF
--- a/api-tests/features/strategic-app/p1-strategic-app.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app.feature
@@ -106,6 +106,18 @@ Feature: M2B Strategic App Journeys
       When I submit an 'anotherWay' event
       Then I get a 'page-multiple-doc-check' page response with context 'nino'
 
+    Scenario: MAM journey detected iphone
+      When I submit an 'mobileDownloadIphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+
+    Scenario: MAM journey detected iphone - invalid OS version
+      When I submit an 'appTriageSmartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+
+    Scenario: MAM journey detected android
+      When I submit an 'mobileDownloadAndroid' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'android'
+
     Scenario: DAD journey no compatible smartphone continues to other methods
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -113,10 +113,12 @@ Feature: M2B Strategic App Journeys
       Then I get an 'pyi-no-match' page response
 
     Scenario: MAM journey detected iphone
-      When I submit an 'appTriageIphone' event
-      Then I get a 'pyi-triage-mobile-confirm' page response with context 'iphone'
-      When I submit an 'next' event
+      When I submit an 'mobileDownloadIphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+
+    Scenario: MAM journey detected iphone - invalid OS version
+      When I submit an 'appTriageSmartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
 
     Scenario: MAM journey declared android
       When I submit an 'appTriage' event
@@ -127,9 +129,7 @@ Feature: M2B Strategic App Journeys
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'android'
 
     Scenario: MAM journey detected android
-      When I submit an 'appTriageAndroid' event
-      Then I get a 'pyi-triage-mobile-confirm' page response with context 'android'
-      When I submit an 'next' event
+      When I submit an 'mobileDownloadAndroid' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'android'
 
     Scenario: MAM journey no compatible smartphone

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -15,10 +15,12 @@ nestedJourneyStates:
     events:
       appTriage:
         targetState: SELECT_DEVICE_PAGE
-      appTriageIphone:
-        targetState: MOBILE_IPHONE_CONFIRM_PAGE
-      appTriageAndroid:
-        targetState: MOBILE_ANDROID_CONFIRM_PAGE
+      mobileDownloadIphone:
+        targetState: MOBILE_IPHONE_START_SESSION
+      mobileDownloadAndroid:
+        targetState: MOBILE_ANDROID_START_SESSION
+      appTriageSmartphone:
+        targetState: MAM_SELECT_SMARTPHONE
 
   SELECT_DEVICE_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -203,28 +203,6 @@ nestedJourneyStates:
       neither:
         targetState: DAD_SELECT_SMARTPHONE
 
-  MOBILE_IPHONE_CONFIRM_PAGE:
-    response:
-      type: page
-      pageId: pyi-triage-mobile-confirm
-      context: iphone
-    events:
-      next:
-        targetState: MOBILE_IPHONE_START_SESSION
-      otherDevice:
-        targetState: DAD_SELECT_SMARTPHONE
-
-  MOBILE_ANDROID_CONFIRM_PAGE:
-    response:
-      type: page
-      pageId: pyi-triage-mobile-confirm
-      context: android
-    events:
-      next:
-        targetState: MOBILE_ANDROID_START_SESSION
-      otherDevice:
-        targetState: DAD_SELECT_SMARTPHONE
-
   MOBILE_IPHONE_START_SESSION:
     response:
       type: process


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
identify-device now emits different events (done as part of this [ticket](https://github.com/govuk-one-login/ipv-core-front/pull/1913)) so we update the routing based on this and to remove routing for the skipped pages.

### Why did it change
We want to update the strategic app to remove the mobile confirm pages so that:
- User is on a mobile device with ios 14+ or any android device
  - route to [pyi-triage-mobile-download-app](https://identity.build.account.gov.uk/dev/template/pyi-triage-mobile--download-app/en?context=iphone)
- User has a mobile device but is on ios < 14
  - route straight to [pyi-triage-select-smartphone](https://identity.build.account.gov.uk/dev/template/pyi-triage-select-smartphone/en?context=mam)
- Device sniffing fails or they are on a desktop
  - route to [pyi-triage-select-device](https://identity.build.account.gov.uk/dev/template/pyi-triage-select-device/en)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8191](https://govukverify.atlassian.net/browse/PYIC-8191)


[PYIC-8191]: https://govukverify.atlassian.net/browse/PYIC-8191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ