### PR TITLE
PYIC-8190: Fix being routed to P2 journey if failed F2F on P1 mitigation

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -76,7 +76,8 @@ import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DCMAW_ASYNC_VC_RECEIVED_LOW_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DCMAW_ASYNC_VC_RECEIVED_MEDIUM_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
-import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_P1_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_P2_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_IN_MIGRATION_REUSE_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_IPV_GPG45_LOW_PATH;
@@ -105,8 +106,10 @@ public class CheckExistingIdentityHandler
             new JourneyResponse(JOURNEY_IPV_GPG45_LOW_PATH);
     private static final JourneyResponse JOURNEY_IPV_GPG45_MEDIUM =
             new JourneyResponse(JOURNEY_IPV_GPG45_MEDIUM_PATH);
-    private static final JourneyResponse JOURNEY_F2F_FAIL =
-            new JourneyResponse(JOURNEY_F2F_FAIL_PATH);
+    private static final JourneyResponse JOURNEY_F2F_FAIL_P1 =
+            new JourneyResponse(JOURNEY_F2F_FAIL_P1_PATH);
+    private static final JourneyResponse JOURNEY_F2F_FAIL_P2 =
+            new JourneyResponse(JOURNEY_F2F_FAIL_P2_PATH);
     private static final JourneyResponse JOURNEY_REPEAT_FRAUD_CHECK =
             new JourneyResponse(JOURNEY_REPEAT_FRAUD_CHECK_PATH);
     private static final JourneyResponse JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM =
@@ -324,7 +327,7 @@ public class CheckExistingIdentityHandler
                     // Returned with F2F async VC. Should have matched a profile.
 
                     return buildF2FNoMatchResponse(
-                            areGpg45VcsCorrelated, auditEventUser, deviceInformation);
+                            areGpg45VcsCorrelated, auditEventUser, deviceInformation, targetVot);
                 }
                 if (asyncCriStatus.cri() == DCMAW_ASYNC) {
 
@@ -431,7 +434,8 @@ public class CheckExistingIdentityHandler
     private JourneyResponse buildF2FNoMatchResponse(
             boolean areGpg45VcsCorrelated,
             AuditEventUser auditEventUser,
-            String deviceInformation) {
+            String deviceInformation,
+            Vot targetVot) {
         LOGGER.info(LogHelper.buildLogMessage("F2F return - failed to match a profile."));
         sendAuditEvent(
                 !areGpg45VcsCorrelated
@@ -440,7 +444,10 @@ public class CheckExistingIdentityHandler
                 auditEventUser,
                 deviceInformation);
 
-        return JOURNEY_F2F_FAIL;
+        if (targetVot == Vot.P1) {
+            return JOURNEY_F2F_FAIL_P1;
+        }
+        return JOURNEY_F2F_FAIL_P2;
     }
 
     private JourneyResponse buildDCMAWContinuationResponse(

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -256,7 +256,11 @@ public class CheckExistingIdentityHandler
 
             var asyncCriStatus =
                     criResponseService.getAsyncResponseStatus(
-                            userId, credentialBundle.credentials, credentialBundle.isPendingReturn);
+                            userId,
+                            credentialBundle.credentials,
+                            credentialBundle.isPendingReturn,
+                            ipvSessionItem,
+                            clientOAuthSessionItem);
 
             var targetVot = VotHelper.getThresholdVot(ipvSessionItem, clientOAuthSessionItem);
 

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -128,7 +128,8 @@ import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1B;
 import static uk.gov.di.ipv.core.library.journeys.Events.ENHANCED_VERIFICATION_EVENT;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DCMAW_ASYNC_VC_RECEIVED_LOW_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DCMAW_ASYNC_VC_RECEIVED_MEDIUM_PATH;
-import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_P1_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_P2_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_PENDING_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_IN_MIGRATION_REUSE_PATH;
@@ -176,7 +177,9 @@ class CheckExistingIdentityHandlerTest {
     private static final JourneyResponse JOURNEY_PENDING =
             new JourneyResponse(JOURNEY_F2F_PENDING_PATH);
     private static final JourneyResponse JOURNEY_F2F_FAIL =
-            new JourneyResponse(JOURNEY_F2F_FAIL_PATH);
+            new JourneyResponse(JOURNEY_F2F_FAIL_P2_PATH);
+    private static final JourneyResponse JOURNEY_F2F_FAIL_P1 =
+            new JourneyResponse(JOURNEY_F2F_FAIL_P1_PATH);
     private static final JourneyResponse JOURNEY_REPEAT_FRAUD_CHECK =
             new JourneyResponse(JOURNEY_REPEAT_FRAUD_CHECK_PATH);
     private static final JourneyResponse JOURNEY_DCMAW_ASYNC_VC_RECEIVED_LOW =
@@ -889,7 +892,7 @@ class CheckExistingIdentityHandlerTest {
                         checkExistingIdentityHandler.handleRequest(event, context),
                         JourneyResponse.class);
 
-        assertEquals(JOURNEY_F2F_FAIL, journeyResponse);
+        assertEquals(JOURNEY_F2F_FAIL_P1, journeyResponse);
 
         assertEquals(Vot.P0, ipvSessionItem.getVot());
     }
@@ -908,7 +911,7 @@ class CheckExistingIdentityHandlerTest {
                         checkExistingIdentityHandler.handleRequest(event, context),
                         JourneyResponse.class);
 
-        assertEquals(JOURNEY_F2F_FAIL, journeyResponse);
+        assertEquals(JOURNEY_F2F_FAIL_P1, journeyResponse);
 
         assertEquals(Vot.P0, ipvSessionItem.getVot());
     }
@@ -1036,8 +1039,8 @@ class CheckExistingIdentityHandlerTest {
     private static Stream<Arguments> f2fIncompleteStatus() {
         return Stream.of(
                 Arguments.of(AsyncCriStatus.STATUS_PENDING, JOURNEY_F2F_PENDING_PATH),
-                Arguments.of(AsyncCriStatus.STATUS_ABANDON, JOURNEY_F2F_FAIL_PATH),
-                Arguments.of(AsyncCriStatus.STATUS_ERROR, JOURNEY_F2F_FAIL_PATH));
+                Arguments.of(AsyncCriStatus.STATUS_ABANDON, JOURNEY_F2F_FAIL_P1_PATH),
+                Arguments.of(AsyncCriStatus.STATUS_ERROR, JOURNEY_F2F_FAIL_P1_PATH));
     }
 
     @ParameterizedTest
@@ -1351,7 +1354,7 @@ class CheckExistingIdentityHandlerTest {
                         checkExistingIdentityHandler.handleRequest(event, context),
                         JourneyResponse.class);
 
-        assertEquals(JOURNEY_F2F_FAIL_PATH, journeyResponse.getJourney());
+        assertEquals(JOURNEY_F2F_FAIL_P2_PATH, journeyResponse.getJourney());
     }
 
     @Test

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -193,7 +193,7 @@ class CheckExistingIdentityHandlerTest {
     private static VerifiableCredential pcl200Vc;
     private static VerifiableCredential pcl250Vc;
     private static AsyncCriStatus emptyAsyncCriStatus =
-            new AsyncCriStatus(null, null, false, false, false);
+            new AsyncCriStatus(null, null, false, false, false, null);
 
     @Mock private Context context;
     @Mock private UserIdentityService userIdentityService;
@@ -265,7 +265,12 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
 
         JourneyResponse journeyResponse =
@@ -284,7 +289,12 @@ class CheckExistingIdentityHandlerTest {
         clientOAuthSessionItem.setVtr(List.of(P2.name(), P1.name()));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
 
         JourneyResponse journeyResponse =
@@ -310,7 +320,12 @@ class CheckExistingIdentityHandlerTest {
 
         @Test
         void shouldUseEvcsService() throws Exception {
-            when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+            when(criResponseService.getAsyncResponseStatus(
+                            eq(TEST_USER_ID),
+                            any(),
+                            eq(false),
+                            eq(ipvSessionItem),
+                            eq(clientOAuthSessionItem)))
                     .thenReturn(emptyAsyncCriStatus);
             when(mockEvcsService.getVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
@@ -333,7 +348,12 @@ class CheckExistingIdentityHandlerTest {
             when(mockEvcsService.getVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, hmrcMigrationVC)));
-            when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+            when(criResponseService.getAsyncResponseStatus(
+                            eq(TEST_USER_ID),
+                            any(),
+                            eq(false),
+                            eq(ipvSessionItem),
+                            eq(clientOAuthSessionItem)))
                     .thenReturn(emptyAsyncCriStatus);
             when(mockVotMatcher.matchFirstVot(
                             List.of(P2), List.of(gpg45Vc, hmrcMigrationVC), List.of(), true))
@@ -371,7 +391,8 @@ class CheckExistingIdentityHandlerTest {
             when(mockEvcsService.getVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
-            when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, true))
+            when(criResponseService.getAsyncResponseStatus(
+                            TEST_USER_ID, vcs, true, ipvSessionItem, clientOAuthSessionItem))
                     .thenReturn(emptyAsyncCriStatus);
             when(mockVotMatcher.matchFirstVot(List.of(P2), vcs, List.of(), true))
                     .thenReturn(
@@ -395,7 +416,12 @@ class CheckExistingIdentityHandlerTest {
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs, CURRENT, List.of(inheritedIdentityVc)));
             var combinedVcs = List.of(inheritedIdentityVc, gpg45Vc, f2fVc);
-            when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, combinedVcs, true))
+            when(criResponseService.getAsyncResponseStatus(
+                            TEST_USER_ID,
+                            combinedVcs,
+                            true,
+                            ipvSessionItem,
+                            clientOAuthSessionItem))
                     .thenReturn(emptyAsyncCriStatus);
 
             checkExistingIdentityHandler.handleRequest(event, context);
@@ -466,7 +492,12 @@ class CheckExistingIdentityHandlerTest {
 
         @Test // User returning after migration
         void shouldReturnJourneyOpProfileReuseResponseIfOpProfileAndPendingF2F() throws Exception {
-            when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+            when(criResponseService.getAsyncResponseStatus(
+                            eq(TEST_USER_ID),
+                            any(),
+                            eq(false),
+                            eq(ipvSessionItem),
+                            eq(clientOAuthSessionItem)))
                     .thenReturn(emptyAsyncCriStatus);
             when(mockEvcsService.getVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
@@ -593,9 +624,15 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(true),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(
-                        new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
+                        new AsyncCriStatus(
+                                F2F, AsyncCriStatus.STATUS_PENDING, false, true, false, P2));
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(false);
 
         clientOAuthSessionItem.setVtr(List.of(Vot.PCL250.name(), PCL200.name(), P2.name()));
@@ -639,10 +676,20 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionByClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID))
                 .thenReturn(previousIpvSession);
         var vcs = List.of(vcDcmawAsyncDrivingPermitDva());
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(true),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(
                         new AsyncCriStatus(
-                                DCMAW_ASYNC, AsyncCriStatus.STATUS_PENDING, false, true, false));
+                                DCMAW_ASYNC,
+                                AsyncCriStatus.STATUS_PENDING,
+                                false,
+                                true,
+                                false,
+                                P1));
         Mockito.lenient().when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
         when(mockEvcsService.getVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
@@ -691,7 +738,12 @@ class CheckExistingIdentityHandlerTest {
         when(mockEvcsService.getVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(PENDING_RETURN, List.of(vcDcmawAsyncDrivingPermitDva())));
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(true),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
 
@@ -718,7 +770,12 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, List.of(vcF2fPassportPhotoM1a())));
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(false);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
 
         clientOAuthSessionItem.setVtr(List.of(Vot.PCL250.name(), PCL200.name(), P2.name()));
@@ -751,7 +808,12 @@ class CheckExistingIdentityHandlerTest {
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         clientOAuthSessionItem.setVtr(vtr);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
 
         var journeyResponse =
@@ -771,7 +833,12 @@ class CheckExistingIdentityHandlerTest {
         when(mockEvcsService.getVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, VCS_FROM_STORE));
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -792,7 +859,12 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldNotSendAuditEventIfNewUser() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
         when(mockEvcsService.getVerifiableCredentialsByState(
@@ -839,9 +911,15 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnPendingResponseIfFaceToFaceVerificationIsPending() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(
-                        new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, true, false, false));
+                        new AsyncCriStatus(
+                                F2F, AsyncCriStatus.STATUS_PENDING, true, false, false, P1));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -859,9 +937,15 @@ class CheckExistingIdentityHandlerTest {
     void shouldReturnPendingResponseIfFaceToFaceVerificationIsPendingAndBreachingCi()
             throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(
-                        new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, true, false, false));
+                        new AsyncCriStatus(
+                                F2F, AsyncCriStatus.STATUS_PENDING, true, false, false, P1));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(true);
@@ -881,9 +965,15 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnFailResponseIfFaceToFaceVerificationIsError() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(
-                        new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_ERROR, true, false, false));
+                        new AsyncCriStatus(
+                                F2F, AsyncCriStatus.STATUS_ERROR, true, false, false, P1));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -900,9 +990,15 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnFailResponseIfFaceToFaceVerificationIsAbandon() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(
-                        new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_ABANDON, true, false, false));
+                        new AsyncCriStatus(
+                                F2F, AsyncCriStatus.STATUS_ABANDON, true, false, false, P1));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
 
@@ -923,9 +1019,15 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(true),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(
-                        new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
+                        new AsyncCriStatus(
+                                F2F, AsyncCriStatus.STATUS_PENDING, false, true, false, P1));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
@@ -952,9 +1054,15 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(true),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(
-                        new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
+                        new AsyncCriStatus(
+                                F2F, AsyncCriStatus.STATUS_PENDING, false, true, false, P1));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(false);
@@ -980,7 +1088,12 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(true),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
@@ -1004,7 +1117,12 @@ class CheckExistingIdentityHandlerTest {
         when(cimitUtilityService.getCiMitigationEvent(any(), any())).thenReturn(Optional.empty());
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
 
         var response =
@@ -1025,7 +1143,12 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(ENHANCED_VERIFICATION_EVENT));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
 
         var response =
@@ -1054,8 +1177,9 @@ class CheckExistingIdentityHandlerTest {
                 .thenReturn(Optional.of(ENHANCED_VERIFICATION_EVENT));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, List.of(), false))
-                .thenReturn(new AsyncCriStatus(F2F, asyncCriStatus, true, true, false));
+        when(criResponseService.getAsyncResponseStatus(
+                        TEST_USER_ID, List.of(), false, ipvSessionItem, clientOAuthSessionItem))
+                .thenReturn(new AsyncCriStatus(F2F, asyncCriStatus, true, true, false, P1));
 
         var response =
                 toResponseClass(
@@ -1188,7 +1312,8 @@ class CheckExistingIdentityHandlerTest {
         @Test
         void shouldReturnReproveP2JourneyIfReproveIdentityFlagSet() {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
-            when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, List.of(), false))
+            when(criResponseService.getAsyncResponseStatus(
+                            TEST_USER_ID, List.of(), false, ipvSessionItem, clientOAuthSessionItem))
                     .thenReturn(emptyAsyncCriStatus);
 
             var journeyResponse =
@@ -1204,7 +1329,12 @@ class CheckExistingIdentityHandlerTest {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
             clientOAuthSessionItem.setVtr(List.of(P2.name(), P1.name()));
             lenient().when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
-            when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+            when(criResponseService.getAsyncResponseStatus(
+                            eq(TEST_USER_ID),
+                            any(),
+                            eq(false),
+                            eq(ipvSessionItem),
+                            eq(clientOAuthSessionItem)))
                     .thenReturn(emptyAsyncCriStatus);
 
             var journeyResponse =
@@ -1218,10 +1348,11 @@ class CheckExistingIdentityHandlerTest {
         @Test
         void shouldReturnReproveP2JourneyIfReproveIdentityFlagSetAndPendingF2FDoesNotHaveFlag() {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
-            when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, List.of(), false))
+            when(criResponseService.getAsyncResponseStatus(
+                            TEST_USER_ID, List.of(), false, ipvSessionItem, clientOAuthSessionItem))
                     .thenReturn(
                             new AsyncCriStatus(
-                                    F2F, AsyncCriStatus.STATUS_PENDING, false, false, false));
+                                    F2F, AsyncCriStatus.STATUS_PENDING, false, false, false, P1));
 
             var journeyResponse =
                     toResponseClass(
@@ -1239,10 +1370,11 @@ class CheckExistingIdentityHandlerTest {
             when(mockEvcsService.getVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, vcs));
-            when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, false))
+            when(criResponseService.getAsyncResponseStatus(
+                            TEST_USER_ID, vcs, false, ipvSessionItem, clientOAuthSessionItem))
                     .thenReturn(
                             new AsyncCriStatus(
-                                    F2F, AsyncCriStatus.STATUS_PENDING, false, true, true));
+                                    F2F, AsyncCriStatus.STATUS_PENDING, false, true, true, P1));
 
             var journeyResponse =
                     toResponseClass(
@@ -1259,10 +1391,11 @@ class CheckExistingIdentityHandlerTest {
             when(mockEvcsService.getVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
-            when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, true))
+            when(criResponseService.getAsyncResponseStatus(
+                            TEST_USER_ID, vcs, true, ipvSessionItem, clientOAuthSessionItem))
                     .thenReturn(
                             new AsyncCriStatus(
-                                    F2F, AsyncCriStatus.STATUS_PENDING, true, true, true));
+                                    F2F, AsyncCriStatus.STATUS_PENDING, true, true, true, P1));
 
             var journeyResponse =
                     toResponseClass(
@@ -1317,7 +1450,12 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
         when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(testContraIndicators);
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(false),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(emptyAsyncCriStatus);
         when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
 
@@ -1343,9 +1481,15 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
-        when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+        when(criResponseService.getAsyncResponseStatus(
+                        eq(TEST_USER_ID),
+                        any(),
+                        eq(true),
+                        eq(ipvSessionItem),
+                        eq(clientOAuthSessionItem)))
                 .thenReturn(
-                        new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
+                        new AsyncCriStatus(
+                                F2F, AsyncCriStatus.STATUS_PENDING, false, true, false, P1));
         when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(testContraIndicators);
         when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
 

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -201,8 +201,8 @@ public class CheckMobileAppVcReceiptHandler
                         criResponseItem.getStatus(),
                         dcmawAsyncVc.isEmpty(),
                         true,
-                        false);
-
+                        false,
+                        null);
         if (asyncCriStatus.isAwaitingVc()) {
             return asyncCriStatus.getJourneyForAwaitingVc(true);
         }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/NestedJourneyTypes.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/NestedJourneyTypes.java
@@ -15,7 +15,8 @@ public enum NestedJourneyTypes {
     KBVS("kbvs"),
     STRATEGIC_APP_HANDLE_RESULT("strategic-app-handle-result"),
     STRATEGIC_APP_TRIAGE("strategic-app-triage"),
-    WEB_DL_OR_PASSPORT("web-dl-or-passport");
+    WEB_DL_OR_PASSPORT("web-dl-or-passport"),
+    F2F_FAILED("f2f-failed");
 
     private final String journeyName;
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -50,9 +50,12 @@ states:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
-      f2f-fail:
-        targetJourney: F2F_FAILED
-        targetState: FAILED
+      f2f-fail-p1:
+        targetState: F2F_FAILED
+        targetEntryEvent: f2f-fail-p1
+      f2f-fail-p2:
+        targetState: F2F_FAILED
+        targetEntryEvent: f2f-fail-p2
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -65,3 +68,13 @@ states:
       reprove-identity-gpg45-low:
         targetJourney: NEW_P1_IDENTITY
         targetState: REPROVE_IDENTITY
+
+  F2F_FAILED:
+    nestedJourney: F2F_FAILED
+    exitEvents:
+      next-p1:
+        targetJourney: NEW_P1_IDENTITY
+        targetState: START
+      next-p2:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: START

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/f2f-failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/f2f-failed.yaml
@@ -4,18 +4,24 @@ description: >-
   but their attempt failed. For example, they might
   have taken the wrong document or the name they entered
   did not match the name on their document.
+entryEvents:
+  f2f-fail-p1:
+    targetState: F2F_FAILED_P1_PAGE
+  f2f-fail-p2:
+    targetState: F2F_FAILED_P2_PAGE
 
-states:
-  # Entry points
-
-  FAILED:
+nestedJourneyStates:
+  F2F_FAILED_P1_PAGE:
+    response:
+      type: page
+      pageId: pyi-f2f-technical
     events:
       next:
-        targetState: F2F_FAILED_PAGE
+        targetState: RESET_SESSION_BEFORE_NEW_P1_IDENTITY
+      end:
+        targetState: RESET_SESSION_BEFORE_RETURN_TO_RP
 
-  # Journey states
-
-  F2F_FAILED_PAGE:
+  F2F_FAILED_P2_PAGE:
     response:
       type: page
       pageId: pyi-f2f-technical
@@ -25,6 +31,16 @@ states:
       end:
         targetState: RESET_SESSION_BEFORE_RETURN_TO_RP
 
+  RESET_SESSION_BEFORE_NEW_P1_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: PENDING_F2F_ALL
+    events:
+      next:
+        exitEventToEmit: next-p1
+
   RESET_SESSION_BEFORE_NEW_P2_IDENTITY:
     response:
       type: process
@@ -33,8 +49,7 @@ states:
         resetType: PENDING_F2F_ALL
     events:
       next:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: START
+        exitEventToEmit: next-p2
 
   RESET_SESSION_BEFORE_RETURN_TO_RP:
     response:

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
@@ -27,7 +27,6 @@ public enum IpvJourneyTypes {
     // F2F journeys
     F2F_HAND_OFF("f2f-hand-off"),
     F2F_PENDING("f2f-pending"),
-    F2F_FAILED("f2f-failed"),
 
     // Operational profile journeys
     OPERATIONAL_PROFILE_MIGRATION("operational-profile-migration"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
@@ -27,7 +27,8 @@ public class JourneyUris {
     public static final String JOURNEY_ENHANCED_VERIFICATION_PATH =
             "/journey/enhanced-verification";
     public static final String JOURNEY_ERROR_PATH = "/journey/error";
-    public static final String JOURNEY_F2F_FAIL_PATH = "/journey/f2f-fail";
+    public static final String JOURNEY_F2F_FAIL_P1_PATH = "/journey/f2f-fail-p1";
+    public static final String JOURNEY_F2F_FAIL_P2_PATH = "/journey/f2f-fail-p2";
     public static final String JOURNEY_FAIL_WITH_CI_PATH = "/journey/fail-with-ci";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
     public static final String JOURNEY_FOUND = "/journey/found";

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/domain/AsyncCriStatus.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/domain/AsyncCriStatus.java
@@ -8,7 +8,7 @@ import uk.gov.di.ipv.core.library.helpers.LogHelper;
 
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ABANDON_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
-import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_FAIL_P1_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_F2F_PENDING_PATH;
 
 public record AsyncCriStatus(
@@ -26,7 +26,7 @@ public record AsyncCriStatus(
     private static final JourneyResponse JOURNEY_F2F_PENDING =
             new JourneyResponse(JOURNEY_F2F_PENDING_PATH);
     private static final JourneyResponse JOURNEY_F2F_FAIL =
-            new JourneyResponse(JOURNEY_F2F_FAIL_PATH);
+            new JourneyResponse(JOURNEY_F2F_FAIL_P1_PATH);
     private static final JourneyResponse JOURNEY_ABANDON =
             new JourneyResponse(JOURNEY_ABANDON_PATH);
     private static final JourneyResponse JOURNEY_ERROR = new JourneyResponse(JOURNEY_ERROR_PATH);

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseService.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseService.java
@@ -6,9 +6,11 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.criresponse.domain.AsyncCriStatus;
 import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
+import uk.gov.di.ipv.core.library.helpers.VotHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.time.Instant;
@@ -85,10 +87,15 @@ public class CriResponseService {
     }
 
     public AsyncCriStatus getAsyncResponseStatus(
-            String userId, List<VerifiableCredential> credentials, boolean isPendingReturn) {
+            String userId,
+            List<VerifiableCredential> credentials,
+            boolean isPendingReturn,
+            IpvSessionItem ipvSessionItem,
+            ClientOAuthSessionItem clientOAuthSessionItem) {
         // F2F CRI response item blocks other async CRI routes, except for
         // enhanced-verification-f2f-fail, which enforces the user stays on the same mitigation
         // route, so it is fine here as we check F2F first.
+        var targetVot = VotHelper.getThresholdVot(ipvSessionItem, clientOAuthSessionItem);
         var f2fCriResponseItem = getCriResponseItem(userId, F2F);
         if (f2fCriResponseItem != null) {
             var f2fVc = credentials.stream().filter(vc -> vc.getCri().equals(F2F)).findFirst();
@@ -99,7 +106,8 @@ public class CriResponseService {
                     f2fCriResponseItem.getStatus(),
                     !hasVc,
                     isPendingReturn,
-                    f2fCriResponseItem.isReproveIdentity());
+                    f2fCriResponseItem.isReproveIdentity(),
+                    targetVot);
         }
 
         // DCMAW async VC existence determines success or abandonment
@@ -126,11 +134,12 @@ public class CriResponseService {
                             // This allows us to test journeys with pre-existing DCMAW Async VCs
                             // without having to go through
                             // the whole journey to populate the datastore.
-                            criResponse != null && criResponse.isReproveIdentity());
+                            criResponse != null && criResponse.isReproveIdentity(),
+                            targetVot);
                 }
             }
         }
 
-        return new AsyncCriStatus(null, null, false, false, false);
+        return new AsyncCriStatus(null, null, false, false, false, null);
     }
 }

--- a/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/domain/AsyncCriStatusTest.java
+++ b/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/domain/AsyncCriStatusTest.java
@@ -65,8 +65,8 @@ class AsyncCriStatusTest {
     static Stream<Arguments> F2fJourneysAndCriResponseItemStatuses() {
         return Stream.of(
                 Arguments.of(AsyncCriStatus.STATUS_PENDING, "/journey/pending"),
-                Arguments.of(AsyncCriStatus.STATUS_ABANDON, "/journey/f2f-fail"),
-                Arguments.of(AsyncCriStatus.STATUS_ERROR, "/journey/f2f-fail"),
+                Arguments.of(AsyncCriStatus.STATUS_ABANDON, "/journey/f2f-fail-p1"),
+                Arguments.of(AsyncCriStatus.STATUS_ERROR, "/journey/f2f-fail-p1"),
                 Arguments.of("not a status", "/journey/error"));
     }
 }

--- a/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/domain/AsyncCriStatusTest.java
+++ b/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/domain/AsyncCriStatusTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.enums.Vot;
 
 import java.util.stream.Stream;
 
@@ -20,7 +21,8 @@ class AsyncCriStatusTest {
     void getJourneyForAwaitingVcShouldReturnCorrectJourneyForDcmawAsyncSameSession(
             String incompleteStatus, String expectedJourney) {
         // Arrange
-        var asyncCriStatus = new AsyncCriStatus(DCMAW_ASYNC, incompleteStatus, false, false, false);
+        var asyncCriStatus =
+                new AsyncCriStatus(DCMAW_ASYNC, incompleteStatus, false, false, false, Vot.P1);
 
         // Act
         var journeyResponse = asyncCriStatus.getJourneyForAwaitingVc(true);
@@ -39,7 +41,8 @@ class AsyncCriStatusTest {
     void getJourneyForAwaitingVcShouldReturnCorrectJourneyForDcmawAsyncSameSession() {
         // Arrange
         var asyncCriStatus =
-                new AsyncCriStatus(DCMAW_ASYNC, AsyncCriStatus.STATUS_PENDING, false, false, false);
+                new AsyncCriStatus(
+                        DCMAW_ASYNC, AsyncCriStatus.STATUS_PENDING, false, false, false, Vot.P1);
 
         // Act
         var journeyResponse = asyncCriStatus.getJourneyForAwaitingVc(true);
@@ -49,11 +52,32 @@ class AsyncCriStatusTest {
     }
 
     @ParameterizedTest
+    @MethodSource("F2fFailJourneys")
+    void getF2FFailJourneyShouldReturnCorrectJourney(Vot targetVot, String expectedJourney) {
+        // Arrange
+        var asyncCriStatus =
+                new AsyncCriStatus(
+                        F2F, AsyncCriStatus.STATUS_ERROR, false, false, false, targetVot);
+
+        // Act
+        var journeyResponse = asyncCriStatus.getJourneyForAwaitingVc(false);
+
+        // Assert
+        assertEquals(expectedJourney, journeyResponse.getJourney());
+    }
+
+    static Stream<Arguments> F2fFailJourneys() {
+        return Stream.of(
+                Arguments.of(Vot.P1, "/journey/f2f-fail-p1"),
+                Arguments.of(Vot.P2, "/journey/f2f-fail-p2"));
+    }
+
+    @ParameterizedTest
     @MethodSource("F2fJourneysAndCriResponseItemStatuses")
     void getJourneyForAwaitingVcShouldReturnCorrectJourneyForF2f(
             String incompleteStatus, String expectedJourney) {
         // Arrange
-        var asyncCriStatus = new AsyncCriStatus(F2F, incompleteStatus, false, false, false);
+        var asyncCriStatus = new AsyncCriStatus(F2F, incompleteStatus, false, false, false, Vot.P1);
 
         // Act
         var journeyResponse = asyncCriStatus.getJourneyForAwaitingVc(false);

--- a/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseServiceTest.java
+++ b/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseServiceTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
+import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.time.Instant;
@@ -54,6 +56,8 @@ class CriResponseServiceTest {
                     + "\"https://vocab.account.gov.uk/v1/credentialStatus\":\"pending\"}";
 
     private static final String TEST_OAUTH_STATE = UUID.randomUUID().toString();
+    @Spy private IpvSessionItem ipvSessionItem;
+    private ClientOAuthSessionItem clientOAuthSessionItem;
 
     @BeforeEach
     void setUp() {
@@ -166,7 +170,9 @@ class CriResponseServiceTest {
                         : new ArrayList<VerifiableCredential>();
 
         // Act
-        var asyncCriStatus = criResponseService.getAsyncResponseStatus(USER_ID_1, vcs, false);
+        var asyncCriStatus =
+                criResponseService.getAsyncResponseStatus(
+                        USER_ID_1, vcs, false, ipvSessionItem, clientOAuthSessionItem);
 
         // Assert
         assertEquals(F2F, asyncCriStatus.cri());
@@ -180,7 +186,9 @@ class CriResponseServiceTest {
         var vcs = new ArrayList<VerifiableCredential>();
 
         // Act
-        var asyncCriStatus = criResponseService.getAsyncResponseStatus(USER_ID_1, vcs, false);
+        var asyncCriStatus =
+                criResponseService.getAsyncResponseStatus(
+                        USER_ID_1, vcs, false, ipvSessionItem, clientOAuthSessionItem);
 
         // Assert
         assertNull(asyncCriStatus.cri());
@@ -198,7 +206,9 @@ class CriResponseServiceTest {
         var vcs = List.of(vcDcmawAsyncDrivingPermitDva(), vcAddressTwo());
 
         // Act
-        var asyncCriStatus = criResponseService.getAsyncResponseStatus(USER_ID_1, vcs, false);
+        var asyncCriStatus =
+                criResponseService.getAsyncResponseStatus(
+                        USER_ID_1, vcs, false, ipvSessionItem, clientOAuthSessionItem);
 
         // Assert
         assertEquals(DCMAW_ASYNC, asyncCriStatus.cri());
@@ -214,7 +224,11 @@ class CriResponseServiceTest {
         // Act
         var asyncCriStatus =
                 criResponseService.getAsyncResponseStatus(
-                        USER_ID_1, List.of(vcDcmawAsyncDrivingPermitDva(), vcAddressTwo()), false);
+                        USER_ID_1,
+                        List.of(vcDcmawAsyncDrivingPermitDva(), vcAddressTwo()),
+                        false,
+                        ipvSessionItem,
+                        clientOAuthSessionItem);
 
         // Assert
         assertNull(asyncCriStatus.cri());
@@ -225,7 +239,9 @@ class CriResponseServiceTest {
     @Test
     void getAsyncResponseStatusShouldReturnEmptyStatusIfNoCriResponseFound() {
         // Act
-        var asyncCriStatus = criResponseService.getAsyncResponseStatus(USER_ID_1, List.of(), false);
+        var asyncCriStatus =
+                criResponseService.getAsyncResponseStatus(
+                        USER_ID_1, List.of(), false, ipvSessionItem, clientOAuthSessionItem);
 
         // Assert
         assertNull(asyncCriStatus.cri());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

We’re not handling routing to new P1 proving journey for F2F_FAILED
Fix being routed to P2 journey if failed F2F on P1 mitigation

Converted the f2f-failed journeyMap into a nestedJourneyMap to facilitate both P1 & P2 journeys
Update AsyncCriStatus to include VOT to determine the journey
Add API test for P1 mitigation routing

### Why did it change

Incorrect routing

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8190](https://govukverify.atlassian.net/browse/PYIC-8190)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-8190]: https://govukverify.atlassian.net/browse/PYIC-8190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ