### PR TITLE
PYIC-8220: Disable a λ's Dynatrace & add IOException alarm

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2879,7 +2879,7 @@ Resources:
           ReturnData: true
           MetricStat:
             Metric:
-              Namespace: Custom/LambdaErrors
+              Namespace: AWS/Lambda
               MetricName: IOExceptionCount
             Period: 60
             Stat: Sum
@@ -2891,7 +2891,7 @@ Resources:
       FilterPattern: '"IOException"'
       MetricTransformations:
         - MetricValue: "1"
-          MetricNamespace: Custom/LambdaErrors
+          MetricNamespace: AWS/Lambda
           MetricName: IOExceptionCount
 
   ####################################################################

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -127,6 +127,10 @@ Conditions:
   IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670" ]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
   IsBuild: !Equals [ !Ref Environment, "build" ]
+  IsStaging: !Equals [ !Ref Environment, "staging" ]
+  IsBuildOrStaging: !Or
+    - !Condition IsBuild
+    - !Condition IsStaging
   IsProduction: !Equals [ !Ref Environment, "production" ]
   IsSubscriptionEnviroment: !Or
     - !Equals [ !Ref Environment, staging ]
@@ -1839,6 +1843,16 @@ Resources:
       PackageType: Zip
       CodeUri: ../lambdas/check-existing-identity
       Tracing: Active
+      Layers:
+        - !If
+          - UseDynatrace
+          - !If
+            - IsBuildOrStaging
+            - !Ref AWS::NoValue
+            - !Sub
+              - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}' # pragma: allowlist secret or NODEJS_LAYER or PYTHON_LAYER
+              - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref AWS::AccountId, dynatraceSecretArn ]
+          - !Ref AWS::NoValue
       Environment:
         # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
         Variables:
@@ -1849,6 +1863,13 @@ Resources:
           CRI_RESPONSE_TABLE_NAME: !Ref CRIResponseTable
           CRI_OAUTH_SESSIONS_TABLE_NAME: !Ref CriOAuthSessionsTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          AWS_LAMBDA_EXEC_WRAPPER: !If
+            - UseDynatrace
+            - !If
+              - IsBuildOrStaging
+              - !Ref AWS::NoValue
+              - /opt/dynatrace
+            - !Ref AWS::NoValue
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
@@ -2837,6 +2858,41 @@ Resources:
       Threshold: 30000 #30k milliseconds = 30 seconds
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
+
+  IOExceptionAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevelopment
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue sns-topics-AlarmTopic
+      AlarmName: !Sub ${AWS::StackName}-IOExceptionInLogs
+      InsufficientDataActions: []
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: ioExceptionMetric
+          Label: IOException Count
+          ReturnData: true
+          MetricStat:
+            Metric:
+              Namespace: Custom/LambdaErrors
+              MetricName: IOExceptionCount
+            Period: 60
+            Stat: Sum
+
+  IOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CheckExistingIdentityFunctionLogGroup
+      FilterPattern: '"IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: Custom/LambdaErrors
+          MetricName: IOExceptionCount
 
   ####################################################################
   #                                                                  #

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2886,10 +2886,190 @@ Resources:
             Period: 60
             Stat: Sum
 
-  IOExceptionMetricFilter:
+  IssueClientAccessTokenFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref IssueClientAccessTokenFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  BuildClientOauthResponseFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref BuildClientOauthResponseFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  InitialiseIpvSessionFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref InitialiseIpvSessionFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  BuildCriOauthRequestFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref BuildCriOauthRequestFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  ProcessCriCallbackIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ProcessCriCallbackLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  ProcessMobileAppCallbackIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ProcessMobileAppCallbackLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  CheckMobileAppVcReceiptIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CheckMobileAppVcReceiptLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  BuildUserIdentityFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref BuildUserIdentityFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  UserReverificationFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref UserReverificationFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  JourneyEngineStepFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref JourneyEngineStepFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  IPVProcessJourneyEventFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref IPVProcessJourneyEventFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  BuildProvenUserIdentityDetailsFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref BuildProvenUserIdentityDetailsFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  CheckExistingIdentityFunctionIOExceptionMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckExistingIdentityFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  ProcessAsyncCriCredentialFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ProcessAsyncCriCredentialFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  CheckGpg45ScoreFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CheckGpg45ScoreFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  CallDcmawAsyncCriFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CallDcmawAsyncCriFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  ResetSessionIdentityFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ResetSessionIdentityFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  CheckReverificationIdentityFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CheckReverificationIdentityFunctionLogGroup
+      FilterPattern: '"HTTP request failed with IOException"'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: AWS/Lambda
+          MetricName: IOExceptionCount
+
+  ProcessCandidateIdentityFunctionIOExceptionMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ProcessCandidateIdentityFunctionLogGroup
       FilterPattern: '"HTTP request failed with IOException"'
       MetricTransformations:
         - MetricValue: "1"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2890,7 +2890,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref IssueClientAccessTokenFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2900,7 +2900,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref BuildClientOauthResponseFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2910,7 +2910,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref InitialiseIpvSessionFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2920,7 +2920,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref BuildCriOauthRequestFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2930,7 +2930,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ProcessCriCallbackLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2940,7 +2940,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ProcessMobileAppCallbackLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2950,7 +2950,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckMobileAppVcReceiptLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2960,7 +2960,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref BuildUserIdentityFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2970,7 +2970,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref UserReverificationFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2980,7 +2980,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref JourneyEngineStepFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2990,7 +2990,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref IPVProcessJourneyEventFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3000,7 +3000,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref BuildProvenUserIdentityDetailsFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3010,7 +3010,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckExistingIdentityFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3020,7 +3020,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ProcessAsyncCriCredentialFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3030,7 +3030,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckGpg45ScoreFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3040,7 +3040,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CallDcmawAsyncCriFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3050,7 +3050,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ResetSessionIdentityFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3060,7 +3060,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckReverificationIdentityFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3070,7 +3070,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ProcessCandidateIdentityFunctionLogGroup
-      FilterPattern: '"HTTP request failed with IOException"'
+      FilterPattern: '"IOException: <init>"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1863,6 +1863,8 @@ Resources:
           CRI_RESPONSE_TABLE_NAME: !Ref CRIResponseTable
           CRI_OAUTH_SESSIONS_TABLE_NAME: !Ref CriOAuthSessionsTable
           SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          # We're temporarily disabling this for lower envs to investigate the effect it has on IOExceptions
+          # https://govukverify.atlassian.net/browse/PYIC-8220
           AWS_LAMBDA_EXEC_WRAPPER: !If
             - UseDynatrace
             - !If
@@ -2865,7 +2867,7 @@ Resources:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-        - !ImportValue sns-topics-AlarmTopic
+        - !ImportValue alarm-alerts-topic
       AlarmName: !Sub ${AWS::StackName}-IOExceptionInLogs
       InsufficientDataActions: []
       EvaluationPeriods: 1

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2890,7 +2890,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref IssueClientAccessTokenFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2900,7 +2900,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref BuildClientOauthResponseFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2910,7 +2910,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref InitialiseIpvSessionFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2920,7 +2920,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref BuildCriOauthRequestFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2930,7 +2930,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ProcessCriCallbackLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2940,7 +2940,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ProcessMobileAppCallbackLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2950,7 +2950,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckMobileAppVcReceiptLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2960,7 +2960,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref BuildUserIdentityFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2970,7 +2970,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref UserReverificationFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2980,7 +2980,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref JourneyEngineStepFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -2990,7 +2990,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref IPVProcessJourneyEventFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3000,7 +3000,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref BuildProvenUserIdentityDetailsFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3010,7 +3010,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckExistingIdentityFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3020,7 +3020,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ProcessAsyncCriCredentialFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3030,7 +3030,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckGpg45ScoreFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3040,7 +3040,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CallDcmawAsyncCriFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3050,7 +3050,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ResetSessionIdentityFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3060,7 +3060,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckReverificationIdentityFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda
@@ -3070,7 +3070,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref ProcessCandidateIdentityFunctionLogGroup
-      FilterPattern: '"IOException: <init>"'
+      FilterPattern: '{ $.message.errorDescription = "java.io.IOException: <init>" }'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2888,7 +2888,7 @@ Resources:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Ref CheckExistingIdentityFunctionLogGroup
-      FilterPattern: '"IOException"'
+      FilterPattern: '"HTTP request failed with IOException"'
       MetricTransformations:
         - MetricValue: "1"
           MetricNamespace: AWS/Lambda


### PR DESCRIPTION
## Proposed changes

### What changed

- Update CheckExistingIdentity to conditionally use Dynatrace
- Add alarm for IOExceptions

### Why did it change

- To experiment with and improve monitoring of incident-causing-IOExceptions

### Issue tracking

- [PYIC-8220](https://govukverify.atlassian.net/browse/PYIC-8220)

[PYIC-8220]: https://govukverify.atlassian.net/browse/PYIC-8220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ