### PR TITLE
PYIC-8190: Add P1/P2 mitigation api-test

### DIFF
--- a/api-tests/features/p1-web-journey.feature
+++ b/api-tests/features/p1-web-journey.feature
@@ -9,6 +9,55 @@ Feature: P1 Web Journeys
     When I call the CRI stub and get an 'access_denied' OAuth error
     Then I get a 'page-multiple-doc-check' page response with context 'nino'
 
+  Scenario: P1 fallback for users who fail KBV and F2F but can successfully prove their identity
+    When I submit an 'ukPassport' event
+    Then I get a 'ukPassport' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-1' details to the CRI stub
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'kbv' CRI response
+    When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
+    Then I get a 'photo-id-security-questions-find-another-way' page response
+    When I submit a 'f2f' event
+    Then I get a 'f2f' CRI response
+    When I get an error from the async CRI stub
+    Then I get a 'page-face-to-face-handoff' page response
+
+    # Return journey
+    When I start a new 'low-confidence' journey and return to a 'pyi-f2f-technical' page response
+    Then I get a 'pyi-f2f-technical' page response
+    When I submit a 'next' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'pyi-post-office' page response
+    When I submit a 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'f2f' CRI response
+    When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get a 'page-face-to-face-handoff' page response
+
+    # Return journey
+    When I start a new 'low-confidence' journey and return to a 'page-ipv-reuse' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P1' identity
+
   Scenario Outline: Successful P1 journey - via <cri> and Experian KBV
     When I submit an '<cri>' event
     Then I get a '<cri>' CRI response


### PR DESCRIPTION
This tests a returning using gets a p1_journey route with a p1 identity

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

P1 fallback for users who fail KBV and F2F but can successfully prove their identity
A recent bug meant that a user would always default to a P2_journey when returning, these test confirm that a use gets the correct identity

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8190](https://govukverify.atlassian.net/browse/PYIC-8190)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-8190]: https://govukverify.atlassian.net/browse/PYIC-8190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ