### PR TITLE
PYIC-7909: refactor process-candidate-identity to move evcs call to handler

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -374,7 +374,7 @@ public class CheckExistingIdentityHandler
     private VerifiableCredentialBundle getCredentialBundle(String userId, String evcsAccessToken)
             throws CredentialParseException, EvcsServiceException {
         var vcs =
-                evcsService.getParsedVerifiableCredentialsByState(
+                evcsService.fetchEvcsVerifiableCredentialsByState(
                         userId, evcsAccessToken, CURRENT, PENDING_RETURN);
 
         var isPendingReturn = !isNullOrEmpty(vcs.get(PENDING_RETURN));

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -374,7 +374,7 @@ public class CheckExistingIdentityHandler
     private VerifiableCredentialBundle getCredentialBundle(String userId, String evcsAccessToken)
             throws CredentialParseException, EvcsServiceException {
         var vcs =
-                evcsService.getVerifiableCredentialsByState(
+                evcsService.getParsedVerifiableCredentialsByState(
                         userId, evcsAccessToken, CURRENT, PENDING_RETURN);
 
         var isPendingReturn = !isNullOrEmpty(vcs.get(PENDING_RETURN));

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -309,7 +309,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldUseEvcsService() throws Exception {
             when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                     .thenReturn(emptyAsyncCriStatus);
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc)));
 
@@ -317,7 +317,7 @@ class CheckExistingIdentityHandlerTest {
 
             verify(clientOAuthSessionDetailsService).getClientOAuthSession(any());
             verify(mockEvcsService)
-                    .getVerifiableCredentialsByState(
+                    .getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN);
         }
 
@@ -327,7 +327,7 @@ class CheckExistingIdentityHandlerTest {
                 Gpg45Profile matchedProfile) throws Exception {
             var hmrcMigrationVC = vcHmrcMigrationPCL200();
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, hmrcMigrationVC)));
             when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
@@ -365,7 +365,7 @@ class CheckExistingIdentityHandlerTest {
         @Test
         void shouldReturnJourneyReuseWithStoreResponseIfIsF2fPendingReturn() throws Exception {
             var vcs = List.of(gpg45Vc, vcF2fPassportPhotoM1a());
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
             when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, true))
@@ -388,7 +388,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldIncludeCurrentInheritedIdentityInVcBundleWhenPendingReturn() throws Exception {
             var inheritedIdentityVc = vcHmrcMigrationPCL200();
             var vcs = List.of(gpg45Vc, f2fVc);
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs, CURRENT, List.of(inheritedIdentityVc)));
             var combinedVcs = List.of(inheritedIdentityVc, gpg45Vc, f2fVc);
@@ -403,7 +403,7 @@ class CheckExistingIdentityHandlerTest {
         @Test // User returning after migration
         void shouldReturnJourneyOpProfileReuseResponseIfPCL200RequestedAndMetWhenNotInMigration()
                 throws Exception {
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, pcl200Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -435,7 +435,7 @@ class CheckExistingIdentityHandlerTest {
         @Test // User returning after migration
         void shouldReturnJourneyOpProfileReuseResponseIfPCL250RequestedAndMetWhenNotInMigration()
                 throws Exception {
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, pcl250Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -465,7 +465,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldReturnJourneyOpProfileReuseResponseIfOpProfileAndPendingF2F() throws Exception {
             when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                     .thenReturn(emptyAsyncCriStatus);
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(pcl250Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -491,7 +491,7 @@ class CheckExistingIdentityHandlerTest {
 
         @Test // User in process of migration
         void shouldReturnJourneyInMigrationReuseResponseIfPCL200RequestedAndMet() throws Exception {
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, pcl200Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -522,7 +522,7 @@ class CheckExistingIdentityHandlerTest {
 
         @Test // User in process of migration
         void shouldReturnJourneyInMigrationReuseResponseIfPCL250RequestedAndMet() throws Exception {
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, pcl250Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -586,7 +586,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -641,7 +641,7 @@ class CheckExistingIdentityHandlerTest {
                         new AsyncCriStatus(
                                 DCMAW_ASYNC, AsyncCriStatus.STATUS_PENDING, false, true, false));
         Mockito.lenient().when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(PENDING_RETURN, vcs));
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
@@ -685,7 +685,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(PENDING_RETURN, List.of(vcDcmawAsyncDrivingPermitDva())));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
@@ -711,7 +711,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, List.of(vcF2fPassportPhotoM1a())));
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(false);
@@ -742,7 +742,7 @@ class CheckExistingIdentityHandlerTest {
         if (vot.isPresent()) {
             credentials.add(createOperationalProfileVc(vot.get()));
         }
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, credentials));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -765,7 +765,7 @@ class CheckExistingIdentityHandlerTest {
     void shouldReturnJourneyIpvGpg45MediumResponseIfScoresDoNotSatisfyP2Gpg45Profile()
             throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, VCS_FROM_STORE));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
@@ -792,7 +792,7 @@ class CheckExistingIdentityHandlerTest {
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                 .thenReturn(emptyAsyncCriStatus);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -916,7 +916,7 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnFailResponseForFaceToFaceVerificationIfNoMatchedProfile() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -945,7 +945,7 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnFailResponseForFaceToFaceIfVCsDoNotCorrelate() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -973,7 +973,7 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnJourneyIpvGpg45MediumIfDataDoesNotCorrelateAndNotF2F() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -1069,7 +1069,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenThrow(CiRetrievalException.class);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
 
@@ -1091,7 +1091,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenThrow(CiExtractionException.class);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
 
@@ -1112,7 +1112,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenThrow(CredentialParseException.class);
 
@@ -1233,7 +1233,7 @@ class CheckExistingIdentityHandlerTest {
                 throws Exception {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
             var vcs = new ArrayList<>(List.of(gpg45Vc, f2fVc));
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, vcs));
             when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, false))
@@ -1253,7 +1253,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldNotReturnReproveJourneyIfUserHasPendingF2FWithReproveFlag() throws Exception {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
             var vcs = new ArrayList<>(List.of(gpg45Vc));
-            when(mockEvcsService.getVerifiableCredentialsByState(
+            when(mockEvcsService.getParsedVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
             when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, true))
@@ -1310,7 +1310,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
         when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(testContraIndicators);
@@ -1336,7 +1336,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -1365,7 +1365,7 @@ class CheckExistingIdentityHandlerTest {
                         fraudVc,
                         vcExperianKbvM1a(),
                         vcDcmawDrivingPermitDvaM1b());
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, vcs));
 
@@ -1397,7 +1397,7 @@ class CheckExistingIdentityHandlerTest {
     void shouldNotReturnJourneyRepeatFraudCheckResponseIfNotExpiredFraudAndFlagIsTrue()
             throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getVerifiableCredentialsByState(
+        when(mockEvcsService.getParsedVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, VCS_FROM_STORE));
 

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -309,7 +309,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldUseEvcsService() throws Exception {
             when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                     .thenReturn(emptyAsyncCriStatus);
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc)));
 
@@ -317,7 +317,7 @@ class CheckExistingIdentityHandlerTest {
 
             verify(clientOAuthSessionDetailsService).getClientOAuthSession(any());
             verify(mockEvcsService)
-                    .getParsedVerifiableCredentialsByState(
+                    .fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN);
         }
 
@@ -327,7 +327,7 @@ class CheckExistingIdentityHandlerTest {
                 Gpg45Profile matchedProfile) throws Exception {
             var hmrcMigrationVC = vcHmrcMigrationPCL200();
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, hmrcMigrationVC)));
             when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
@@ -365,7 +365,7 @@ class CheckExistingIdentityHandlerTest {
         @Test
         void shouldReturnJourneyReuseWithStoreResponseIfIsF2fPendingReturn() throws Exception {
             var vcs = List.of(gpg45Vc, vcF2fPassportPhotoM1a());
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
             when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, true))
@@ -388,7 +388,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldIncludeCurrentInheritedIdentityInVcBundleWhenPendingReturn() throws Exception {
             var inheritedIdentityVc = vcHmrcMigrationPCL200();
             var vcs = List.of(gpg45Vc, f2fVc);
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs, CURRENT, List.of(inheritedIdentityVc)));
             var combinedVcs = List.of(inheritedIdentityVc, gpg45Vc, f2fVc);
@@ -403,7 +403,7 @@ class CheckExistingIdentityHandlerTest {
         @Test // User returning after migration
         void shouldReturnJourneyOpProfileReuseResponseIfPCL200RequestedAndMetWhenNotInMigration()
                 throws Exception {
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, pcl200Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -435,7 +435,7 @@ class CheckExistingIdentityHandlerTest {
         @Test // User returning after migration
         void shouldReturnJourneyOpProfileReuseResponseIfPCL250RequestedAndMetWhenNotInMigration()
                 throws Exception {
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, pcl250Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -465,7 +465,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldReturnJourneyOpProfileReuseResponseIfOpProfileAndPendingF2F() throws Exception {
             when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                     .thenReturn(emptyAsyncCriStatus);
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(pcl250Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -491,7 +491,7 @@ class CheckExistingIdentityHandlerTest {
 
         @Test // User in process of migration
         void shouldReturnJourneyInMigrationReuseResponseIfPCL200RequestedAndMet() throws Exception {
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, pcl200Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -522,7 +522,7 @@ class CheckExistingIdentityHandlerTest {
 
         @Test // User in process of migration
         void shouldReturnJourneyInMigrationReuseResponseIfPCL250RequestedAndMet() throws Exception {
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, List.of(gpg45Vc, pcl250Vc)));
             when(mockVotMatcher.matchFirstVot(
@@ -586,7 +586,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -641,7 +641,7 @@ class CheckExistingIdentityHandlerTest {
                         new AsyncCriStatus(
                                 DCMAW_ASYNC, AsyncCriStatus.STATUS_PENDING, false, true, false));
         Mockito.lenient().when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(PENDING_RETURN, vcs));
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
@@ -685,7 +685,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(PENDING_RETURN, List.of(vcDcmawAsyncDrivingPermitDva())));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
@@ -711,7 +711,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, List.of(vcF2fPassportPhotoM1a())));
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(false);
@@ -742,7 +742,7 @@ class CheckExistingIdentityHandlerTest {
         if (vot.isPresent()) {
             credentials.add(createOperationalProfileVc(vot.get()));
         }
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, credentials));
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -765,7 +765,7 @@ class CheckExistingIdentityHandlerTest {
     void shouldReturnJourneyIpvGpg45MediumResponseIfScoresDoNotSatisfyP2Gpg45Profile()
             throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, VCS_FROM_STORE));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
@@ -792,7 +792,7 @@ class CheckExistingIdentityHandlerTest {
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                 .thenReturn(emptyAsyncCriStatus);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -916,7 +916,7 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnFailResponseForFaceToFaceVerificationIfNoMatchedProfile() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -945,7 +945,7 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnFailResponseForFaceToFaceIfVCsDoNotCorrelate() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -973,7 +973,7 @@ class CheckExistingIdentityHandlerTest {
     @Test
     void shouldReturnJourneyIpvGpg45MediumIfDataDoesNotCorrelateAndNotF2F() throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -1069,7 +1069,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenThrow(CiRetrievalException.class);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
 
@@ -1091,7 +1091,7 @@ class CheckExistingIdentityHandlerTest {
                 .thenThrow(CiExtractionException.class);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
 
@@ -1112,7 +1112,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenThrow(CredentialParseException.class);
 
@@ -1233,7 +1233,7 @@ class CheckExistingIdentityHandlerTest {
                 throws Exception {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
             var vcs = new ArrayList<>(List.of(gpg45Vc, f2fVc));
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, vcs));
             when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, false))
@@ -1253,7 +1253,7 @@ class CheckExistingIdentityHandlerTest {
         void shouldNotReturnReproveJourneyIfUserHasPendingF2FWithReproveFlag() throws Exception {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
             var vcs = new ArrayList<>(List.of(gpg45Vc));
-            when(mockEvcsService.getParsedVerifiableCredentialsByState(
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
             when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, true))
@@ -1310,7 +1310,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of());
         when(cimitUtilityService.getContraIndicatorsFromVc(any())).thenReturn(testContraIndicators);
@@ -1336,7 +1336,7 @@ class CheckExistingIdentityHandlerTest {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
@@ -1365,7 +1365,7 @@ class CheckExistingIdentityHandlerTest {
                         fraudVc,
                         vcExperianKbvM1a(),
                         vcDcmawDrivingPermitDvaM1b());
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, vcs));
 
@@ -1397,7 +1397,7 @@ class CheckExistingIdentityHandlerTest {
     void shouldNotReturnJourneyRepeatFraudCheckResponseIfNotExpiredFraudAndFlagIsTrue()
             throws Exception {
         when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockEvcsService.getParsedVerifiableCredentialsByState(
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, VCS_FROM_STORE));
 

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -210,6 +210,7 @@ class InitialiseIpvSessionHandlerTest {
         clientOAuthSessionItem.setUserId(TEST_USER_ID);
         clientOAuthSessionItem.setGovukSigninJourneyId("test-journey-id");
         clientOAuthSessionItem.setVtr(List.of("Cl.Cm.P2", "Cl.Cm.PCL200"));
+        clientOAuthSessionItem.setEvcsAccessToken(TEST_EVCS_ACCESS_TOKEN);
     }
 
     @AfterEach
@@ -724,7 +725,8 @@ class InitialiseIpvSessionHandlerTest {
             // Arrange
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
-            when(mockEvcsService.getVerifiableCredentials(eq(TEST_USER_ID), any(), eq(CURRENT)))
+            when(mockEvcsService.getVerifiableCredentials(
+                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
                     .thenReturn(List.of());
 
             // Act
@@ -744,7 +746,8 @@ class InitialiseIpvSessionHandlerTest {
             // Arrange
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
-            when(mockEvcsService.getVerifiableCredentials(eq(TEST_USER_ID), any(), eq(CURRENT)))
+            when(mockEvcsService.getVerifiableCredentials(
+                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
                     .thenReturn(List.of(PCL200_MIGRATION_VC));
 
             // Act
@@ -765,7 +768,8 @@ class InitialiseIpvSessionHandlerTest {
             // Arrange
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
-            when(mockEvcsService.getVerifiableCredentials(eq(TEST_USER_ID), any(), eq(CURRENT)))
+            when(mockEvcsService.getVerifiableCredentials(
+                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
                     .thenReturn(List.of(PCL200_MIGRATION_VC, pcl200MigrationWithEvidenceVc));
 
             // Act
@@ -788,7 +792,8 @@ class InitialiseIpvSessionHandlerTest {
             // Arrange
             setupMocksForReceivedInheritedId(PCL250_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
-            when(mockEvcsService.getVerifiableCredentials(eq(TEST_USER_ID), any(), eq(CURRENT)))
+            when(mockEvcsService.getVerifiableCredentials(
+                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
                     .thenReturn(List.of(PCL200_MIGRATION_VC));
 
             // Act
@@ -809,7 +814,8 @@ class InitialiseIpvSessionHandlerTest {
             // Arrange
             setupMocksForReceivedInheritedId(PCL250_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
-            when(mockEvcsService.getVerifiableCredentials(eq(TEST_USER_ID), any(), eq(CURRENT)))
+            when(mockEvcsService.getVerifiableCredentials(
+                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
                     .thenReturn(List.of(PCL200_MIGRATION_VC, pcl200MigrationWithEvidenceVc));
 
             // Act
@@ -832,7 +838,8 @@ class InitialiseIpvSessionHandlerTest {
             // Arrange
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
-            when(mockEvcsService.getVerifiableCredentials(eq(TEST_USER_ID), any(), eq(CURRENT)))
+            when(mockEvcsService.getVerifiableCredentials(
+                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
                     .thenReturn(List.of(PCL250_MIGRATION_VC));
 
             // Act
@@ -847,7 +854,8 @@ class InitialiseIpvSessionHandlerTest {
             // Arrange
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
-            when(mockEvcsService.getVerifiableCredentials(eq(TEST_USER_ID), any(), eq(CURRENT)))
+            when(mockEvcsService.getVerifiableCredentials(
+                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
                     .thenReturn(List.of(PCL200_MIGRATION_VC, PCL250_MIGRATION_VC));
 
             // Act
@@ -862,7 +870,8 @@ class InitialiseIpvSessionHandlerTest {
             // Arrange
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
-            when(mockEvcsService.getVerifiableCredentials(eq(TEST_USER_ID), any(), eq(CURRENT)))
+            when(mockEvcsService.getVerifiableCredentials(
+                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
                     .thenReturn(List.of());
 
             // Act
@@ -948,7 +957,7 @@ class InitialiseIpvSessionHandlerTest {
                             TEST_COMPONENT_ID,
                             true))
                     .thenReturn(PCL200_MIGRATION_VC);
-            when(mockEvcsService.getVerifiableCredentials(any(), any(), any()))
+            when(mockEvcsService.getVerifiableCredentials(any(), eq(TEST_EVCS_ACCESS_TOKEN), any()))
                     .thenReturn(List.of());
 
             doThrow(new EvcsServiceException(SC_SERVER_ERROR, FAILED_TO_CONSTRUCT_EVCS_URI))

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -726,7 +726,7 @@ class InitialiseIpvSessionHandlerTest {
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
             when(mockEvcsService.getVerifiableCredentials(
-                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
+                            TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, CURRENT))
                     .thenReturn(List.of());
 
             // Act
@@ -747,7 +747,7 @@ class InitialiseIpvSessionHandlerTest {
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
             when(mockEvcsService.getVerifiableCredentials(
-                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
+                            TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, CURRENT))
                     .thenReturn(List.of(PCL200_MIGRATION_VC));
 
             // Act
@@ -769,7 +769,7 @@ class InitialiseIpvSessionHandlerTest {
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
             when(mockEvcsService.getVerifiableCredentials(
-                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
+                            TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, CURRENT))
                     .thenReturn(List.of(PCL200_MIGRATION_VC, pcl200MigrationWithEvidenceVc));
 
             // Act
@@ -793,7 +793,7 @@ class InitialiseIpvSessionHandlerTest {
             setupMocksForReceivedInheritedId(PCL250_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
             when(mockEvcsService.getVerifiableCredentials(
-                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
+                            TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, CURRENT))
                     .thenReturn(List.of(PCL200_MIGRATION_VC));
 
             // Act
@@ -815,7 +815,7 @@ class InitialiseIpvSessionHandlerTest {
             setupMocksForReceivedInheritedId(PCL250_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
             when(mockEvcsService.getVerifiableCredentials(
-                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
+                            TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, CURRENT))
                     .thenReturn(List.of(PCL200_MIGRATION_VC, pcl200MigrationWithEvidenceVc));
 
             // Act
@@ -839,7 +839,7 @@ class InitialiseIpvSessionHandlerTest {
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
             when(mockEvcsService.getVerifiableCredentials(
-                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
+                            TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, CURRENT))
                     .thenReturn(List.of(PCL250_MIGRATION_VC));
 
             // Act
@@ -855,7 +855,7 @@ class InitialiseIpvSessionHandlerTest {
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
             when(mockEvcsService.getVerifiableCredentials(
-                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
+                            TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, CURRENT))
                     .thenReturn(List.of(PCL200_MIGRATION_VC, PCL250_MIGRATION_VC));
 
             // Act
@@ -871,7 +871,7 @@ class InitialiseIpvSessionHandlerTest {
             setupMocksForReceivedInheritedId(PCL200_MIGRATION_VC);
             when(mockUserIdentityService.getVot(any())).thenCallRealMethod();
             when(mockEvcsService.getVerifiableCredentials(
-                            eq(TEST_USER_ID), eq(TEST_EVCS_ACCESS_TOKEN), eq(CURRENT)))
+                            TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, CURRENT))
                     .thenReturn(List.of());
 
             // Act

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -368,10 +368,6 @@ public class ProcessCandidateIdentityHandler
                 // We still store a pending identity - it might be mitigating an existing CI
                 if (PENDING.equals(processIdentityType)) {
                     LOGGER.info(LogHelper.buildLogMessage("Storing identity"));
-
-                    if (evcsService == null) {
-                        evcsUserVcs = getUserVcsFromEvcs(clientOAuthSessionItem);
-                    }
                     storeIdentityService.storeIdentity(
                             ipvSessionItem,
                             userId,
@@ -379,7 +375,9 @@ public class ProcessCandidateIdentityHandler
                             deviceInformation,
                             sessionVcs,
                             auditEventUser,
-                            evcsUserVcs);
+                            evcsUserVcs == null
+                                    ? getUserVcsFromEvcs(clientOAuthSessionItem)
+                                    : evcsUserVcs);
                 }
                 return journey.toObjectMap();
             }
@@ -388,10 +386,6 @@ public class ProcessCandidateIdentityHandler
 
         if (STORE_IDENTITY_TYPES.contains(processIdentityType)) {
             LOGGER.info(LogHelper.buildLogMessage("Storing identity"));
-
-            if (evcsService == null) {
-                evcsUserVcs = getUserVcsFromEvcs(clientOAuthSessionItem);
-            }
             storeIdentityService.storeIdentity(
                     ipvSessionItem,
                     userId,
@@ -399,7 +393,7 @@ public class ProcessCandidateIdentityHandler
                     deviceInformation,
                     sessionVcs,
                     auditEventUser,
-                    evcsUserVcs);
+                    evcsUserVcs == null ? getUserVcsFromEvcs(clientOAuthSessionItem) : evcsUserVcs);
         }
 
         return JOURNEY_NEXT.toObjectMap();

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -316,13 +316,19 @@ public class ProcessCandidateIdentityHandler
         List<EvcsGetUserVCDto> evcsUserVcs = null;
         var userId = clientOAuthSessionItem.getUserId();
 
+        // These identity types require the VCs from EVCS. To save multiple calls,
+        // we call for them once here.
+        if (COI_CHECK_TYPES.contains(processIdentityType)
+                || STORE_IDENTITY_TYPES.contains(processIdentityType)
+                || PENDING.equals(processIdentityType)) {
+            evcsUserVcs = getUserVcsFromEvcs(clientOAuthSessionItem);
+        }
+
         if (COI_CHECK_TYPES.contains(processIdentityType)) {
             var coiCheckType = getCoiCheckType(processIdentityType, clientOAuthSessionItem);
             LOGGER.info(
                     LogHelper.buildLogMessage("Performing COI check")
                             .with(LOG_CHECK_TYPE.getFieldName(), coiCheckType.name()));
-
-            evcsUserVcs = getUserVcsFromEvcs(clientOAuthSessionItem);
 
             var isCoiCheckSuccessful =
                     checkCoiService.isCoiCheckSuccessful(
@@ -375,9 +381,7 @@ public class ProcessCandidateIdentityHandler
                             deviceInformation,
                             sessionVcs,
                             auditEventUser,
-                            evcsUserVcs == null
-                                    ? getUserVcsFromEvcs(clientOAuthSessionItem)
-                                    : evcsUserVcs);
+                            evcsUserVcs);
                 }
                 return journey.toObjectMap();
             }
@@ -393,7 +397,7 @@ public class ProcessCandidateIdentityHandler
                     deviceInformation,
                     sessionVcs,
                     auditEventUser,
-                    evcsUserVcs == null ? getUserVcsFromEvcs(clientOAuthSessionItem) : evcsUserVcs);
+                    evcsUserVcs);
         }
 
         return JOURNEY_NEXT.toObjectMap();

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -321,7 +321,12 @@ public class ProcessCandidateIdentityHandler
         if (COI_CHECK_TYPES.contains(processIdentityType)
                 || STORE_IDENTITY_TYPES.contains(processIdentityType)
                 || PENDING.equals(processIdentityType)) {
-            evcsUserVcs = getUserVcsFromEvcs(clientOAuthSessionItem);
+            evcsUserVcs =
+                    evcsService.getUserVCs(
+                            userId,
+                            clientOAuthSessionItem.getEvcsAccessToken(),
+                            CURRENT,
+                            PENDING_RETURN);
         }
 
         if (COI_CHECK_TYPES.contains(processIdentityType)) {
@@ -401,15 +406,6 @@ public class ProcessCandidateIdentityHandler
         }
 
         return JOURNEY_NEXT.toObjectMap();
-    }
-
-    private List<EvcsGetUserVCDto> getUserVcsFromEvcs(ClientOAuthSessionItem clientOAuthSessionItem)
-            throws EvcsServiceException {
-        return evcsService.getUserVCs(
-                clientOAuthSessionItem.getUserId(),
-                clientOAuthSessionItem.getEvcsAccessToken(),
-                CURRENT,
-                PENDING_RETURN);
     }
 
     private JourneyResponse getJourneyResponseForProfileMatching(

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiService.java
@@ -17,7 +17,6 @@ import uk.gov.di.ipv.core.library.domain.ReverificationStatus;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.CoiCheckType;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
-import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.evcs.service.EvcsService;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
@@ -79,8 +78,7 @@ public class CheckCoiService {
             List<VerifiableCredential> sessionVcs,
             AuditEventUser auditEventUser,
             List<EvcsGetUserVCDto> evcsUserVcs)
-            throws HttpResponseExceptionWithErrorBody, CredentialParseException,
-                    EvcsServiceException {
+            throws HttpResponseExceptionWithErrorBody, CredentialParseException {
 
         var userId = clientOAuthSession.getUserId();
 

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -11,10 +11,10 @@ import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.CandidateIdentityType;
 import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.evcs.service.EvcsService;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -47,20 +47,17 @@ public class StoreIdentityService {
 
     public void storeIdentity(
             IpvSessionItem ipvSessionItem,
-            ClientOAuthSessionItem clientOAuthSessionItem,
+            String userId,
             CandidateIdentityType identityType,
             String deviceInformation,
             List<VerifiableCredential> credentials,
-            AuditEventUser auditEventUser)
+            AuditEventUser auditEventUser,
+            List<EvcsGetUserVCDto> evcsVcs)
             throws EvcsServiceException {
-        String userId = clientOAuthSessionItem.getUserId();
-
         if (identityType == CandidateIdentityType.PENDING) {
-            evcsService.storePendingIdentity(
-                    userId, credentials, clientOAuthSessionItem.getEvcsAccessToken());
+            evcsService.storePendingIdentity(userId, credentials, evcsVcs);
         } else {
-            evcsService.storeCompletedIdentity(
-                    userId, credentials, clientOAuthSessionItem.getEvcsAccessToken());
+            evcsService.storeCompletedIdentity(userId, credentials, evcsVcs);
         }
 
         LOGGER.info(LogHelper.buildLogMessage("Identity successfully stored"));

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiServiceTest.java
@@ -72,8 +72,7 @@ class CheckCoiServiceTest {
     void setup() throws Exception {
         testAuditEventUser =
                 new AuditEventUser(USER_ID, IPV_SESSION_ID, "govuk-signin_journeyid", "ip-address");
-        when(mockEvcsService.getVerifiableCredentials(
-                        USER_ID, EVCS_ACCESS_TOKEN, EvcsVCState.CURRENT))
+        when(mockEvcsService.getVerifiableCredentials(USER_ID, List.of(), EvcsVCState.CURRENT))
                 .thenReturn(List.of(ADDRESS_VC));
         when(mockConfigService.getParameter(ConfigurationVariable.COMPONENT_ID))
                 .thenReturn("some-component-id");
@@ -111,7 +110,8 @@ class CheckCoiServiceTest {
                         STANDARD,
                         "device-information",
                         List.of(),
-                        testAuditEventUser);
+                        testAuditEventUser,
+                        List.of());
 
         // Assert
         assertTrue(res);
@@ -164,7 +164,8 @@ class CheckCoiServiceTest {
                         ACCOUNT_INTERVENTION,
                         "device-information",
                         List.of(),
-                        testAuditEventUser);
+                        testAuditEventUser,
+                        List.of());
 
         // Assert
         assertTrue(res);
@@ -195,7 +196,8 @@ class CheckCoiServiceTest {
                         STANDARD,
                         "device-information",
                         List.of(fraudVc),
-                        testAuditEventUser);
+                        testAuditEventUser,
+                        List.of());
 
         // Assert
         assertTrue(res);
@@ -225,7 +227,8 @@ class CheckCoiServiceTest {
                         ACCOUNT_INTERVENTION,
                         "device-information",
                         List.of(),
-                        testAuditEventUser);
+                        testAuditEventUser,
+                        List.of());
 
         // Assert
         assertTrue(res);
@@ -258,7 +261,8 @@ class CheckCoiServiceTest {
                         STANDARD,
                         "device-information",
                         List.of(),
-                        testAuditEventUser);
+                        testAuditEventUser,
+                        List.of());
 
         // Assert
         assertTrue(res);
@@ -312,7 +316,8 @@ class CheckCoiServiceTest {
                         STANDARD,
                         "device-information",
                         List.of(),
-                        testAuditEventUser);
+                        testAuditEventUser,
+                        List.of());
 
         // Assert
         assertFalse(res);
@@ -366,7 +371,8 @@ class CheckCoiServiceTest {
                         ACCOUNT_INTERVENTION,
                         "device-information",
                         List.of(),
-                        testAuditEventUser);
+                        testAuditEventUser,
+                        List.of());
 
         // Assert
         assertFalse(res);
@@ -406,7 +412,8 @@ class CheckCoiServiceTest {
                         ACCOUNT_INTERVENTION,
                         "device-information",
                         List.of(),
-                        testAuditEventUser);
+                        testAuditEventUser,
+                        List.of());
 
         // Assert
         assertFalse(res);

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -105,7 +105,7 @@ public class EvcsService {
     public List<VerifiableCredential> getVerifiableCredentials(
             String userId, String evcsAccessToken, EvcsVCState... states)
             throws CredentialParseException, EvcsServiceException {
-        return getParsedVerifiableCredentialsByState(userId, evcsAccessToken, states)
+        return fetchEvcsVerifiableCredentialsByState(userId, evcsAccessToken, states)
                 .values()
                 .stream()
                 .flatMap(List::stream)
@@ -126,14 +126,14 @@ public class EvcsService {
                 .toList();
     }
 
-    public Map<EvcsVCState, List<VerifiableCredential>> getParsedVerifiableCredentialsByState(
+    public Map<EvcsVCState, List<VerifiableCredential>> fetchEvcsVerifiableCredentialsByState(
             String userId, String evcsAccessToken, EvcsVCState... states)
             throws CredentialParseException, EvcsServiceException {
         var evcsUserVcs = getUserVCs(userId, evcsAccessToken, states);
         return getParsedVerifiableCredentialsFromEvcsResponse(userId, evcsUserVcs);
     }
 
-    public Map<EvcsVCState, List<VerifiableCredential>>
+    private Map<EvcsVCState, List<VerifiableCredential>>
             getParsedVerifiableCredentialsFromEvcsResponse(
                     String userId, List<EvcsGetUserVCDto> evcsUserVcs)
                     throws CredentialParseException {

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -114,7 +114,7 @@ public class EvcsService {
 
     public List<VerifiableCredential> getVerifiableCredentials(
             String userId, List<EvcsGetUserVCDto> evcsUserVcs, EvcsVCState... states)
-            throws CredentialParseException, EvcsServiceException {
+            throws CredentialParseException {
         var evcsUserVcsByRequiredState =
                 evcsUserVcs.stream()
                         .filter(evcsVc -> List.of(states).contains(evcsVc.state()))

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -46,23 +46,19 @@ public class EvcsService {
     }
 
     public void storeCompletedIdentity(
-            String userId, List<VerifiableCredential> credentials, String evcsAccessToken)
+            String userId,
+            List<VerifiableCredential> credentials,
+            List<EvcsGetUserVCDto> currentAndPendingEvcsVcs)
             throws EvcsServiceException {
-        persistUserVCs(
-                userId,
-                credentials,
-                getUserVCs(userId, evcsAccessToken, CURRENT, PENDING_RETURN),
-                false);
+        persistUserVCs(userId, credentials, currentAndPendingEvcsVcs, false);
     }
 
     public void storePendingIdentity(
-            String userId, List<VerifiableCredential> credentials, String evcsAccessToken)
+            String userId,
+            List<VerifiableCredential> credentials,
+            List<EvcsGetUserVCDto> currentAndPendingEvcsVcs)
             throws EvcsServiceException {
-        persistUserVCs(
-                userId,
-                credentials,
-                getUserVCs(userId, evcsAccessToken, CURRENT, PENDING_RETURN),
-                true);
+        persistUserVCs(userId, credentials, currentAndPendingEvcsVcs, true);
     }
 
     public void storeMigratedIdentity(String userId, List<VerifiableCredential> credentials)
@@ -109,16 +105,40 @@ public class EvcsService {
     public List<VerifiableCredential> getVerifiableCredentials(
             String userId, String evcsAccessToken, EvcsVCState... states)
             throws CredentialParseException, EvcsServiceException {
-        return getVerifiableCredentialsByState(userId, evcsAccessToken, states).values().stream()
+        return getParsedVerifiableCredentialsByState(userId, evcsAccessToken, states)
+                .values()
+                .stream()
                 .flatMap(List::stream)
                 .toList();
     }
 
-    public Map<EvcsVCState, List<VerifiableCredential>> getVerifiableCredentialsByState(
+    public List<VerifiableCredential> getVerifiableCredentials(
+            String userId, List<EvcsGetUserVCDto> evcsUserVcs, EvcsVCState... states)
+            throws CredentialParseException, EvcsServiceException {
+        var evcsUserVcsByRequiredState =
+                evcsUserVcs.stream()
+                        .filter(evcsVc -> List.of(states).contains(evcsVc.state()))
+                        .toList();
+        return getParsedVerifiableCredentialsFromEvcsResponse(userId, evcsUserVcsByRequiredState)
+                .values()
+                .stream()
+                .flatMap(List::stream)
+                .toList();
+    }
+
+    public Map<EvcsVCState, List<VerifiableCredential>> getParsedVerifiableCredentialsByState(
             String userId, String evcsAccessToken, EvcsVCState... states)
             throws CredentialParseException, EvcsServiceException {
+        var evcsUserVcs = getUserVCs(userId, evcsAccessToken, states);
+        return getParsedVerifiableCredentialsFromEvcsResponse(userId, evcsUserVcs);
+    }
+
+    public Map<EvcsVCState, List<VerifiableCredential>>
+            getParsedVerifiableCredentialsFromEvcsResponse(
+                    String userId, List<EvcsGetUserVCDto> evcsUserVcs)
+                    throws CredentialParseException {
         Map<EvcsVCState, List<VerifiableCredential>> credentials = new EnumMap<>(EvcsVCState.class);
-        for (var vc : getUserVCs(userId, evcsAccessToken, states)) {
+        for (var vc : evcsUserVcs) {
             try {
                 var jwt = SignedJWT.parse(vc.vc());
                 var cri = configService.getCriByIssuer(jwt.getJWTClaimsSet().getIssuer());
@@ -158,7 +178,7 @@ public class EvcsService {
         if (!vcsToUpdates.isEmpty()) evcsClient.updateUserVCs(userId, vcsToUpdates);
     }
 
-    private List<EvcsGetUserVCDto> getUserVCs(
+    public List<EvcsGetUserVCDto> getUserVCs(
             String userId, String evcsAccessToken, EvcsVCState... states)
             throws EvcsServiceException {
         return evcsClient.getUserVcs(userId, evcsAccessToken, List.of(states)).vcs();

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -78,30 +78,29 @@ class EvcsServiceTest {
             List.of(CURRENT, PENDING_RETURN);
 
     private static final String TEST_EVCS_ACCESS_TOKEN = "TEST_EVCS_ACCESS_TOKEN";
-    private static final EvcsGetUserVCsDto EVCS_GET_USER_VCS_DTO =
-            new EvcsGetUserVCsDto(
-                    List.of(
-                            new EvcsGetUserVCDto(
-                                    vcAddressTwo().getVcString(),
-                                    EvcsVCState.CURRENT,
-                                    Map.of(
-                                            "reason", "testing",
-                                            "txmaEventId", "txma-event-id-2",
-                                            "timestampMs", "1714478033959")),
-                            new EvcsGetUserVCDto(
-                                    vcWebDrivingPermitDvlaValid().getVcString(),
-                                    EvcsVCState.PENDING_RETURN,
-                                    Map.of(
-                                            "reason", "testing",
-                                            "txmaEventId", "txma-event-id-2",
-                                            "timestampMs", "1714478033959")),
-                            new EvcsGetUserVCDto(
-                                    VC_PASSPORT_NON_DCMAW_SUCCESSFUL_TEST.getVcString(),
-                                    EvcsVCState.CURRENT,
-                                    Map.of(
-                                            "reason", "testing",
-                                            "txmaEventId", "txma-event-id-2",
-                                            "timestampMs", "1714478033959"))));
+    private static final List<EvcsGetUserVCDto> EVCS_GET_USER_VC_DTO =
+            List.of(
+                    new EvcsGetUserVCDto(
+                            vcAddressTwo().getVcString(),
+                            EvcsVCState.CURRENT,
+                            Map.of(
+                                    "reason", "testing",
+                                    "txmaEventId", "txma-event-id-2",
+                                    "timestampMs", "1714478033959")),
+                    new EvcsGetUserVCDto(
+                            vcWebDrivingPermitDvlaValid().getVcString(),
+                            EvcsVCState.PENDING_RETURN,
+                            Map.of(
+                                    "reason", "testing",
+                                    "txmaEventId", "txma-event-id-2",
+                                    "timestampMs", "1714478033959")),
+                    new EvcsGetUserVCDto(
+                            VC_PASSPORT_NON_DCMAW_SUCCESSFUL_TEST.getVcString(),
+                            EvcsVCState.CURRENT,
+                            Map.of(
+                                    "reason", "testing",
+                                    "txmaEventId", "txma-event-id-2",
+                                    "timestampMs", "1714478033959")));
 
     @Captor ArgumentCaptor<List<EvcsCreateUserVCsDto>> evcsCreateUserVCsDtosCaptor;
     @Captor ArgumentCaptor<List<EvcsUpdateUserVCsDto>> evcsUpdateUserVCsDtosCaptor;
@@ -114,17 +113,10 @@ class EvcsServiceTest {
     @Test
     void testStoreIdentity_whenNoExistingEvcsUserVCs() throws Exception {
         // Arrange
-        when(mockEvcsClient.getUserVcs(
-                        TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR))
-                .thenReturn(new EvcsGetUserVCsDto(Collections.emptyList()));
         // Act
-        evcsService.storeCompletedIdentity(
-                TEST_USER_ID, VERIFIABLE_CREDENTIALS, TEST_EVCS_ACCESS_TOKEN);
+        evcsService.storeCompletedIdentity(TEST_USER_ID, VERIFIABLE_CREDENTIALS, List.of());
         // Assert
         InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-        mockOrderVerifier
-                .verify(mockEvcsClient)
-                .getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR);
         mockOrderVerifier.verify(mockEvcsClient, times(0)).updateUserVCs(any(), any());
         mockOrderVerifier
                 .verify(mockEvcsClient)
@@ -143,17 +135,11 @@ class EvcsServiceTest {
     @Test
     void testStorePendingIdentity_onSuccessfulJourney_for_incompleteF2F() throws Exception {
         // Arrange
-        when(mockEvcsClient.getUserVcs(
-                        TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR))
-                .thenReturn(new EvcsGetUserVCsDto(Collections.emptyList()));
         // Act
         evcsService.storePendingIdentity(
-                TEST_USER_ID, VERIFIABLE_CREDENTIALS_ONE_EXIST_IN_EVCS, TEST_EVCS_ACCESS_TOKEN);
+                TEST_USER_ID, VERIFIABLE_CREDENTIALS_ONE_EXIST_IN_EVCS, List.of());
         // Assert
         InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-        mockOrderVerifier
-                .verify(mockEvcsClient)
-                .getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR);
         mockOrderVerifier
                 .verify(mockEvcsClient, times(0))
                 .updateUserVCs(any(), evcsUpdateUserVCsDtosCaptor.capture());
@@ -168,18 +154,11 @@ class EvcsServiceTest {
 
     @Test
     void testStoreIdentity_for_6MFCJourney() throws Exception {
-        // Arrange
-        when(mockEvcsClient.getUserVcs(
-                        TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR))
-                .thenReturn(EVCS_GET_USER_VCS_DTO);
         // Act
         evcsService.storeCompletedIdentity(
-                TEST_USER_ID, VERIFIABLE_CREDENTIALS_ONE_EXIST_IN_EVCS, TEST_EVCS_ACCESS_TOKEN);
+                TEST_USER_ID, VERIFIABLE_CREDENTIALS_ONE_EXIST_IN_EVCS, EVCS_GET_USER_VC_DTO);
         // Assert
         InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-        mockOrderVerifier
-                .verify(mockEvcsClient)
-                .getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR);
         mockOrderVerifier
                 .verify(mockEvcsClient)
                 .updateUserVCs(any(), evcsUpdateUserVCsDtosCaptor.capture());
@@ -204,32 +183,27 @@ class EvcsServiceTest {
     @Test
     void testStoreCompleteIdentity_whenAllVCsExistInEvcs_withCurrentState() throws Exception {
         // Arrange
-        EvcsGetUserVCsDto evcsGetUserVcsWithCurrentStateAllExistingDto =
-                new EvcsGetUserVCsDto(
-                        List.of(
-                                new EvcsGetUserVCDto(
-                                        VC_ADDRESS_TEST.getVcString(),
-                                        EvcsVCState.CURRENT,
-                                        Map.of("reason", "testing")),
-                                new EvcsGetUserVCDto(
-                                        VC_DRIVING_PERMIT_TEST.getVcString(),
-                                        EvcsVCState.CURRENT,
-                                        Map.of("reason", "testing")),
-                                new EvcsGetUserVCDto(
-                                        VC_F2F.getVcString(),
-                                        EvcsVCState.CURRENT,
-                                        Map.of("reason", "testing"))));
-        when(mockEvcsClient.getUserVcs(
-                        TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR))
-                .thenReturn(evcsGetUserVcsWithCurrentStateAllExistingDto);
+        List<EvcsGetUserVCDto> evcsGetUserVcsWithCurrentStateAllExistingDto =
+                List.of(
+                        new EvcsGetUserVCDto(
+                                VC_ADDRESS_TEST.getVcString(),
+                                EvcsVCState.CURRENT,
+                                Map.of("reason", "testing")),
+                        new EvcsGetUserVCDto(
+                                VC_DRIVING_PERMIT_TEST.getVcString(),
+                                EvcsVCState.CURRENT,
+                                Map.of("reason", "testing")),
+                        new EvcsGetUserVCDto(
+                                VC_F2F.getVcString(),
+                                EvcsVCState.CURRENT,
+                                Map.of("reason", "testing")));
         // Act
         evcsService.storeCompletedIdentity(
-                TEST_USER_ID, VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS, TEST_EVCS_ACCESS_TOKEN);
+                TEST_USER_ID,
+                VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS,
+                evcsGetUserVcsWithCurrentStateAllExistingDto);
         // Assert
         InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-        mockOrderVerifier
-                .verify(mockEvcsClient)
-                .getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR);
         mockOrderVerifier.verify(mockEvcsClient, times(0)).updateUserVCs(any(), any());
         mockOrderVerifier.verify(mockEvcsClient, times(0)).storeUserVCs(any(), any());
     }
@@ -238,32 +212,27 @@ class EvcsServiceTest {
     void testStoreCompleteIdentity_whenAllVCsExistInEvcs_inSession_withPendingReturnState()
             throws Exception {
         // Arrange
-        EvcsGetUserVCsDto evcsGetUserVcsWithPendingAllExistingDto =
-                new EvcsGetUserVCsDto(
-                        List.of(
-                                new EvcsGetUserVCDto(
-                                        VC_ADDRESS_TEST.getVcString(),
-                                        EvcsVCState.PENDING_RETURN,
-                                        Map.of("reason", "testing")),
-                                new EvcsGetUserVCDto(
-                                        VC_DRIVING_PERMIT_TEST.getVcString(),
-                                        EvcsVCState.PENDING_RETURN,
-                                        Map.of("reason", "testing")),
-                                new EvcsGetUserVCDto(
-                                        VC_F2F.getVcString(),
-                                        EvcsVCState.PENDING_RETURN,
-                                        Map.of("reason", "testing"))));
-        when(mockEvcsClient.getUserVcs(
-                        TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR))
-                .thenReturn(evcsGetUserVcsWithPendingAllExistingDto);
+        List<EvcsGetUserVCDto> evcsGetUserVcsWithPendingAllExistingDto =
+                List.of(
+                        new EvcsGetUserVCDto(
+                                VC_ADDRESS_TEST.getVcString(),
+                                EvcsVCState.PENDING_RETURN,
+                                Map.of("reason", "testing")),
+                        new EvcsGetUserVCDto(
+                                VC_DRIVING_PERMIT_TEST.getVcString(),
+                                EvcsVCState.PENDING_RETURN,
+                                Map.of("reason", "testing")),
+                        new EvcsGetUserVCDto(
+                                VC_F2F.getVcString(),
+                                EvcsVCState.PENDING_RETURN,
+                                Map.of("reason", "testing")));
         // Act
         evcsService.storeCompletedIdentity(
-                TEST_USER_ID, VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS, TEST_EVCS_ACCESS_TOKEN);
+                TEST_USER_ID,
+                VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS,
+                evcsGetUserVcsWithPendingAllExistingDto);
         // Assert
         InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-        mockOrderVerifier
-                .verify(mockEvcsClient)
-                .getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR);
         mockOrderVerifier
                 .verify(mockEvcsClient, times(1))
                 .updateUserVCs(any(), evcsUpdateUserVCsDtosCaptor.capture());
@@ -280,32 +249,25 @@ class EvcsServiceTest {
     void testStoreCompleteIdentity_whenAllVCsExistInEvcs_notInSession_withPendingReturnState()
             throws Exception {
         // Arrange
-        EvcsGetUserVCsDto evcsGetUserVcsWithPendingAllExistingDto =
-                new EvcsGetUserVCsDto(
-                        List.of(
-                                new EvcsGetUserVCDto(
-                                        VC_ADDRESS_TEST.getVcString(),
-                                        EvcsVCState.PENDING_RETURN,
-                                        Map.of("reason", "testing")),
-                                new EvcsGetUserVCDto(
-                                        VC_DRIVING_PERMIT_TEST.getVcString(),
-                                        EvcsVCState.PENDING_RETURN,
-                                        Map.of("reason", "testing")),
-                                new EvcsGetUserVCDto(
-                                        VC_F2F.getVcString(),
-                                        EvcsVCState.PENDING_RETURN,
-                                        Map.of("reason", "testing"))));
-        when(mockEvcsClient.getUserVcs(
-                        TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR))
-                .thenReturn(evcsGetUserVcsWithPendingAllExistingDto);
+        List<EvcsGetUserVCDto> evcsGetUserVcsWithPendingAllExistingDto =
+                List.of(
+                        new EvcsGetUserVCDto(
+                                VC_ADDRESS_TEST.getVcString(),
+                                EvcsVCState.PENDING_RETURN,
+                                Map.of("reason", "testing")),
+                        new EvcsGetUserVCDto(
+                                VC_DRIVING_PERMIT_TEST.getVcString(),
+                                EvcsVCState.PENDING_RETURN,
+                                Map.of("reason", "testing")),
+                        new EvcsGetUserVCDto(
+                                VC_F2F.getVcString(),
+                                EvcsVCState.PENDING_RETURN,
+                                Map.of("reason", "testing")));
         // Act
         evcsService.storeCompletedIdentity(
-                TEST_USER_ID, Collections.emptyList(), TEST_EVCS_ACCESS_TOKEN);
+                TEST_USER_ID, Collections.emptyList(), evcsGetUserVcsWithPendingAllExistingDto);
         // Assert
         InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-        mockOrderVerifier
-                .verify(mockEvcsClient)
-                .getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR);
         mockOrderVerifier
                 .verify(mockEvcsClient, times(1))
                 .updateUserVCs(any(), evcsUpdateUserVCsDtosCaptor.capture());
@@ -321,23 +283,16 @@ class EvcsServiceTest {
     @Test
     void storeCompletedIdentityShouldNotUpdateInheritedIdentity() throws Exception {
         var vcsInEvcs =
-                new EvcsGetUserVCsDto(
-                        List.of(
-                                new EvcsGetUserVCDto(
-                                        vcHmrcMigrationPCL200().getVcString(),
-                                        EvcsVCState.CURRENT,
-                                        Map.of("inheritedIdentity", Cri.HMRC_MIGRATION.getId()))));
-        when(mockEvcsClient.getUserVcs(
-                        TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR))
-                .thenReturn(vcsInEvcs);
+                List.of(
+                        new EvcsGetUserVCDto(
+                                vcHmrcMigrationPCL200().getVcString(),
+                                EvcsVCState.CURRENT,
+                                Map.of("inheritedIdentity", Cri.HMRC_MIGRATION.getId())));
         // Act
         evcsService.storeCompletedIdentity(
-                TEST_USER_ID, VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS, TEST_EVCS_ACCESS_TOKEN);
+                TEST_USER_ID, VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS, vcsInEvcs);
         // Assert
         InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-        mockOrderVerifier
-                .verify(mockEvcsClient)
-                .getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, VC_STATES_TO_QUERY_FOR);
 
         mockOrderVerifier.verify(mockEvcsClient, never()).updateUserVCs(any(), any());
         mockOrderVerifier.verify(mockEvcsClient, times(1)).storeUserVCs(any(), any());


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Moved EVCS call to get user VCs from CoiCheckService and StoreIdentityService to the ProcessCandidateIdentityHandler 

### Why did it change
We make a call to evcs to retrieve existing user VCs a couple of times as part of `process-candidate-identity` lambda's services. Instead, moving and consolidating them to a single call in the handler can improve our performance as a single call can take up to 200ms.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-7909](https://govukverify.atlassian.net/browse/PYIC-7909)


[PYIC-7909]: https://govukverify.atlassian.net/browse/PYIC-7909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ