### PR TITLE
PYIC-8241 Support full range of journeys with reprove identity

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -123,6 +123,8 @@ Feature: Audit Events
     And I start a new 'medium-confidence' journey with reprove identity
     Then I get a 'reprove-identity-start' page response
     When I submit a 'next' event
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response

--- a/api-tests/features/inherited-identity/extended-scenarios.feature
+++ b/api-tests/features/inherited-identity/extended-scenarios.feature
@@ -137,6 +137,8 @@ Feature: Inherited identity extended scenarios
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with reprove identity and with inherited identity 'kenneth-vot-pcl250-passport'
     Then I get a 'reprove-identity-start' page response
     When I submit a 'next' event
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response

--- a/api-tests/features/p2-reprove-identity.feature
+++ b/api-tests/features/p2-reprove-identity.feature
@@ -9,6 +9,8 @@ Feature: Reprove Identity Journey
         When I start a new 'medium-confidence' journey with reprove identity
         Then I get a 'reprove-identity-start' page response
         When I submit a 'next' event
+        Then I get a 'live-in-uk' page response
+        When I submit a 'uk' event
         Then I get a 'page-ipv-identity-document-start' page response
         When I submit an 'appTriage' event
         Then I get a 'dcmaw' CRI response
@@ -34,6 +36,8 @@ Feature: Reprove Identity Journey
         When I start a new 'medium-confidence' journey with reprove identity
         Then I get a 'reprove-identity-start' page response
         When I submit a 'next' event
+        Then I get a 'live-in-uk' page response
+        When I submit a 'uk' event
         Then I get a 'page-ipv-identity-document-start' page response
         When I submit an 'end' event
         Then I get a 'page-ipv-identity-postoffice-start' page response
@@ -81,7 +85,7 @@ Feature: Reprove Identity Journey
         When I start a new 'medium-confidence' journey with reprove identity
         Then I get a 'reprove-identity-start' page response
         When I submit a 'next' event
-        Then I get a 'page-ipv-identity-document-start' page response
+        Then I get a 'live-in-uk' page response
 
     Rule: F2F journeys are subject to COI checks
         Background:
@@ -93,6 +97,8 @@ Feature: Reprove Identity Journey
             When I start a new 'medium-confidence' journey with reprove identity
             Then I get a 'reprove-identity-start' page response
             When I submit a 'next' event
+            Then I get a 'live-in-uk' page response
+            When I submit a 'uk' event
             Then I get a 'page-ipv-identity-document-start' page response
             When I submit an 'end' event
             Then I get a 'page-ipv-identity-postoffice-start' page response

--- a/journey-map/public/constants.mjs
+++ b/journey-map/public/constants.mjs
@@ -12,6 +12,7 @@ export const JOURNEY_TYPES = {
   SESSION_TIMEOUT: "Session timeout",
   F2F_HAND_OFF: "F2F hand off",
   F2F_PENDING: "F2F pending",
+  F2F_FAILED: "F2F failed",
   OPERATIONAL_PROFILE_MIGRATION: "Operational profile migration",
   OPERATIONAL_PROFILE_REUSE: "Operational profile reuse",
   REVERIFICATION: "Reverification",
@@ -24,10 +25,10 @@ export const NESTED_JOURNEY_TYPES = {
   STRATEGIC_APP_HANDLE_RESULT: "Strategic app handle result",
   STRATEGIC_APP_TRIAGE: "Strategic app triage",
   WEB_DL_OR_PASSPORT: "Web DL or passport",
-  F2F_FAILED: "F2F failed",
 };
 
 export const COMMON_JOURNEY_TYPES = [
+  "NEW_P1_IDENTITY",
   "NEW_P2_IDENTITY",
   "REUSE_EXISTING_IDENTITY",
   "REPEAT_FRAUD_CHECK",

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/initial-journey-selection.yaml
@@ -59,9 +59,25 @@ states:
       repeat-fraud-check:
         targetJourney: REPEAT_FRAUD_CHECK
         targetState: START
-      reprove-identity:
-        targetJourney: NEW_P2_IDENTITY
-        targetState: REPROVE_IDENTITY
+      reprove-identity-gpg45-medium:
+        targetState: REPROVE_IDENTITY_START_P2
       reprove-identity-gpg45-low:
+        targetState: REPROVE_IDENTITY_START_P1
+
+  REPROVE_IDENTITY_START_P1:
+    response:
+      type: page
+      pageId: reprove-identity-start
+    events:
+      next:
         targetJourney: NEW_P1_IDENTITY
-        targetState: REPROVE_IDENTITY
+        targetState: START
+
+  REPROVE_IDENTITY_START_P2:
+    response:
+      type: page
+      pageId: reprove-identity-start
+    events:
+      next:
+        targetJourney: NEW_P2_IDENTITY
+        targetState: START

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -24,16 +24,6 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
-  ENHANCED_VERIFICATION_F2F_FAIL:
-    events:
-      next:
-        targetState: F2F_FAILED_MITIGATION_PAGE
-
-  REPROVE_IDENTITY:
-    events:
-      next:
-        targetState: REPROVE_IDENTITY_START
-
   DCMAW_ASYNC_COMPLETE:
     events:
       next:
@@ -72,13 +62,6 @@ states:
         targetState: ERROR
 
   # Journey states
-  REPROVE_IDENTITY_START:
-    response:
-      type: page
-      pageId: reprove-identity-start
-    events:
-      next:
-        targetState: IDENTITY_START_PAGE
 
   RESET_SESSION_IDENTITY:
     response:
@@ -676,21 +659,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-
-  # Common Mitigation states - invalid-dl/invalid-passport
-  F2F_FAILED_MITIGATION_PAGE:
-    response:
-      type: page
-      pageId: pyi-f2f-technical
-    events:
-      next:
-        targetState: IDENTITY_START_PAGE
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: enhanced-verification
-      end:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -24,11 +24,6 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
-  REPROVE_IDENTITY:
-    events:
-      next:
-        targetState: REPROVE_IDENTITY_START
-
   DCMAW_ASYNC_COMPLETE:
     events:
       next:
@@ -67,13 +62,6 @@ states:
         targetState: ERROR
 
   # Journey states
-  REPROVE_IDENTITY_START:
-    response:
-      type: page
-      pageId: reprove-identity-start
-    events:
-      next:
-        targetState: IDENTITY_START_PAGE
 
   RESET_SESSION_IDENTITY:
     response:

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
@@ -44,7 +44,7 @@ public class JourneyUris {
     public static final String JOURNEY_F2F_PENDING_PATH = "/journey/pending";
     public static final String JOURNEY_REPEAT_FRAUD_CHECK_PATH = "/journey/repeat-fraud-check";
     public static final String JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM_PATH =
-            "/journey/reprove-identity";
+            "/journey/reprove-identity-gpg45-medium";
     public static final String JOURNEY_REPROVE_IDENTITY_GPG45_LOW_PATH =
             "/journey/reprove-identity-gpg45-low";
     public static final String JOURNEY_RESET_SESSION_IDENTITY_PATH =


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Shifted reprove identity screen into initial journey selection, allowing us to use the standard journey map for the relevant level of confidence
- Added P1 to list of common journeys in visualisation
- Tidied up some unused states

![image](https://github.com/user-attachments/assets/2257fbd4-ce08-484f-807e-20a9d2d06287)

### Why did it change

Reprove identity interventions would only route into the UK address journey with no CI mitigations.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8241](https://govukverify.atlassian.net/browse/PYIC-8241)


[PYIC-8241]: https://govukverify.atlassian.net/browse/PYIC-8241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ