### PR TITLE
PYIC-8242 Turn on DT debug logging for single build lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1078,6 +1078,15 @@ Resources:
             - UseDynatrace
             - /opt/dynatrace
             - !Ref AWS::NoValue
+          # PYIC-8242 Turn on DT debug logging for single build lambda
+          DT_LOGGING_DESTINATION: !If
+            - IsBuild
+            - "stdout"
+            - !Ref AWS::NoValue
+          DT_LOGGING_JAVA_FLAGS: !If
+            - IsBuild
+            - "log-Transformer=true,log-OpenTelemetryUtils=true,log-AsyncClassRetransformer=true,log-ClassValue=true"
+            - !Ref AWS::NoValue
       Layers:
         - !If
           - UseDynatrace


### PR DESCRIPTION
To diagnose the mystery segfaults/IOExceptions issue, Dynatrace have asked that we enable detailed debug logging again

`process-cri-callback-build` has had the most segfaults in the last month so selecting this to try

(Last time we tried this the segfaults curiously stopped so let’s see..)
