### PR TITLE
PYIC-8244 Separate app output from api tests

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -155,6 +155,14 @@ jobs:
           path: api-tests/reports/
           retention-days: 7
 
+      - name: Upload Application logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Application logs
+          path: api-tests/core-back-output.log
+          retention-days: 7
+
   sam-build:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/api-tests/package.json
+++ b/api-tests/package.json
@@ -9,7 +9,7 @@
     "test:build": "CORE_ENV=build cucumber-js --tags '@Build'",
     "test:local": "CORE_ENV=local cucumber-js",
     "test:ci": "start-server-and-test run-local-core-back 'http://localhost:4502' test:local",
-    "run-local-core-back": "../gradlew -p ../local-running run",
+    "run-local-core-back": "../gradlew -p ../local-running run > core-back-output.log",
     "lint": "eslint . && prettier . --check",
     "lint-fix": "eslint --fix . && prettier . --write"
   },


### PR DESCRIPTION
## Proposed changes

### What changed

Redirect app output to a file when running API tests locally and upload as a separate artifact

### Why did it change

At the moment the test output is munged with the application output, making it very hard to navigate

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8244](https://govukverify.atlassian.net/browse/PYIC-8244)


[PYIC-8244]: https://govukverify.atlassian.net/browse/PYIC-8244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ