### PR TITLE
PYIC-8226: Add runbook URL to alarm descriptions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -211,6 +211,9 @@ Mappings:
     PrefixListIds:
       dynamodb: "pl-b3a742da"
       s3: "pl-7ca54015"
+  Constants:
+    Urls:
+      pagerDutyRunbook: "https://team-manual.account.gov.uk/teams/IPV-Core-team/Supporting-IPV-Core/pager-duty-runbooks/"
 
 Resources:
   # ssl cert
@@ -2897,6 +2900,9 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
         AlarmName: PrivateApiGateWay5xxAlarm
+        AlarmDescription: !Sub
+          - 'The internal API gateway in front of core-back has returned 2 or more 500 errors in a 5 minute period, for 3 periods in a row. See runbook: ${RunbookUrl}'
+          - RunbookUrl: !FindInMap [ Constants, Urls, pagerDutyRunbook ]
         ActionsEnabled: true
         AlarmActions:
           - !ImportValue sns-topics-AlarmTopic
@@ -2930,6 +2936,9 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       AlarmName: ExternalApiGateWay5xxAlarm
+      AlarmDescription: !Sub
+        - 'The external API gateway in front of core-back has returned 2 or more 500 errors in a 5 minute period, for 3 periods in a row. See runbook: ${RunbookUrl}'
+        - RunbookUrl: !FindInMap [ Constants, Urls, pagerDutyRunbook ]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue sns-topics-AlarmTopic


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add runbook URL to alarm description

### Why did it change

So people responding to the alarm can easily find the runbook

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8226](https://govukverify.atlassian.net/browse/PYIC-8226)


[PYIC-8226]: https://govukverify.atlassian.net/browse/PYIC-8226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ