### PR TITLE
PYIC-8216: add BackupFrequency tag to CriResponseTable

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2683,6 +2683,9 @@ Resources:
         SSEEnabled: true
         SSEType: KMS
         KMSMasterKeyId: !GetAtt DynamoDBKmsKey.Arn
+      Tags:
+        - Key: "BackupFrequency"
+          Value: "Daily"
 
   SessionsTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Add BackupFrequency tag to CriResponseTable resource.

### Why did it change
Allows the CriResponseTable to be backed up every 24 hours

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8216](https://govukverify.atlassian.net/browse/PYIC-8216)



[PYIC-8216]: https://govukverify.atlassian.net/browse/PYIC-8216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ