### PR TITLE
PYIC-8264: Add routes for banner links

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -172,6 +172,10 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
+      # PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetState: PYI_ESCAPE
 
@@ -538,6 +542,10 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
+#     PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
@@ -549,6 +557,10 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
+      # PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
@@ -656,6 +668,10 @@ states:
       next:
         targetJourney: F2F_HAND_OFF
         targetState: START
+#     PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -203,6 +203,10 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
+#     PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetState: BANK_ACCOUNT_START_PAGE
         checkIfDisabled:
@@ -216,6 +220,10 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
+#     PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetState: BANK_ACCOUNT_START_PAGE
         checkIfDisabled:
@@ -231,6 +239,10 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_NO_PHOTO_ID
         auditEvents:
           - IPV_NO_PHOTO_ID_JOURNEY_START
+#     PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetState: PYI_ESCAPE_NO_PHOTO_ID
 
@@ -243,6 +255,10 @@ states:
         targetState: WEB_DL_OR_PASSPORT
       drivingLicence:
         targetState: WEB_DL_OR_PASSPORT
+#     PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetState: F2F_PYI_POST_OFFICE
         checkIfDisabled:
@@ -588,6 +604,10 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
+#     PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
@@ -599,6 +619,10 @@ states:
     events:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
+#     PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
@@ -705,6 +729,10 @@ states:
       next:
         targetJourney: F2F_HAND_OFF
         targetState: START
+#     PYIC-8264 Temporary routing
+      appTriageBanner:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add routes for links that will appear in the Experian outage banners

### Why did it change

So the links work

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8264](https://govukverify.atlassian.net/browse/PYIC-8264)


[PYIC-8264]: https://govukverify.atlassian.net/browse/PYIC-8264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ