### PR TITLE
PYIC-8099 Add GitHub action to deploy journey map using secure pipelines

### DIFF
--- a/.github/workflows/journey-map.yml
+++ b/.github/workflows/journey-map.yml
@@ -45,3 +45,46 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  deploy-aws:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      AWS_REGION: eu-west-2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up AWS creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN_JOURNEY_MAP }}
+          aws-region: eu-west-2
+
+      - name: Set up esbuild
+        run: curl -fsSL https://esbuild.github.io/dl/latest | sh
+
+      - name: Add esbuild to path
+        run: echo "${GITHUB_WORKSPACE}" >> $GITHUB_PATH
+
+      - name: Set up SAM cli
+        uses: aws-actions/setup-sam@v2
+
+      - name: SAM Validate
+        working-directory: ./journey-map/deploy
+        run: sam validate --region ${{ env.AWS_REGION }}
+
+      - name: SAM build and test
+        working-directory: ./journey-map/deploy
+        run: sam build
+
+      - name: Deploy SAM app
+        uses: govuk-one-login/devplatform-upload-action@v3.9
+        with:
+          artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME_JOURNEY_MAP }}
+          signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
+          working-directory: ./journey-map/deploy
+          template-file: .aws-sam/build/template.yaml


### PR DESCRIPTION
## Proposed changes

### What changed

Add job to journey map deployment that uses secure pipelines.

The terraform to deploy the secure pipeline will be in stubs-common-infra

### Why did it change

We want to start deploying using secure pipelines, to replace GitHub pages

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8099](https://govukverify.atlassian.net/browse/PYIC-8099)


[PYIC-8099]: https://govukverify.atlassian.net/browse/PYIC-8099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ