### PR TITLE
PYIC-8274: fix expand nested journey bug

### DIFF
--- a/journey-map/public/constants.mjs
+++ b/journey-map/public/constants.mjs
@@ -10,7 +10,6 @@ export const JOURNEY_TYPES = {
   TECHNICAL_ERROR: "Technical error",
   REPEAT_FRAUD_CHECK: "Repeat fraud check",
   SESSION_TIMEOUT: "Session timeout",
-  F2F_FAILED: "F2F failed",
   F2F_HAND_OFF: "F2F hand off",
   F2F_PENDING: "F2F pending",
   F2F_FAILED: "F2F failed",

--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -92,30 +92,34 @@ const expandNestedJourneys = (journeyMap, subjourneys, formData) => {
 
         Object.values(journeyMap).forEach((journeyDef) => {
           if (journeyDef.events?.[entryEvent]) {
-            const target = resolveEventTargets(
+            const targets = resolveEventTargets(
               journeyDef.events[entryEvent],
               formData,
-            ).find((t) => !t.journeyContext);
-            if (
-              target.targetState === subJourneyState &&
-              !target.targetEntryEvent
-            ) {
-              journeyDef.events[entryEvent] = entryEventDef;
-            }
+            ).filter((t) => !t.journeyContext);
+            targets
+              .filter(
+                (t) => t.targetState === subJourneyState && !t.targetEntryEvent,
+              )
+              .forEach(() => {
+                journeyDef.events[entryEvent] = entryEventDef;
+              });
           }
 
           // Resolve targets with a `targetEntryEvent` override
           Object.values(journeyDef.events ?? {}).forEach((eventDef) => {
-            const target = resolveEventTargets(eventDef, formData).find(
+            const targets = resolveEventTargets(eventDef, formData).filter(
               (t) => !t.journeyContext,
             );
-            if (
-              target.targetState === subJourneyState &&
-              target.targetEntryEvent === entryEvent
-            ) {
-              Object.assign(target, entryEventDef);
-              delete target.targetEntryEvent;
-            }
+            targets
+              .filter(
+                (t) =>
+                  t.targetState === subJourneyState &&
+                  t.targetEntryEvent === entryEvent,
+              )
+              .forEach((t) => {
+                Object.assign(t, entryEventDef);
+                delete t.targetEntryEvent;
+              });
           });
         });
       });

--- a/journey-map/public/render.mjs
+++ b/journey-map/public/render.mjs
@@ -92,13 +92,12 @@ const expandNestedJourneys = (journeyMap, subjourneys, formData) => {
 
         Object.values(journeyMap).forEach((journeyDef) => {
           if (journeyDef.events?.[entryEvent]) {
-            const targets = resolveEventTargets(
-              journeyDef.events[entryEvent],
-              formData,
-            ).filter((t) => !t.journeyContext);
-            targets
+            resolveEventTargets(journeyDef.events[entryEvent], formData)
               .filter(
-                (t) => t.targetState === subJourneyState && !t.targetEntryEvent,
+                (t) =>
+                  !t.journeyContext &&
+                  t.targetState === subJourneyState &&
+                  !t.targetEntryEvent,
               )
               .forEach(() => {
                 journeyDef.events[entryEvent] = entryEventDef;
@@ -107,12 +106,10 @@ const expandNestedJourneys = (journeyMap, subjourneys, formData) => {
 
           // Resolve targets with a `targetEntryEvent` override
           Object.values(journeyDef.events ?? {}).forEach((eventDef) => {
-            const targets = resolveEventTargets(eventDef, formData).filter(
-              (t) => !t.journeyContext,
-            );
-            targets
+            resolveEventTargets(eventDef, formData)
               .filter(
                 (t) =>
+                  !t.journey &&
                   t.targetState === subJourneyState &&
                   t.targetEntryEvent === entryEvent,
               )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the `expandNestedJourneys` function to support multiple targets being returned.

| Unexpanded | Expanded |
|-|-|
|<img width="1529" alt="Screenshot 2025-04-25 at 14 13 41" src="https://github.com/user-attachments/assets/af60a58d-a7a3-41f7-9caf-71d9a123c901" />| <img width="1633" alt="Screenshot 2025-04-25 at 14 13 58" src="https://github.com/user-attachments/assets/033d6ff6-e4fb-4e9e-963f-1697936dad6d" />|

### Why did it change
`expandNestedJourneys` only looked at the _first_ event that didn't have a journeyContext. I suspect it wasn't breaking before because checkMitigation now allows for multiple target events to be returned from `resolveEventTargets`. What we want is to apply the necessary event definition changes to all target events returned.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->



- [PYIC-8274](https://govukverify.atlassian.net/browse/PYIC-8274)



[PYIC-8274]: https://govukverify.atlassian.net/browse/PYIC-8274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ