### PR TITLE
PYIC-8262: Update third party github action references to use SHAs

### DIFF
--- a/.github/workflows/link-workflows.yaml
+++ b/.github/workflows/link-workflows.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65.2
         with:
           reporter: github-pr-check
           fail_level: error

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -1,4 +1,3 @@
-
 name: build and test
 
 on:
@@ -19,13 +18,13 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11.2'
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-      with:
-        extra_args: "detect-secrets --all-files"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.2'
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          extra_args: "detect-secrets --all-files"
 
   test-java:
     runs-on: ubuntu-latest
@@ -36,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -94,7 +93,7 @@ jobs:
       - name: Setup .npmrc
         run: |
           cp .npmrc.template .npmrc && \
-          sed -i s/GITHUB_PAT_WITH_READ:PACKAGES/${{ secrets.GITHUB_TOKEN }}/ .npmrc
+          sed -i s/GITHUB_PAT_WITH_READ:PACKAGES/"${{ secrets.GITHUB_TOKEN }}"/ .npmrc
 
       - name: Install dependencies
         run: npm ci
@@ -123,18 +122,18 @@ jobs:
         # SQS queue names have a max length of 80 and cannot contain special characters
         run: |
           queue_name=$(echo "$SAFE_BRANCH_NAME" | sed 's/[^[:alnum:]-]/\_/g' | cut -c1-60)
-          echo "queue_name=stubQueue_branch_$queue_name" >> $GITHUB_OUTPUT
+          echo "queue_name=stubQueue_branch_$queue_name" >> "$GITHUB_OUTPUT"
         id: extract_queue_name
 
       - name: Setup app secrets
         run: |
           cp ../local-running/core.local.secrets.template.yaml ../local-running/core.local.secrets.yaml && \
-          sed -i s/CIMIT_API_KEY/${{ secrets.API_KEY_CIMIT }}/ ../local-running/core.local.secrets.yaml && \
-          sed -i s/EVCS_API_KEY/${{ secrets.API_KEY_EVCS }}/ ../local-running/core.local.secrets.yaml && \
-          sed -i s/ASYNC_QUEUE_API_KEY/${{ secrets.ASYNC_QUEUE_API_KEY }}/ ../local-running/core.local.secrets.yaml && \
-          sed -i s/ASYNC_QUEUE_NAME/${{ steps.extract_queue_name.outputs.queue_name }}/ ../local-running/core.local.secrets.yaml && \
-          sed -i s/TICF_API_KEY/${{ secrets.TICF_API_KEY }}/ ../local-running/core.local.secrets.yaml
-          sed -i s/DCMAW_ASYNC_SECRET/${{ secrets.DCMAW_ASYNC_SECRET }}/ ../local-running/core.local.secrets.yaml
+          sed -i s/CIMIT_API_KEY/"${{ secrets.API_KEY_CIMIT }}"/ ../local-running/core.local.secrets.yaml && \
+          sed -i s/EVCS_API_KEY/"${{ secrets.API_KEY_EVCS }}"/ ../local-running/core.local.secrets.yaml && \
+          sed -i s/ASYNC_QUEUE_API_KEY/"${{ secrets.ASYNC_QUEUE_API_KEY }}"/ ../local-running/core.local.secrets.yaml && \
+          sed -i s/ASYNC_QUEUE_NAME/"${{ steps.extract_queue_name.outputs.queue_name }}"/ ../local-running/core.local.secrets.yaml && \
+          sed -i s/TICF_API_KEY/"${{ secrets.TICF_API_KEY }}"/ ../local-running/core.local.secrets.yaml && \
+          sed -i s/DCMAW_ASYNC_SECRET/"${{ secrets.DCMAW_ASYNC_SECRET }}"/ ../local-running/core.local.secrets.yaml
 
       - name: Local API tests
         env:
@@ -172,7 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11.2'
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       with:
         extra_args: "detect-secrets --all-files"
 

--- a/.github/workflows/secure-pipeline-api-tests-image.yml
+++ b/.github/workflows/secure-pipeline-api-tests-image.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@main
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
         with:
           cosign-release: 'v1.9.0'
 

--- a/.github/workflows/secure-pipeline-api-tests-image.yml
+++ b/.github/workflows/secure-pipeline-api-tests-image.yml
@@ -37,13 +37,13 @@ jobs:
           SHA: ${{ github.sha }}
           BUILD_CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
         run: |
-          docker build --build-arg GITHUB_PAT=${{ secrets.GITHUB_TOKEN }} \
-            -t $BUILD_ECR_REG/$BUILD_API_TESTS_ECR_REPO:latest \
-            -t $BUILD_ECR_REG/$BUILD_API_TESTS_ECR_REPO:$SHA \
+          docker build --build-arg GITHUB_PAT="${{ secrets.GITHUB_TOKEN }}" \
+            -t "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:latest" \
+            -t "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:${SHA}" \
             -f api-tests/secure-pipeline/api-tests.Dockerfile .
 
-          docker push $BUILD_ECR_REG/$BUILD_API_TESTS_ECR_REPO:latest
-          docker push $BUILD_ECR_REG/$BUILD_API_TESTS_ECR_REPO:$SHA
+          docker push "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:latest"
+          docker push "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:${SHA}"
 
-          cosign sign --key awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY} $BUILD_ECR_REG/$BUILD_API_TESTS_ECR_REPO:latest
-          cosign sign --key awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY} $BUILD_ECR_REG/$BUILD_API_TESTS_ECR_REPO:$SHA
+          cosign sign --key "awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY}" "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:latest"
+          cosign sign --key "awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY}" "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:${SHA}"

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -76,7 +76,7 @@ jobs:
           python-version: "3.8"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
         with:
           gradle-version: 8.2.1
 

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           CHANGED_FILES: ${{ steps.get-changed-files.outputs.all_changed_files }}
         run: |
-          for file in ${CHANGED_FILES}; do
+          for file in $CHANGED_FILES; do
             echo "$file was changed"
           done
 
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -80,11 +80,12 @@ jobs:
         with:
           gradle-version: 8.2.1
 
-      - name: Set up SAM cli
+      - name: Set up SAM CLI
         uses: aws-actions/setup-sam@v2
 
-      - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
-        run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
+      - name: Fix SAM cryptography issue https://github.com/aws/aws-sam-cli/issues/4527
+        run: |
+          "$(dirname "$(readlink "$(which sam)")")/pip" install --force-reinstall "cryptography==38.0.4"
 
       - name: Set up AWS creds For Pipeline
         uses: aws-actions/configure-aws-credentials@v4
@@ -94,7 +95,7 @@ jobs:
 
       - name: SAM validate
         working-directory: ./deploy
-        run: sam validate --region ${{ env.AWS_REGION }}
+        run: sam validate --region "${{ env.AWS_REGION }}"
 
       - name: SAM build and test
         working-directory: ./deploy


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

For any action that doesn’t start with actions or aws-actions we need to find the commit SHA for the version currently in use and update the line use that SHA value.

### Why did it change

Commit SHAs for third-party GitHub Actions to guarantee the exact code version being run, prevent supply chain attacks from tag re-pointing, and ensure that even if a repository is compromised, our workflows remain secure and immutable.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8262](https://govukverify.atlassian.net/browse/PYIC-8262)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[PYIC-8262]: https://govukverify.atlassian.net/browse/PYIC-8262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ