### PR TITLE
PYIC-8263: Update get cred bundle to filter invalid async VCs

### DIFF
--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -168,13 +168,25 @@ Feature: P2 F2F journey
 
   Scenario: F2F PYI escape route
     Given I start a new 'medium-confidence' journey
-      Then I get a 'live-in-uk' page response
-      When I submit a 'uk' event
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'end' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'page-ipv-identity-postoffice-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-no-photo-id' page response
+
+  Scenario: F2F discounts VC when no associated pending record
+    Given the subject already has the following credentials
+      | CRI     | scenario               |
+      | f2f     | kenneth-passport-valid |
+      | address | kenneth-current        |
+      | fraud   | kenneth-no-applicable  |
+
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
 
   Rule: F2F evidence requested strength score
     Background: User has pending F2F verification

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -181,7 +181,7 @@ Feature: P2 F2F journey
       | CRI     | scenario               |
       | f2f     | kenneth-passport-valid |
       | address | kenneth-current        |
-      | fraud   | kenneth-no-applicable  |
+      | fraud   | kenneth-score-2        |
 
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -97,6 +97,7 @@ public class CheckExistingIdentityHandler
         implements RequestHandler<JourneyRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
 
+    private static final List<Cri> ASYNC_CRIS = List.of(F2F, DCMAW_ASYNC);
     private static final JourneyResponse JOURNEY_REUSE = new JourneyResponse(JOURNEY_REUSE_PATH);
     private static final JourneyResponse JOURNEY_REUSE_WITH_STORE =
             new JourneyResponse(JOURNEY_REUSE_WITH_STORE_PATH);
@@ -386,7 +387,7 @@ public class CheckExistingIdentityHandler
                 evcsService.fetchEvcsVerifiableCredentialsByState(
                         userId, evcsAccessToken, CURRENT, PENDING_RETURN);
 
-        // PENDING_RETURN vcs need a pending record to be valid
+        // PENDING_RETURN async vcs need a pending record to be valid
         var pendingRecordCris =
                 criResponseService.getCriResponseItems(userId).stream()
                         .map(CriResponseItem::getCredentialIssuer)
@@ -394,7 +395,10 @@ public class CheckExistingIdentityHandler
                         .toList();
         var validPendingReturnVcs =
                 vcs.getOrDefault(PENDING_RETURN, List.of()).stream()
-                        .filter(vc -> pendingRecordCris.contains(vc.getCri()))
+                        .filter(
+                                vc ->
+                                        !ASYNC_CRIS.contains(vc.getCri())
+                                                || pendingRecordCris.contains(vc.getCri()))
                         .toList();
         var hasValidPendingReturnVcs = !isNullOrEmpty(validPendingReturnVcs);
 

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -393,7 +393,7 @@ public class CheckExistingIdentityHandler
                         .map(Cri::fromId)
                         .toList();
         var validPendingReturnVcs =
-                vcs.get(PENDING_RETURN).stream()
+                vcs.getOrDefault(PENDING_RETURN, List.of()).stream()
                         .filter(vc -> pendingRecordCris.contains(vc.getCri()))
                         .toList();
         var hasValidPendingReturnVcs = !isNullOrEmpty(validPendingReturnVcs);

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -364,10 +364,17 @@ class CheckExistingIdentityHandlerTest {
 
         @Test
         void shouldReturnJourneyReuseWithStoreResponseIfIsF2fPendingReturn() throws Exception {
-            var vcs = List.of(gpg45Vc, vcF2fPassportPhotoM1a());
+            var vcs = List.of(f2fVc);
             when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
+            when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                    .thenReturn(
+                            List.of(
+                                    CriResponseItem.builder()
+                                            .credentialIssuer(F2F.getId())
+                                            .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                            .build()));
             when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, true))
                     .thenReturn(emptyAsyncCriStatus);
             when(mockVotMatcher.matchFirstVot(List.of(P2), vcs, List.of(), true))
@@ -387,11 +394,18 @@ class CheckExistingIdentityHandlerTest {
         @Test
         void shouldIncludeCurrentInheritedIdentityInVcBundleWhenPendingReturn() throws Exception {
             var inheritedIdentityVc = vcHmrcMigrationPCL200();
-            var vcs = List.of(gpg45Vc, f2fVc);
+            var vcs = List.of(f2fVc);
             when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs, CURRENT, List.of(inheritedIdentityVc)));
-            var combinedVcs = List.of(inheritedIdentityVc, gpg45Vc, f2fVc);
+            var combinedVcs = List.of(inheritedIdentityVc, f2fVc);
+            when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                    .thenReturn(
+                            List.of(
+                                    CriResponseItem.builder()
+                                            .credentialIssuer(F2F.getId())
+                                            .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                            .build()));
             when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, combinedVcs, true))
                     .thenReturn(emptyAsyncCriStatus);
 
@@ -590,6 +604,13 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
+        when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                CriResponseItem.builder()
+                                        .credentialIssuer(F2F.getId())
+                                        .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                        .build()));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
                 .thenReturn(
                         new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
@@ -626,6 +647,13 @@ class CheckExistingIdentityHandlerTest {
         when(criResponseService.getCriResponseItem(TEST_USER_ID, DCMAW_ASYNC))
                 .thenReturn(
                         CriResponseItem.builder().oauthState(TEST_CRI_OAUTH_SESSION_ID).build());
+        when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                CriResponseItem.builder()
+                                        .credentialIssuer(DCMAW_ASYNC.getId())
+                                        .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                        .build()));
         when(criOAuthSessionService.getCriOauthSessionItem(TEST_CRI_OAUTH_SESSION_ID))
                 .thenReturn(
                         CriOAuthSessionItem.builder()
@@ -688,6 +716,13 @@ class CheckExistingIdentityHandlerTest {
         when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(PENDING_RETURN, List.of(vcDcmawAsyncDrivingPermitDva())));
+        when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                CriResponseItem.builder()
+                                        .credentialIssuer(DCMAW_ASYNC.getId())
+                                        .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                        .build()));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
                 .thenReturn(emptyAsyncCriStatus);
         when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
@@ -920,6 +955,13 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
+        when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                CriResponseItem.builder()
+                                        .credentialIssuer(F2F.getId())
+                                        .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                        .build()));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
                 .thenReturn(
                         new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
@@ -949,6 +991,13 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
+        when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                CriResponseItem.builder()
+                                        .credentialIssuer(F2F.getId())
+                                        .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                        .build()));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
                 .thenReturn(
                         new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
@@ -977,6 +1026,13 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
+        when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                CriResponseItem.builder()
+                                        .credentialIssuer(F2F.getId())
+                                        .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                        .build()));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
                 .thenReturn(emptyAsyncCriStatus);
         when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -1252,10 +1308,17 @@ class CheckExistingIdentityHandlerTest {
         @Test
         void shouldNotReturnReproveJourneyIfUserHasPendingF2FWithReproveFlag() throws Exception {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
-            var vcs = new ArrayList<>(List.of(gpg45Vc));
+            var vcs = new ArrayList<>(List.of(f2fVc));
             when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
+            when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                    .thenReturn(
+                            List.of(
+                                    CriResponseItem.builder()
+                                            .credentialIssuer(F2F.getId())
+                                            .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                            .build()));
             when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, vcs, true))
                     .thenReturn(
                             new AsyncCriStatus(
@@ -1340,6 +1403,13 @@ class CheckExistingIdentityHandlerTest {
                         TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                 .thenReturn(
                         Map.of(PENDING_RETURN, new ArrayList<>(List.of(vcF2fPassportPhotoM1a()))));
+        when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                .thenReturn(
+                        List.of(
+                                CriResponseItem.builder()
+                                        .credentialIssuer(F2F.getId())
+                                        .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                        .build()));
         when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
                 .thenReturn(
                         new AsyncCriStatus(F2F, AsyncCriStatus.STATUS_PENDING, false, true, false));
@@ -1352,6 +1422,33 @@ class CheckExistingIdentityHandlerTest {
                         JourneyResponse.class);
 
         assertEquals(JOURNEY_F2F_FAIL_PATH, journeyResponse.getJourney());
+    }
+
+    @Test
+    void shouldReturnNewIdentityJourneyWhenPendingReturnVcNotAssociatedWithPendingRecord()
+            throws Exception {
+        // Arrange
+        when(ipvSessionService.getIpvSessionWithRetry(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(clientOAuthSessionDetailsService.getClientOAuthSession(TEST_CLIENT_OAUTH_SESSION_ID))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
+                        TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
+                .thenReturn(Map.of(PENDING_RETURN, new ArrayList<>(List.of(f2fVc))));
+        when(criResponseService.getCriResponseItems(TEST_USER_ID)).thenReturn(List.of());
+        when(criResponseService.getAsyncResponseStatus(TEST_USER_ID, List.of(), false))
+                .thenReturn(
+                        new AsyncCriStatus(
+                                F2F, AsyncCriStatus.STATUS_PENDING, false, false, false));
+        when(cimitUtilityService.isBreachingCiThreshold(List.of(), P2)).thenReturn(false);
+
+        // Act
+        var journeyResponse =
+                toResponseClass(
+                        checkExistingIdentityHandler.handleRequest(event, context),
+                        JourneyResponse.class);
+
+        // Assert
+        assertEquals(JOURNEY_IPV_GPG45_MEDIUM_PATH, journeyResponse.getJourney());
     }
 
     @Test

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -364,7 +364,7 @@ class CheckExistingIdentityHandlerTest {
 
         @Test
         void shouldReturnJourneyReuseWithStoreResponseIfIsF2fPendingReturn() throws Exception {
-            var vcs = List.of(f2fVc);
+            var vcs = List.of(gpg45Vc, vcF2fPassportPhotoM1a());
             when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
@@ -394,11 +394,11 @@ class CheckExistingIdentityHandlerTest {
         @Test
         void shouldIncludeCurrentInheritedIdentityInVcBundleWhenPendingReturn() throws Exception {
             var inheritedIdentityVc = vcHmrcMigrationPCL200();
-            var vcs = List.of(f2fVc);
+            var vcs = List.of(gpg45Vc, f2fVc);
             when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs, CURRENT, List.of(inheritedIdentityVc)));
-            var combinedVcs = List.of(inheritedIdentityVc, f2fVc);
+            var combinedVcs = List.of(inheritedIdentityVc, gpg45Vc, f2fVc);
             when(criResponseService.getCriResponseItems(TEST_USER_ID))
                     .thenReturn(
                             List.of(

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseService.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseService.java
@@ -51,7 +51,11 @@ public class CriResponseService {
     }
 
     public List<CriResponseItem> getCriResponseItems(String userId) {
-        return dataStore.getItems(userId);
+        var criResponseItems = dataStore.getItems(userId);
+        if (criResponseItems == null) {
+            return List.of();
+        }
+        return criResponseItems;
     }
 
     public CriResponseItem getCriResponseItem(String userId, Cri cri) {

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseService.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseService.java
@@ -50,6 +50,10 @@ public class CriResponseService {
                 .findFirst();
     }
 
+    public List<CriResponseItem> getCriResponseItems(String userId) {
+        return dataStore.getItems(userId);
+    }
+
     public CriResponseItem getCriResponseItem(String userId, Cri cri) {
         return dataStore.getItem(userId, cri.getId());
     }

--- a/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseServiceTest.java
+++ b/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseServiceTest.java
@@ -154,6 +154,34 @@ class CriResponseServiceTest {
         assertEquals(criResponseItem2, criResponseItem.get());
     }
 
+    @Test
+    void getCriResponseItemsShouldGetCorrectItems() {
+        // Arrange
+        var expectedCriResponseItems =
+                List.of(
+                        createCriResponseStoreItem(vcWebPassportSuccessful(), Instant.now()),
+                        createCriResponseStoreItem(vcWebPassportSuccessful(), Instant.now()));
+        when(mockDataStore.getItems(USER_ID_1)).thenReturn(expectedCriResponseItems);
+
+        // Act
+        var criResponseItems = criResponseService.getCriResponseItems(USER_ID_1);
+
+        // Assert
+        assertEquals(expectedCriResponseItems, criResponseItems);
+    }
+
+    @Test
+    void getCriResponseItemsShouldDefaultToEmptyList() {
+        // Arrange
+        when(mockDataStore.getItems(USER_ID_1)).thenReturn(null);
+
+        // Act
+        var criResponseItems = criResponseService.getCriResponseItems(USER_ID_1);
+
+        // Assert
+        assertEquals(List.of(), criResponseItems);
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void getF2FAsyncResponseStatusShouldGetStatus(boolean hasVc) {


### PR DESCRIPTION
## Proposed changes

### What changed

- Update get cred bundle to filter invalid async VCs

### Why did it change

- Async VCs should be discounted if no CriResponseItem

### Issue tracking

- [PYIC-8263](https://govukverify.atlassian.net/browse/PYIC-8263)

[PYIC-8263]: https://govukverify.atlassian.net/browse/PYIC-8263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ