### PR TITLE
PYIC-8189: Update MAM journey fails without a VC to enable a successful callback

### DIFF
--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -112,24 +112,6 @@ Feature: M2B Strategic App Journeys
       When I submit the returned journey event
       Then I get an 'pyi-no-match' page response
 
-    Scenario: MAM journey fails without a VC
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
-      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-      # To fetch the oauth state to callback with
-      When the async DCMAW CRI produces a 'pending' error response
-      And I pass on the DCMAW callback
-      Then I get an 'check-mobile-app-result' page response
-      # To update the state for an error
-      When the async DCMAW CRI produces an 'error' error response
-      And I poll for async DCMAW credential receipt
-      Then the poll returns a '201'
-      When I submit the returned journey event
-      Then I get an 'pyi-technical' page response
-
     Scenario: MAM journey abandoned without a VC
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -119,11 +119,13 @@ Feature: M2B Strategic App Journeys
       Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
       When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-      When the async DCMAW CRI produces an 'error' error response
-      # And the user returns from the app to core-front
+      # To fetch the oauth state to callback with
+      When the async DCMAW CRI produces a 'pending' error response
       And I pass on the DCMAW callback
       Then I get an 'check-mobile-app-result' page response
-      When I poll for async DCMAW credential receipt
+      # To update the state for an error
+      When the async DCMAW CRI produces an 'error' error response
+      And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
       Then I get an 'pyi-technical' page response


### PR DESCRIPTION
## Proposed changes

### What changed

- Update MAM journey fails without a VC to enable a successful callback

### Why did it change

- .

### Issue tracking

- [PYIC-8189](https://govukverify.atlassian.net/browse/PYIC-8189)

[PYIC-8189]: https://govukverify.atlassian.net/browse/PYIC-8189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ