### PR TITLE
PYIC-8099 Redirect journey map to aws

### DIFF
--- a/.github/workflows/journey-map.yml
+++ b/.github/workflows/journey-map.yml
@@ -1,5 +1,4 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy Journey Map
 
 on:
   # Runs on pushes targeting the default branch
@@ -34,14 +33,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Copy yaml
-        run: 'cp -r ./lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/* ./journey-map/public/'
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './journey-map/public/'
+          path: './journey-map/redirect/'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/journey-map/redirect/index.html
+++ b/journey-map/redirect/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>IPV Core Journey Map</title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      The IPV Core journey map is now located at:
+      <a href="https://journey-map.stubs.account.gov.uk/"
+        >https://journey-map.stubs.account.gov.uk/</a
+      >
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
## Proposed changes

### What changed

Replace github pages version of journey map with new domain

### Why did it change

Direct people to the new domain

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8099](https://govukverify.atlassian.net/browse/PYIC-8099)


[PYIC-8099]: https://govukverify.atlassian.net/browse/PYIC-8099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ