### PR TITLE
PYIC-8252: update core-back to use new PUT endpoint on EVCS

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2589,6 +2589,12 @@ Resources:
                 - 'kms:GenerateDataKey'
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
+            - Sid: kmsSigningKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:sign'
+              Resource:
+                - !ImportValue SigningKeyArn
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBCrudPolicy:

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -195,7 +195,6 @@ public class ProcessCandidateIdentityHandler
         this.evcsService = evcsService;
     }
 
-    @SuppressWarnings("java:S3776") // Cognitive Complexity of methods should not be too high
     @Override
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
@@ -313,6 +312,7 @@ public class ProcessCandidateIdentityHandler
         return CoiCheckType.STANDARD;
     }
 
+    @SuppressWarnings("java:S3776") // Cognitive Complexity of methods should not be too high
     private Map<String, Object> processCandidateThroughJourney(
             CandidateIdentityType processIdentityType,
             IpvSessionItem ipvSessionItem,

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -195,6 +195,7 @@ public class ProcessCandidateIdentityHandler
         this.evcsService = evcsService;
     }
 
+    @SuppressWarnings("java:S3776") // Cognitive Complexity of methods should not be too high
     @Override
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/domain/SharedAuditEventParameters.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/domain/SharedAuditEventParameters.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.core.processcandidateidentity.domain;
+
+import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
+
+public record SharedAuditEventParameters(AuditEventUser auditEventUser, String deviceInformation) {}

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiService.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
-import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionCoiCheck;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedCheckCoi;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
@@ -27,6 +26,7 @@ import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.useridentity.service.UserIdentityService;
+import uk.gov.di.ipv.core.processcandidateidentity.domain.SharedAuditEventParameters;
 import uk.gov.di.model.PostalAddress;
 
 import java.util.List;
@@ -74,10 +74,9 @@ public class CheckCoiService {
             IpvSessionItem ipvSessionItem,
             ClientOAuthSessionItem clientOAuthSession,
             CoiCheckType checkType,
-            String deviceInformation,
             List<VerifiableCredential> sessionVcs,
-            AuditEventUser auditEventUser,
-            List<EvcsGetUserVCDto> evcsUserVcs)
+            List<EvcsGetUserVCDto> evcsUserVcs,
+            SharedAuditEventParameters sharedAuditEventParameters)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException {
 
         var userId = clientOAuthSession.getUserId();
@@ -93,10 +92,9 @@ public class CheckCoiService {
                 AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_START,
                 checkType,
                 null,
-                auditEventUser,
                 null,
                 null,
-                deviceInformation);
+                sharedAuditEventParameters);
 
         var oldVcs = evcsService.getVerifiableCredentials(userId, evcsUserVcs, CURRENT);
         var combinedCredentials = Stream.concat(oldVcs.stream(), sessionVcs.stream()).toList();
@@ -114,10 +112,9 @@ public class CheckCoiService {
                 AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_END,
                 checkType,
                 successfulCheck,
-                auditEventUser,
                 oldVcs,
                 sessionVcs,
-                deviceInformation);
+                sharedAuditEventParameters);
 
         if (clientOAuthSession.isReverification()) {
             ipvSessionItem.setReverificationStatus(
@@ -148,11 +145,12 @@ public class CheckCoiService {
             AuditEventTypes auditEventType,
             CoiCheckType coiCheckType,
             Boolean coiCheckSuccess,
-            AuditEventUser auditEventUser,
             List<VerifiableCredential> oldVcs,
             List<VerifiableCredential> sessionsVcs,
-            String deviceInformation)
+            SharedAuditEventParameters sharedAuditEventParameters)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException {
+        var deviceInformation = sharedAuditEventParameters.deviceInformation();
+        var auditEventUser = sharedAuditEventParameters.auditEventUser();
 
         var restrictedData =
                 auditEventType == AuditEventTypes.IPV_CONTINUITY_OF_IDENTITY_CHECK_END

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -15,8 +15,6 @@ import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.evcs.service.EvcsService;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
-import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
@@ -49,40 +47,39 @@ public class StoreIdentityService {
 
     @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public void storeIdentity(
-            IpvSessionItem ipvSessionItem,
-            ClientOAuthSessionItem clientOAuthSessionItem,
+            Vot achievedVot,
+            String userId,
             CandidateIdentityType identityType,
             String deviceInformation,
             List<VerifiableCredential> credentials,
             AuditEventUser auditEventUser,
             List<EvcsGetUserVCDto> evcsVcs,
-            VotMatchingResult matchingVot)
+            VotMatchingResult.VotAndProfile strongestMatchedVot)
             throws EvcsServiceException {
         if (identityType == CandidateIdentityType.PENDING) {
-            evcsService.storePendingIdentity(clientOAuthSessionItem, credentials, evcsVcs);
+            evcsService.storePendingIdentity(userId, credentials, evcsVcs, achievedVot);
         } else {
             evcsService.storeCompletedIdentity(
-                    clientOAuthSessionItem, credentials, evcsVcs, matchingVot);
+                    userId, credentials, evcsVcs, strongestMatchedVot, achievedVot);
         }
 
         LOGGER.info(LogHelper.buildLogMessage("Identity successfully stored"));
 
-        sendIdentityStoredEvent(ipvSessionItem, identityType, deviceInformation, auditEventUser);
+        sendIdentityStoredEvent(achievedVot, identityType, deviceInformation, auditEventUser);
     }
 
     private void sendIdentityStoredEvent(
-            IpvSessionItem ipvSessionItem,
+            Vot achievedVot,
             CandidateIdentityType identityType,
             String deviceInformation,
             AuditEventUser auditEventUser) {
-        Vot vot = ipvSessionItem.getVot();
         auditService.sendAuditEvent(
                 AuditEvent.createWithDeviceInformation(
                         IPV_IDENTITY_STORED,
                         configService.getParameter(ConfigurationVariable.COMPONENT_ID),
                         auditEventUser,
                         new AuditExtensionCandidateIdentityType(
-                                identityType, vot.equals(P0) ? null : vot),
+                                identityType, achievedVot.equals(P0) ? null : achievedVot),
                         new AuditRestrictedDeviceInformation(deviceInformation)));
     }
 }

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -47,6 +47,7 @@ public class StoreIdentityService {
         this.evcsService = evcsService;
     }
 
+    @SuppressWarnings("java:S107") // Methods should not have too many parameters
     public void storeIdentity(
             IpvSessionItem ipvSessionItem,
             ClientOAuthSessionItem clientOAuthSessionItem,

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -15,9 +15,11 @@ import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.evcs.service.EvcsService;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
+import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
 
 import java.util.List;
 
@@ -47,17 +49,19 @@ public class StoreIdentityService {
 
     public void storeIdentity(
             IpvSessionItem ipvSessionItem,
-            String userId,
+            ClientOAuthSessionItem clientOAuthSessionItem,
             CandidateIdentityType identityType,
             String deviceInformation,
             List<VerifiableCredential> credentials,
             AuditEventUser auditEventUser,
-            List<EvcsGetUserVCDto> evcsVcs)
+            List<EvcsGetUserVCDto> evcsVcs,
+            VotMatchingResult matchingVot)
             throws EvcsServiceException {
         if (identityType == CandidateIdentityType.PENDING) {
-            evcsService.storePendingIdentity(userId, credentials, evcsVcs);
+            evcsService.storePendingIdentity(clientOAuthSessionItem, credentials, evcsVcs);
         } else {
-            evcsService.storeCompletedIdentity(userId, credentials, evcsVcs);
+            evcsService.storeCompletedIdentity(
+                    clientOAuthSessionItem, credentials, evcsVcs, matchingVot);
         }
 
         LOGGER.info(LogHelper.buildLogMessage("Identity successfully stored"));

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -170,9 +170,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(votMatcher.findStrongestMatches(anyList(), eq(List.of()), eq(List.of()), eq(true)))
@@ -234,9 +233,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(configService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, Cri.TICF.getId()))
@@ -304,9 +302,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(configService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, Cri.TICF.getId()))
@@ -363,9 +360,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(REVERIFICATION),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(configService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, Cri.TICF.getId()))
@@ -439,7 +435,7 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(0))
                     .storeIdentity(any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
-                    .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
+                    .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any());
         }
 
         @Test
@@ -471,7 +467,7 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(0))
                     .storeIdentity(any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
-                    .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
+                    .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any());
         }
 
         @Test
@@ -508,7 +504,7 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(0))
                     .storeIdentity(any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
-                    .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
+                    .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any());
         }
 
         @Test
@@ -519,9 +515,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(votMatcher.findStrongestMatches(anyList(), eq(List.of()), eq(List.of()), eq(true)))
@@ -599,7 +594,7 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(0))
                     .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
-                    .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
+                    .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any());
             verify(ticfCriService, times(0)).getTicfVc(any(), any());
         }
 
@@ -616,9 +611,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(false);
 
@@ -651,9 +645,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(userIdentityService.areVcsCorrelated(List.of())).thenReturn(false);
@@ -687,9 +680,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(votMatcher.findStrongestMatches(anyList(), eq(List.of()), eq(List.of()), eq(true)))
@@ -721,9 +713,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(votMatcher.findStrongestMatches(anyList(), eq(List.of()), eq(ticfCis), eq(true)))
@@ -773,9 +764,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(votMatcher.findStrongestMatches(anyList(), eq(List.of()), eq(ticfCis), eq(true)))
@@ -829,9 +819,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(reproveIdentityClientOAuthSessionItem),
                             eq(ACCOUNT_INTERVENTION),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(votMatcher.findStrongestMatches(anyList(), eq(List.of()), eq(List.of()), eq(true)))
@@ -886,8 +875,7 @@ class ProcessCandidateIdentityHandlerTest {
                             EvcsVCState.CURRENT,
                             EvcsVCState.PENDING_RETURN))
                     .thenReturn(List.of());
-            when(checkCoiService.isCoiCheckSuccessful(
-                            any(), any(), any(), any(), any(), any(), any()))
+            when(checkCoiService.isCoiCheckSuccessful(any(), any(), any(), any(), any(), any()))
                     .thenThrow(new CredentialParseException("Unable to parse credentials"));
 
             var request =
@@ -921,9 +909,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(userIdentityService.areVcsCorrelated(List.of())).thenReturn(true);
@@ -962,9 +949,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
 
@@ -1000,9 +986,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(votMatcher.findStrongestMatches(anyList(), eq(List.of()), eq(List.of()), eq(true)))
@@ -1048,9 +1033,8 @@ class ProcessCandidateIdentityHandlerTest {
                             eq(ipvSessionItem),
                             eq(clientOAuthSessionItem),
                             eq(STANDARD),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
+                            any(),
                             any()))
                     .thenReturn(true);
             when(votMatcher.findStrongestMatches(anyList(), eq(List.of()), eq(List.of()), eq(true)))

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -203,11 +203,12 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(1))
                     .storeIdentity(
                             eq(ipvSessionItem),
-                            eq(USER_ID),
+                            eq(clientOAuthSessionItem),
                             eq(CandidateIdentityType.NEW),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
                             any(AuditEventUser.class),
+                            any(),
                             any());
             verify(criStoringService, times(1))
                     .storeVcs(
@@ -275,11 +276,12 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(1))
                     .storeIdentity(
                             eq(ipvSessionItem),
-                            eq(USER_ID),
+                            eq(clientOAuthSessionItem),
                             eq(CandidateIdentityType.PENDING),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
                             any(AuditEventUser.class),
+                            any(),
                             any());
             verify(criStoringService, times(1))
                     .storeVcs(
@@ -337,11 +339,12 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(1))
                     .storeIdentity(
                             eq(ipvSessionItem),
-                            eq(USER_ID),
+                            eq(clientOAuthSessionItem),
                             eq(CandidateIdentityType.PENDING),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
                             any(AuditEventUser.class),
+                            any(),
                             any());
             verify(criStoringService, times(1))
                     .storeVcs(
@@ -399,7 +402,7 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
             verify(criStoringService, times(1))
                     .storeVcs(
                             eq(Cri.TICF),
@@ -441,7 +444,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_NEXT.getJourney(), response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
                     .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
         }
@@ -473,7 +476,7 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
                     .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
         }
@@ -510,7 +513,7 @@ class ProcessCandidateIdentityHandlerTest {
             verify(cimitService, times(2)).fetchContraIndicatorsVc(any(), any(), any(), any());
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
                     .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
         }
@@ -561,11 +564,12 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(1))
                     .storeIdentity(
                             eq(ipvSessionItem),
-                            eq(USER_ID),
+                            eq(clientOAuthSessionItem),
                             eq(CandidateIdentityType.UPDATE),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
                             any(AuditEventUser.class),
+                            any(),
                             any());
             verify(criStoringService, times(1))
                     .storeVcs(
@@ -601,7 +605,7 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
                     .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
             verify(ticfCriService, times(0)).getTicfVc(any(), any());
@@ -639,7 +643,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_COI_CHECK_FAILED_PATH, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
         }
 
         @Test
@@ -675,7 +679,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_VCS_NOT_CORRELATED, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
         }
 
         @Test
@@ -713,7 +717,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_PROFILE_UNMET_PATH, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
         }
 
         @Test
@@ -765,7 +769,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_FAIL_WITH_CI_PATH, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
         }
 
         @Test
@@ -817,7 +821,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_FAIL_WITH_CI_PATH, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
         }
 
         @Test
@@ -863,12 +867,13 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(1))
                     .storeIdentity(
                             eq(ipvSessionItem),
-                            eq(USER_ID),
+                            eq(reproveIdentityClientOAuthSessionItem),
                             eq(CandidateIdentityType.NEW),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
                             any(AuditEventUser.class),
-                            any());
+                            eq(List.of()),
+                            eq(P2_M1A_VOT_MATCH_RESULT));
             verify(criStoringService, times(1))
                     .storeVcs(
                             eq(Cri.TICF),
@@ -909,7 +914,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(FAILED_TO_PARSE_ISSUED_CREDENTIALS.getMessage(), response.get("message"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
         }
 
         @Test
@@ -949,7 +954,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(FAILED_TO_EXTRACT_CIS_FROM_VC.getMessage(), response.get("message"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
         }
 
         @Test
@@ -987,7 +992,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(MISSING_SECURITY_CHECK_CREDENTIAL.getMessage(), response.get("message"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
         }
 
         @Test
@@ -1035,7 +1040,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(ERROR_PROCESSING_TICF_CRI_RESPONSE.getMessage(), response.get("message"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
         }
 
         @Test
@@ -1072,7 +1077,7 @@ class ProcessCandidateIdentityHandlerTest {
                             new EvcsServiceException(
                                     SC_SERVER_ERROR, RECEIVED_NON_200_RESPONSE_STATUS_CODE))
                     .when(storeIdentityService)
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
 
             var request =
                     requestBuilder

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -205,13 +205,12 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(storeIdentityService, times(1))
                     .storeIdentity(
-                            eq(P2),
                             eq(USER_ID),
-                            eq(CandidateIdentityType.NEW),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
-                            any(),
+                            eq(List.of()),
+                            eq(P2),
+                            eq(STRONGEST_MATCHED_VOT),
+                            eq(CandidateIdentityType.NEW),
                             any());
             verify(criStoringService, times(1))
                     .storeVcs(
@@ -278,13 +277,12 @@ class ProcessCandidateIdentityHandlerTest {
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(1))
                     .storeIdentity(
-                            eq(P0),
                             eq(USER_ID),
-                            eq(CandidateIdentityType.PENDING),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
-                            any(),
+                            eq(List.of()),
+                            eq(P0),
+                            eq(null),
+                            eq(CandidateIdentityType.PENDING),
                             any());
             verify(criStoringService, times(1))
                     .storeVcs(
@@ -340,15 +338,7 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(1))
-                    .storeIdentity(
-                            eq(P2),
-                            eq(USER_ID),
-                            eq(CandidateIdentityType.PENDING),
-                            eq(DEVICE_INFORMATION),
-                            eq(List.of()),
-                            any(AuditEventUser.class),
-                            any(),
-                            any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
             verify(criStoringService, times(1))
                     .storeVcs(
                             eq(Cri.TICF),
@@ -405,7 +395,7 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
             verify(criStoringService, times(1))
                     .storeVcs(
                             eq(Cri.TICF),
@@ -447,7 +437,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_NEXT.getJourney(), response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
                     .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
         }
@@ -479,7 +469,7 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
                     .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
         }
@@ -516,7 +506,7 @@ class ProcessCandidateIdentityHandlerTest {
             verify(cimitService, times(2)).fetchContraIndicatorsVc(any(), any(), any(), any());
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), any(), any(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
                     .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
         }
@@ -566,13 +556,12 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(storeIdentityService, times(1))
                     .storeIdentity(
-                            eq(P2),
                             eq(USER_ID),
-                            eq(CandidateIdentityType.UPDATE),
-                            eq(DEVICE_INFORMATION),
                             eq(List.of()),
-                            any(AuditEventUser.class),
-                            any(),
+                            eq(List.of()),
+                            eq(P2),
+                            eq(STRONGEST_MATCHED_VOT),
+                            eq(CandidateIdentityType.UPDATE),
                             any());
             verify(criStoringService, times(1))
                     .storeVcs(
@@ -608,7 +597,7 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), any(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
             verify(checkCoiService, times(0))
                     .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any(), any());
             verify(ticfCriService, times(0)).getTicfVc(any(), any());
@@ -646,7 +635,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_COI_CHECK_FAILED_PATH, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
         }
 
         @Test
@@ -682,7 +671,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_VCS_NOT_CORRELATED, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
         }
 
         @Test
@@ -720,7 +709,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_PROFILE_UNMET_PATH, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
         }
 
         @Test
@@ -772,7 +761,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_FAIL_WITH_CI_PATH, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
         }
 
         @Test
@@ -824,7 +813,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(JOURNEY_FAIL_WITH_CI_PATH, response.get("journey"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
         }
 
         @Test
@@ -869,14 +858,13 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(storeIdentityService, times(1))
                     .storeIdentity(
-                            eq(P2),
                             eq(USER_ID),
+                            eq(List.of()),
+                            eq(List.of()),
+                            eq(P2),
+                            eq(STRONGEST_MATCHED_VOT),
                             eq(CandidateIdentityType.NEW),
-                            eq(DEVICE_INFORMATION),
-                            eq(List.of()),
-                            any(AuditEventUser.class),
-                            eq(List.of()),
-                            eq(STRONGEST_MATCHED_VOT));
+                            any());
             verify(criStoringService, times(1))
                     .storeVcs(
                             eq(Cri.TICF),
@@ -917,7 +905,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(FAILED_TO_PARSE_ISSUED_CREDENTIALS.getMessage(), response.get("message"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
         }
 
         @Test
@@ -957,7 +945,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(FAILED_TO_EXTRACT_CIS_FROM_VC.getMessage(), response.get("message"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
         }
 
         @Test
@@ -995,7 +983,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(MISSING_SECURITY_CHECK_CREDENTIAL.getMessage(), response.get("message"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
         }
 
         @Test
@@ -1043,7 +1031,7 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(ERROR_PROCESSING_TICF_CRI_RESPONSE.getMessage(), response.get("message"));
 
             verify(storeIdentityService, times(0))
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
         }
 
         @Test
@@ -1080,7 +1068,7 @@ class ProcessCandidateIdentityHandlerTest {
                             new EvcsServiceException(
                                     SC_SERVER_ERROR, RECEIVED_NON_200_RESPONSE_STATUS_CODE))
                     .when(storeIdentityService)
-                    .storeIdentity(any(), any(), any(), any(), anyList(), any(), any(), any());
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
 
             var request =
                     requestBuilder

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -74,6 +74,7 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNEXPECTED_PROCESS
 import static uk.gov.di.ipv.core.library.enums.CoiCheckType.ACCOUNT_INTERVENTION;
 import static uk.gov.di.ipv.core.library.enums.CoiCheckType.REVERIFICATION;
 import static uk.gov.di.ipv.core.library.enums.CoiCheckType.STANDARD;
+import static uk.gov.di.ipv.core.library.enums.Vot.P0;
 import static uk.gov.di.ipv.core.library.enums.Vot.P2;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CIMIT_VC_NO_CI;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcTicf;
@@ -90,10 +91,12 @@ import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_VCS_NOT_CO
 class ProcessCandidateIdentityHandlerTest {
     private static ProcessRequest.ProcessRequestBuilder requestBuilder;
 
+    private static final VotMatchingResult.VotAndProfile STRONGEST_MATCHED_VOT =
+            new VotMatchingResult.VotAndProfile(P2, Optional.of(M1A));
     private static final VotMatchingResult P2_M1A_VOT_MATCH_RESULT =
             new VotMatchingResult(
-                    Optional.of(new VotMatchingResult.VotAndProfile(P2, Optional.of(M1A))),
-                    Optional.of(new VotMatchingResult.VotAndProfile(P2, Optional.of(M1A))),
+                    Optional.of(STRONGEST_MATCHED_VOT),
+                    Optional.of(STRONGEST_MATCHED_VOT),
                     M1A.getScores());
 
     private static final String SESSION_ID = "session-id";
@@ -202,8 +205,8 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(storeIdentityService, times(1))
                     .storeIdentity(
-                            eq(ipvSessionItem),
-                            eq(clientOAuthSessionItem),
+                            eq(P2),
+                            eq(USER_ID),
                             eq(CandidateIdentityType.NEW),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
@@ -275,8 +278,8 @@ class ProcessCandidateIdentityHandlerTest {
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(1))
                     .storeIdentity(
-                            eq(ipvSessionItem),
-                            eq(clientOAuthSessionItem),
+                            eq(P0),
+                            eq(USER_ID),
                             eq(CandidateIdentityType.PENDING),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
@@ -338,8 +341,8 @@ class ProcessCandidateIdentityHandlerTest {
             verify(votMatcher, times(0)).findStrongestMatches(any(), any(), any(), anyBoolean());
             verify(storeIdentityService, times(1))
                     .storeIdentity(
-                            eq(ipvSessionItem),
-                            eq(clientOAuthSessionItem),
+                            eq(P2),
+                            eq(USER_ID),
                             eq(CandidateIdentityType.PENDING),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
@@ -563,8 +566,8 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(storeIdentityService, times(1))
                     .storeIdentity(
-                            eq(ipvSessionItem),
-                            eq(clientOAuthSessionItem),
+                            eq(P2),
+                            eq(USER_ID),
                             eq(CandidateIdentityType.UPDATE),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
@@ -866,14 +869,14 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(storeIdentityService, times(1))
                     .storeIdentity(
-                            eq(ipvSessionItem),
-                            eq(reproveIdentityClientOAuthSessionItem),
+                            eq(P2),
+                            eq(USER_ID),
                             eq(CandidateIdentityType.NEW),
                             eq(DEVICE_INFORMATION),
                             eq(List.of()),
                             any(AuditEventUser.class),
                             eq(List.of()),
-                            eq(P2_M1A_VOT_MATCH_RESULT));
+                            eq(STRONGEST_MATCHED_VOT));
             verify(criStoringService, times(1))
                     .storeVcs(
                             eq(Cri.TICF),

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/CheckCoiServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.service.IpvSessionService;
 import uk.gov.di.ipv.core.library.useridentity.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
+import uk.gov.di.ipv.core.processcandidateidentity.domain.SharedAuditEventParameters;
 import uk.gov.di.model.NamePart;
 import uk.gov.di.model.PostalAddress;
 
@@ -58,6 +59,7 @@ class CheckCoiServiceTest {
     private static final String REVERIFICATION_SCOPE = "reverification";
     private static final VerifiableCredential ADDRESS_VC = vcAddressM1a();
     private AuditEventUser testAuditEventUser;
+    private SharedAuditEventParameters sharedAuditEventParameters;
 
     @Mock private ConfigService mockConfigService;
     @Mock private AuditService mockAuditService;
@@ -72,6 +74,8 @@ class CheckCoiServiceTest {
     void setup() throws Exception {
         testAuditEventUser =
                 new AuditEventUser(USER_ID, IPV_SESSION_ID, "govuk-signin_journeyid", "ip-address");
+        sharedAuditEventParameters =
+                new SharedAuditEventParameters(testAuditEventUser, "device-info");
         when(mockEvcsService.getVerifiableCredentials(USER_ID, List.of(), EvcsVCState.CURRENT))
                 .thenReturn(List.of(ADDRESS_VC));
         when(mockConfigService.getParameter(ConfigurationVariable.COMPONENT_ID))
@@ -108,10 +112,9 @@ class CheckCoiServiceTest {
                         ipvSessionItem,
                         clientOAuthSessionItem,
                         STANDARD,
-                        "device-information",
                         List.of(),
-                        testAuditEventUser,
-                        List.of());
+                        List.of(),
+                        sharedAuditEventParameters);
 
         // Assert
         assertTrue(res);
@@ -162,10 +165,9 @@ class CheckCoiServiceTest {
                         ipvSessionItem,
                         clientOAuthSessionItem,
                         ACCOUNT_INTERVENTION,
-                        "device-information",
                         List.of(),
-                        testAuditEventUser,
-                        List.of());
+                        List.of(),
+                        sharedAuditEventParameters);
 
         // Assert
         assertTrue(res);
@@ -194,10 +196,9 @@ class CheckCoiServiceTest {
                         ipvSessionItem,
                         clientOAuthSessionItem,
                         STANDARD,
-                        "device-information",
                         List.of(fraudVc),
-                        testAuditEventUser,
-                        List.of());
+                        List.of(),
+                        sharedAuditEventParameters);
 
         // Assert
         assertTrue(res);
@@ -225,10 +226,9 @@ class CheckCoiServiceTest {
                         ipvSessionItem,
                         clientOAuthSessionItem,
                         ACCOUNT_INTERVENTION,
-                        "device-information",
                         List.of(),
-                        testAuditEventUser,
-                        List.of());
+                        List.of(),
+                        sharedAuditEventParameters);
 
         // Assert
         assertTrue(res);
@@ -259,10 +259,9 @@ class CheckCoiServiceTest {
                         ipvSessionItem,
                         clientOAuthSessionItem,
                         STANDARD,
-                        "device-information",
                         List.of(),
-                        testAuditEventUser,
-                        List.of());
+                        List.of(),
+                        sharedAuditEventParameters);
 
         // Assert
         assertTrue(res);
@@ -314,10 +313,9 @@ class CheckCoiServiceTest {
                         ipvSessionItem,
                         clientOAuthSessionItem,
                         STANDARD,
-                        "device-information",
                         List.of(),
-                        testAuditEventUser,
-                        List.of());
+                        List.of(),
+                        sharedAuditEventParameters);
 
         // Assert
         assertFalse(res);
@@ -369,10 +367,9 @@ class CheckCoiServiceTest {
                         ipvSessionItem,
                         clientOAuthSessionItem,
                         ACCOUNT_INTERVENTION,
-                        "device-information",
                         List.of(),
-                        testAuditEventUser,
-                        List.of());
+                        List.of(),
+                        sharedAuditEventParameters);
 
         // Assert
         assertFalse(res);
@@ -410,10 +407,9 @@ class CheckCoiServiceTest {
                         ipvSessionItem,
                         clientOAuthSessionItem,
                         ACCOUNT_INTERVENTION,
-                        "device-information",
                         List.of(),
-                        testAuditEventUser,
-                        List.of());
+                        List.of(),
+                        sharedAuditEventParameters);
 
         // Assert
         assertFalse(res);

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
+import uk.gov.di.ipv.core.processcandidateidentity.domain.SharedAuditEventParameters;
 
 import java.time.Instant;
 import java.util.List;
@@ -61,6 +62,7 @@ class StoreIdentityServiceTest {
             new VotMatchingResult.VotAndProfile(P1, Optional.of(L1A));
     @Spy private static IpvSessionItem ipvSessionItem;
     private AuditEventUser testAuditEventUser;
+    private SharedAuditEventParameters sharedAuditEventParameters;
 
     @Mock ConfigService configService;
     @Mock AuditService auditService;
@@ -82,6 +84,8 @@ class StoreIdentityServiceTest {
         void setUpEach() {
             when(configService.getParameter(ConfigurationVariable.COMPONENT_ID))
                     .thenReturn(COMPONENT_ID);
+            sharedAuditEventParameters =
+                    new SharedAuditEventParameters(testAuditEventUser, DEVICE_INFORMATION);
         }
 
         @Test
@@ -98,14 +102,13 @@ class StoreIdentityServiceTest {
 
             // Act
             storeIdentityService.storeIdentity(
-                    P2,
                     USER_ID,
-                    CandidateIdentityType.NEW,
-                    DEVICE_INFORMATION,
                     VCS,
-                    testAuditEventUser,
                     List.of(),
-                    STRONGEST_MATCHED_VOT);
+                    P2,
+                    STRONGEST_MATCHED_VOT,
+                    CandidateIdentityType.NEW,
+                    sharedAuditEventParameters);
 
             // Assert
             verify(evcsService, times(1)).storeCompletedIdentity(any(), any(), any(), any(), any());
@@ -128,14 +131,13 @@ class StoreIdentityServiceTest {
 
             // Act
             storeIdentityService.storeIdentity(
-                    P2,
                     USER_ID,
-                    CandidateIdentityType.NEW,
-                    DEVICE_INFORMATION,
                     VCS,
-                    testAuditEventUser,
                     List.of(),
-                    STRONGEST_MATCHED_VOT);
+                    P2,
+                    STRONGEST_MATCHED_VOT,
+                    CandidateIdentityType.NEW,
+                    sharedAuditEventParameters);
 
             // Assert
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
@@ -158,14 +160,13 @@ class StoreIdentityServiceTest {
                 throws Exception {
             // Act
             storeIdentityService.storeIdentity(
-                    P2,
                     USER_ID,
-                    CandidateIdentityType.UPDATE,
-                    DEVICE_INFORMATION,
                     VCS,
-                    testAuditEventUser,
                     List.of(),
-                    STRONGEST_MATCHED_VOT);
+                    P2,
+                    STRONGEST_MATCHED_VOT,
+                    CandidateIdentityType.UPDATE,
+                    sharedAuditEventParameters);
 
             // Assert
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
@@ -188,14 +189,13 @@ class StoreIdentityServiceTest {
                 throws Exception {
             // Act
             storeIdentityService.storeIdentity(
-                    P0,
                     USER_ID,
-                    CandidateIdentityType.NEW,
-                    DEVICE_INFORMATION,
                     VCS,
-                    testAuditEventUser,
                     List.of(),
-                    STRONGEST_MATCHED_VOT);
+                    P0,
+                    STRONGEST_MATCHED_VOT,
+                    CandidateIdentityType.NEW,
+                    sharedAuditEventParameters);
 
             // Assert
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
@@ -215,14 +215,13 @@ class StoreIdentityServiceTest {
         void shouldStoreIdentityInEvcsAndSendAuditEventForPendingVc() throws Exception {
             // Act
             storeIdentityService.storeIdentity(
-                    P2,
                     USER_ID,
-                    CandidateIdentityType.PENDING,
-                    DEVICE_INFORMATION,
                     VCS,
-                    testAuditEventUser,
                     List.of(),
-                    STRONGEST_MATCHED_VOT);
+                    P2,
+                    STRONGEST_MATCHED_VOT,
+                    CandidateIdentityType.PENDING,
+                    sharedAuditEventParameters);
 
             // Assert
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
@@ -243,7 +242,7 @@ class StoreIdentityServiceTest {
     }
 
     @Test
-    void shouldNotReturnAnErrorJourneyIfFailedAtEvcsIdentityStore_forPendingF2f() throws Exception {
+    void shouldThrowIfEvcsFailsToStorePendingIdentity() throws Exception {
         // Arrange
         doThrow(
                         new EvcsServiceException(
@@ -256,13 +255,12 @@ class StoreIdentityServiceTest {
                 EvcsServiceException.class,
                 () ->
                         storeIdentityService.storeIdentity(
-                                P2,
                                 USER_ID,
-                                CandidateIdentityType.PENDING,
-                                DEVICE_INFORMATION,
                                 VCS,
-                                testAuditEventUser,
                                 List.of(),
-                                STRONGEST_MATCHED_VOT));
+                                P0,
+                                null,
+                                CandidateIdentityType.PENDING,
+                                sharedAuditEventParameters));
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -50,6 +50,7 @@ public enum ConfigurationVariable {
     SESSION_CREDENTIALS_TTL("self/sessionCredentialTtl"),
     SIGNING_KEY_ID("self/signingKeyId"),
     SIGNING_KEY_JWK("self/signingKey"),
+    STORED_IDENTITY_SERVICE_COMPONENT_ID("storedIdentityService/componentId"),
     DCMAW_ASYNC_VC_PENDING_RETURN_TTL("self/dcmawAsyncVcPendingReturnTtl");
 
     private final String path;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -9,7 +9,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     P1_JOURNEYS_ENABLED("p1JourneysEnabled"),
     SQS_ASYNC("sqsAsync"),
     KID_JAR_HEADER("kidJarHeaderEnabled"),
-    DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck");
+    DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
+    STORED_IDENTITY_SERVICE("storedIdentityServiceEnabled");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -119,7 +119,8 @@ public enum ErrorResponse {
     UNEXPECTED_PROCESS_IDENTITY_TYPE(1104, "Unexpected process identity type"),
     FAILED_TO_GET_CREDENTIAL_ISSUER_FOR_VC(1105, "Failed to get credential issuer for VC"),
     FAILED_TO_EXTRACT_CIS_FROM_VC(1106, "Failed to extract contra-indicators from VC"),
-    MISSING_SECURITY_CHECK_CREDENTIAL(1107, "Missing security check credential");
+    MISSING_SECURITY_CHECK_CREDENTIAL(1107, "Missing security check credential"),
+    FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS(1108, "Failed to create stored identity for EVCS");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserClaims.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserClaims.java
@@ -1,0 +1,56 @@
+package uk.gov.di.ipv.core.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.model.DrivingPermitDetails;
+import uk.gov.di.model.PassportDetails;
+import uk.gov.di.model.PostalAddress;
+import uk.gov.di.model.SocialSecurityRecordDetails;
+
+import java.util.List;
+
+import static uk.gov.di.ipv.core.library.domain.VocabConstants.ADDRESS_CLAIM_NAME;
+import static uk.gov.di.ipv.core.library.domain.VocabConstants.DRIVING_PERMIT_CLAIM_NAME;
+import static uk.gov.di.ipv.core.library.domain.VocabConstants.IDENTITY_CLAIM_NAME;
+import static uk.gov.di.ipv.core.library.domain.VocabConstants.NINO_CLAIM_NAME;
+import static uk.gov.di.ipv.core.library.domain.VocabConstants.PASSPORT_CLAIM_NAME;
+
+@Builder
+@Getter
+@Setter
+@ExcludeFromGeneratedCoverageReport
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserClaims {
+    @JsonProperty(IDENTITY_CLAIM_NAME)
+    private IdentityClaim identityClaim;
+
+    @JsonProperty(ADDRESS_CLAIM_NAME)
+    private List<PostalAddress> addressClaim;
+
+    @JsonProperty(PASSPORT_CLAIM_NAME)
+    private List<PassportDetails> passportClaim;
+
+    @JsonProperty(DRIVING_PERMIT_CLAIM_NAME)
+    private List<DrivingPermitDetails> drivingPermitClaim;
+
+    @JsonProperty(NINO_CLAIM_NAME)
+    private List<SocialSecurityRecordDetails> ninoClaim;
+
+    public UserClaims(
+            @JsonProperty(value = IDENTITY_CLAIM_NAME) IdentityClaim identityClaim,
+            @JsonProperty(value = ADDRESS_CLAIM_NAME) List<PostalAddress> addressClaim,
+            @JsonProperty(value = PASSPORT_CLAIM_NAME) List<PassportDetails> passportClaim,
+            @JsonProperty(value = DRIVING_PERMIT_CLAIM_NAME)
+                    List<DrivingPermitDetails> drivingPermitClaim,
+            @JsonProperty(value = NINO_CLAIM_NAME) List<SocialSecurityRecordDetails> ninoClaim) {
+        this.identityClaim = identityClaim;
+        this.addressClaim = addressClaim;
+        this.passportClaim = passportClaim;
+        this.drivingPermitClaim = drivingPermitClaim;
+        this.ninoClaim = ninoClaim;
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -15,6 +15,7 @@ import uk.gov.di.model.PostalAddress;
 import uk.gov.di.model.SocialSecurityRecordDetails;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -89,7 +90,11 @@ public class UserIdentity {
 
     @JsonIgnore
     public List<Object> getAllClaims() {
-        return Stream.of(identityClaim, addressClaim, passportClaim, drivingPermitClaim, ninoClaim)
+        var flattenedClaims =
+                Stream.of(addressClaim, passportClaim, drivingPermitClaim, ninoClaim)
+                        .filter(Objects::nonNull)
+                        .flatMap(Collection::stream);
+        return Stream.concat(Stream.of(identityClaim), flattenedClaims)
                 .filter(Objects::nonNull)
                 .toList();
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -15,6 +16,8 @@ import uk.gov.di.model.SocialSecurityRecordDetails;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.ADDRESS_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.DRIVING_PERMIT_CLAIM_NAME;
@@ -82,5 +85,12 @@ public class UserIdentity {
         this.vot = vot;
         this.vtm = vtm;
         this.returnCode = returnCode;
+    }
+
+    @JsonIgnore
+    public List<Object> getAllClaims() {
+        return Stream.of(identityClaim, addressClaim, passportClaim, drivingPermitClaim, ninoClaim)
+                .filter(Objects::nonNull)
+                .toList();
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/UserIdentity.java
@@ -1,7 +1,6 @@
 package uk.gov.di.ipv.core.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -15,10 +14,7 @@ import uk.gov.di.model.PostalAddress;
 import uk.gov.di.model.SocialSecurityRecordDetails;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.ADDRESS_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.DRIVING_PERMIT_CLAIM_NAME;
@@ -32,27 +28,11 @@ import static uk.gov.di.ipv.core.library.domain.VocabConstants.VOT_CLAIM_NAME;
 @Getter
 @Setter
 @ExcludeFromGeneratedCoverageReport
-@Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class UserIdentity {
+public class UserIdentity extends UserClaims {
 
     @JsonProperty(VCS_CLAIM_NAME)
     private List<String> vcs;
-
-    @JsonProperty(IDENTITY_CLAIM_NAME)
-    private IdentityClaim identityClaim;
-
-    @JsonProperty(ADDRESS_CLAIM_NAME)
-    private List<PostalAddress> addressClaim;
-
-    @JsonProperty(PASSPORT_CLAIM_NAME)
-    private List<PassportDetails> passportClaim;
-
-    @JsonProperty(DRIVING_PERMIT_CLAIM_NAME)
-    private List<DrivingPermitDetails> drivingPermitClaim;
-
-    @JsonProperty(NINO_CLAIM_NAME)
-    private List<SocialSecurityRecordDetails> ninoClaim;
 
     @JsonProperty private String sub;
 
@@ -64,6 +44,7 @@ public class UserIdentity {
     private List<ReturnCode> returnCode;
 
     @JsonCreator
+    @Builder(builderMethodName = "UserIdentityBuilder")
     public UserIdentity(
             @JsonProperty(value = VCS_CLAIM_NAME, required = true) List<String> vcs,
             @JsonProperty(value = IDENTITY_CLAIM_NAME) IdentityClaim identityClaim,
@@ -76,26 +57,11 @@ public class UserIdentity {
             @JsonProperty(value = VOT_CLAIM_NAME, required = true) Vot vot,
             @JsonProperty(value = "vtm", required = true) String vtm,
             @JsonProperty(value = RETURN_CODE_NAME) List<ReturnCode> returnCode) {
+        super(identityClaim, addressClaim, passportClaim, drivingPermitClaim, ninoClaim);
         this.vcs = new ArrayList<>(vcs);
-        this.identityClaim = identityClaim;
-        this.addressClaim = addressClaim;
-        this.passportClaim = passportClaim;
-        this.drivingPermitClaim = drivingPermitClaim;
-        this.ninoClaim = ninoClaim;
         this.sub = sub;
         this.vot = vot;
         this.vtm = vtm;
         this.returnCode = returnCode;
-    }
-
-    @JsonIgnore
-    public List<Object> getAllClaims() {
-        var flattenedClaims =
-                Stream.of(addressClaim, passportClaim, drivingPermitClaim, ninoClaim)
-                        .filter(Objects::nonNull)
-                        .flatMap(Collection::stream);
-        return Stream.concat(Stream.of(identityClaim), flattenedClaims)
-                .filter(Objects::nonNull)
-                .toList();
     }
 }

--- a/libs/evcs-service/build.gradle
+++ b/libs/evcs-service/build.gradle
@@ -10,7 +10,8 @@ dependencies {
 			libs.bundles.log4j,
 			libs.jacksonDatabind,
 			project(":libs:common-services"),
-			project(":libs:verifiable-credentials")
+			project(":libs:verifiable-credentials"),
+			project(":libs:user-identity-service")
 
 	compileOnly libs.lombok
 	annotationProcessor libs.lombok

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPutUserVCsDto.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPutUserVCsDto.java
@@ -1,0 +1,9 @@
+package uk.gov.di.ipv.core.library.evcs.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record EvcsPutUserVCsDto(
+        String userId, List<EvcsCreateUserVCsDto> vcs, EvcsStoredIdentityDto si) {}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsStoredIdentityDto.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsStoredIdentityDto.java
@@ -4,4 +4,4 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import uk.gov.di.ipv.core.library.enums.Vot;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record EvcsStoredIdentityDto(String jwt, Vot vot, Object metadata) {}
+public record EvcsStoredIdentityDto(String jwt, Vot vot) {}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsStoredIdentityDto.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsStoredIdentityDto.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.evcs.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import uk.gov.di.ipv.core.library.enums.Vot;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record EvcsStoredIdentityDto(String jwt, Vot vot, Object metadata) {}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/exception/FailedToCreateStoredIdentityForEvcsException.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/exception/FailedToCreateStoredIdentityForEvcsException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.evcs.exception;
+
+public class FailedToCreateStoredIdentityForEvcsException extends Exception {
+    public FailedToCreateStoredIdentityForEvcsException(String message) {
+        super(message);
+    }
+}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -1,19 +1,25 @@
 package uk.gov.di.ipv.core.library.evcs.service;
 
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.util.CollectionUtils;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.evcs.client.EvcsClient;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsCreateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
+import uk.gov.di.ipv.core.library.evcs.dto.EvcsPutUserVCsDto;
+import uk.gov.di.ipv.core.library.evcs.dto.EvcsStoredIdentityDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
+import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
 import uk.gov.di.ipv.core.library.evcs.metadata.InheritedIdentityMetadata;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
+import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -21,6 +27,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.STORED_IDENTITY_SERVICE;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.ABANDONED;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.CURRENT;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.HISTORIC;
@@ -32,33 +40,45 @@ import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVcProvenance.ONLINE;
 public class EvcsService {
     private final EvcsClient evcsClient;
     private final ConfigService configService;
+    private final StoredIdentityService storedIdentityService;
 
     @ExcludeFromGeneratedCoverageReport
-    public EvcsService(EvcsClient evcsClient, ConfigService configService) {
+    public EvcsService(
+            EvcsClient evcsClient,
+            ConfigService configService,
+            StoredIdentityService storedIdentityService) {
         this.evcsClient = evcsClient;
         this.configService = configService;
+        this.storedIdentityService = storedIdentityService;
     }
 
     @ExcludeFromGeneratedCoverageReport
     public EvcsService(ConfigService configService) {
         this.evcsClient = new EvcsClient(configService);
         this.configService = configService;
+        this.storedIdentityService = new StoredIdentityService(configService);
     }
 
     public void storeCompletedIdentity(
-            String userId,
+            ClientOAuthSessionItem clientOAuthSessionItem,
             List<VerifiableCredential> credentials,
-            List<EvcsGetUserVCDto> currentAndPendingEvcsVcs)
+            List<EvcsGetUserVCDto> currentAndPendingEvcsVcs,
+            VotMatchingResult votMatchingResult)
             throws EvcsServiceException {
-        persistUserVCs(userId, credentials, currentAndPendingEvcsVcs, false);
+        persistUserVCs(
+                clientOAuthSessionItem,
+                credentials,
+                currentAndPendingEvcsVcs,
+                votMatchingResult,
+                false);
     }
 
     public void storePendingIdentity(
-            String userId,
+            ClientOAuthSessionItem clientOAuthSessionItem,
             List<VerifiableCredential> credentials,
             List<EvcsGetUserVCDto> currentAndPendingEvcsVcs)
             throws EvcsServiceException {
-        persistUserVCs(userId, credentials, currentAndPendingEvcsVcs, true);
+        persistUserVCs(clientOAuthSessionItem, credentials, currentAndPendingEvcsVcs, null, true);
     }
 
     public void storeMigratedIdentity(String userId, List<VerifiableCredential> credentials)
@@ -159,11 +179,16 @@ public class EvcsService {
     }
 
     public void storePendingVc(VerifiableCredential credential) throws EvcsServiceException {
-        evcsClient.storeUserVCs(
-                credential.getUserId(),
+        var userVcToStore =
                 List.of(
                         new EvcsCreateUserVCsDto(
-                                credential.getVcString(), PENDING_RETURN, null, OFFLINE)));
+                                credential.getVcString(), PENDING_RETURN, null, OFFLINE));
+        if (configService.enabled(STORED_IDENTITY_SERVICE)) {
+            evcsClient.storeUserVCs(
+                    new EvcsPutUserVCsDto(credential.getUserId(), userVcToStore, null));
+        } else {
+            evcsClient.storeUserVCs(credential.getUserId(), userVcToStore);
+        }
     }
 
     public void abandonPendingIdentity(String userId, String evcsAccessToken)
@@ -185,34 +210,55 @@ public class EvcsService {
     }
 
     private void persistUserVCs(
-            String userId,
+            ClientOAuthSessionItem clientOAuthSessionItem,
             List<VerifiableCredential> credentials,
             List<EvcsGetUserVCDto> existingEvcsUserVCs,
+            VotMatchingResult votMatchingResult,
             boolean isPendingIdentity)
             throws EvcsServiceException {
-        List<EvcsCreateUserVCsDto> userVCsToStore =
-                credentials.stream()
-                        .filter(
-                                credential ->
-                                        existingEvcsUserVCs.stream()
-                                                .noneMatch(
-                                                        evcsVC ->
-                                                                evcsVC.vc()
-                                                                        .equals(
-                                                                                credential
-                                                                                        .getVcString())))
-                        .map(
-                                vc ->
-                                        new EvcsCreateUserVCsDto(
-                                                vc.getVcString(),
-                                                isPendingIdentity ? PENDING_RETURN : CURRENT,
-                                                null,
-                                                ONLINE))
-                        .toList();
+        try {
+            var userId = clientOAuthSessionItem.getUserId();
+            List<EvcsCreateUserVCsDto> userVCsToStore =
+                    credentials.stream()
+                            .filter(
+                                    credential ->
+                                            existingEvcsUserVCs.stream()
+                                                    .noneMatch(
+                                                            evcsVC ->
+                                                                    evcsVC.vc()
+                                                                            .equals(
+                                                                                    credential
+                                                                                            .getVcString())))
+                            .map(
+                                    vc ->
+                                            new EvcsCreateUserVCsDto(
+                                                    vc.getVcString(),
+                                                    isPendingIdentity ? PENDING_RETURN : CURRENT,
+                                                    null,
+                                                    ONLINE))
+                            .toList();
 
-        if (!CollectionUtils.isEmpty(existingEvcsUserVCs))
-            updateExistingUserVCs(userId, credentials, existingEvcsUserVCs, isPendingIdentity);
-        if (!userVCsToStore.isEmpty()) evcsClient.storeUserVCs(userId, userVCsToStore);
+            if (configService.enabled(STORED_IDENTITY_SERVICE)) {
+                EvcsStoredIdentityDto storedIdentityJwt = null;
+                if (!isPendingIdentity || votMatchingResult == null) {
+                    storedIdentityJwt =
+                            storedIdentityService.getStoredIdentityForEvcs(
+                                    clientOAuthSessionItem, credentials, votMatchingResult, null);
+                }
+                var putUserVcsDto =
+                        new EvcsPutUserVCsDto(userId, userVCsToStore, storedIdentityJwt);
+
+                evcsClient.storeUserVCs(putUserVcsDto);
+            } else {
+                if (!CollectionUtils.isEmpty(existingEvcsUserVCs))
+                    updateExistingUserVCs(
+                            userId, credentials, existingEvcsUserVCs, isPendingIdentity);
+                if (!userVCsToStore.isEmpty()) evcsClient.storeUserVCs(userId, userVCsToStore);
+            }
+        } catch (FailedToCreateStoredIdentityForEvcsException e) {
+            throw new EvcsServiceException(
+                    HTTPResponse.SC_SERVER_ERROR, FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS);
+        }
     }
 
     private void updateExistingUserVCs(

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -240,7 +240,7 @@ public class EvcsService {
 
             if (configService.enabled(STORED_IDENTITY_SERVICE)) {
                 EvcsStoredIdentityDto storedIdentityJwt = null;
-                if (!isPendingIdentity || votMatchingResult == null) {
+                if (!isPendingIdentity) {
                     storedIdentityJwt =
                             storedIdentityService.getStoredIdentityForEvcs(
                                     clientOAuthSessionItem, credentials, votMatchingResult, null);

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityService.java
@@ -1,0 +1,111 @@
+package uk.gov.di.ipv.core.library.evcs.service;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jwt.JWTClaimsSet;
+import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
+import uk.gov.di.ipv.core.library.evcs.dto.EvcsStoredIdentityDto;
+import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
+import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.signing.SignerFactory;
+import uk.gov.di.ipv.core.library.useridentity.service.UserIdentityService;
+import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.STORED_IDENTITY_SERVICE_COMPONENT_ID;
+import static uk.gov.di.ipv.core.library.helpers.JwtHelper.createSignedJwt;
+
+public class StoredIdentityService {
+    private final SignerFactory signerFactory;
+    private final ConfigService configService;
+    private final UserIdentityService userIdentityService;
+
+    public StoredIdentityService(
+            SignerFactory signerFactory,
+            ConfigService configService,
+            UserIdentityService userIdentityService) {
+        this.signerFactory = signerFactory;
+        this.configService = configService;
+        this.userIdentityService = userIdentityService;
+    }
+
+    public StoredIdentityService(ConfigService configService) {
+        this.signerFactory = new SignerFactory(configService);
+        this.userIdentityService = new UserIdentityService(configService);
+        this.configService = configService;
+    }
+
+    private JWTClaimsSet createStoredIdentityJwt(
+            ClientOAuthSessionItem clientOAuthSessionItem,
+            List<VerifiableCredential> vcs,
+            VotMatchingResult votMatchingResult)
+            throws HttpResponseExceptionWithErrorBody, CredentialParseException,
+                    FailedToCreateStoredIdentityForEvcsException {
+        Instant now = Instant.now();
+
+        var strongestRequestedVot = votMatchingResult.strongestRequestedMatch();
+        if (strongestRequestedVot.isEmpty()) {
+            throw new FailedToCreateStoredIdentityForEvcsException(
+                    "No strongest requested matched vot found for user");
+        }
+
+        var claims =
+                userIdentityService.getUserClaimsForStoredIdentity(
+                        strongestRequestedVot.get().vot(), vcs);
+
+        return new JWTClaimsSet.Builder()
+                .issuer(configService.getParameter(COMPONENT_ID))
+                .audience(configService.getParameter(STORED_IDENTITY_SERVICE_COMPONENT_ID))
+                .subject(clientOAuthSessionItem.getUserId())
+                .notBeforeTime(Date.from(now))
+                .issueTime(Date.from(now))
+                .claim("vot", strongestRequestedVot.get().vot())
+                .claim("credentials", vcs.stream().map(VerifiableCredential::getVcString).toList())
+                .claim("claims", claims)
+                .build();
+    }
+
+    private String getSignedStoredIdentity(
+            ClientOAuthSessionItem clientOAuthSessionItem,
+            List<VerifiableCredential> vcs,
+            VotMatchingResult votMatchingResult)
+            throws FailedToCreateStoredIdentityForEvcsException {
+        try {
+            var storedIdentity =
+                    createStoredIdentityJwt(clientOAuthSessionItem, vcs, votMatchingResult);
+
+            return createSignedJwt(storedIdentity, signerFactory.getSigner(), false).serialize();
+        } catch (CredentialParseException e) {
+            throw new FailedToCreateStoredIdentityForEvcsException(
+                    "Unable to parse user credentials");
+        } catch (HttpResponseExceptionWithErrorBody e) {
+            throw new FailedToCreateStoredIdentityForEvcsException(
+                    e.getErrorResponse().getMessage());
+        } catch (JOSEException e) {
+            throw new FailedToCreateStoredIdentityForEvcsException("Failed to create signed JWT");
+        }
+    }
+
+    public EvcsStoredIdentityDto getStoredIdentityForEvcs(
+            ClientOAuthSessionItem clientOAuthSessionItem,
+            List<VerifiableCredential> vcs,
+            VotMatchingResult votMatchingResult,
+            Object metadata)
+            throws FailedToCreateStoredIdentityForEvcsException {
+        var strongestMatchedVot = votMatchingResult.strongestMatch();
+        if (strongestMatchedVot.isEmpty()) {
+            throw new FailedToCreateStoredIdentityForEvcsException(
+                    "No strongest matched vot found for user");
+        }
+
+        var signedSiJwt = getSignedStoredIdentity(clientOAuthSessionItem, vcs, votMatchingResult);
+
+        return new EvcsStoredIdentityDto(signedSiJwt, strongestMatchedVot.get().vot(), metadata);
+    }
+}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityService.java
@@ -63,6 +63,10 @@ public class StoredIdentityService {
             throws HttpResponseExceptionWithErrorBody, CredentialParseException {
         Instant now = Instant.now(clock);
 
+        // the serialiseNullClaims(false) on JWTClaimsSet.Builder doesn't work to
+        // remove null properties within the claims value (only if the claims value
+        // is null itself) so we do this prior to passing it into JWTClaimsSet.Builder
+        // with jackson.
         var parsedUserClaims =
                 OBJECT_MAPPER.convertValue(
                         userIdentityService.getUserClaimsForStoredIdentity(achievedVot, vcs),

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
@@ -107,7 +107,7 @@ class EvcsClientTest {
                     List.of(
                             new EvcsCreateUserVCsDto(
                                     "VC_Signature1", EvcsVCState.CURRENT, TEST_METADATA, null)),
-                    new EvcsStoredIdentityDto("storedIdentityJwt", Vot.P2, TEST_METADATA));
+                    new EvcsStoredIdentityDto("storedIdentityJwt", Vot.P2));
     private static final List<EvcsVCState> VC_STATES_FOR_QUERY = List.of(CURRENT, PENDING_RETURN);
 
     @Mock private ConfigService mockConfigService;

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -422,28 +422,6 @@ class EvcsServiceTest {
     }
 
     @Test
-    void storePendingVcShouldStoreVcWithPutMethod() throws Exception {
-        // Assert
-        when(mockConfigService.enabled(STORED_IDENTITY_SERVICE)).thenReturn(true);
-
-        // Act
-        evcsService.storePendingVc(VC_ADDRESS_TEST);
-
-        // Assert
-        verify(mockEvcsClient).storeUserVCs(evcsPutUserVCsDtoCaptor.capture());
-
-        assertEquals(VC_ADDRESS_TEST.getUserId(), evcsPutUserVCsDtoCaptor.getValue().userId());
-        assertEquals(
-                VC_ADDRESS_TEST.getVcString(),
-                evcsPutUserVCsDtoCaptor.getValue().vcs().get(0).vc());
-        assertEquals(PENDING_RETURN, evcsPutUserVCsDtoCaptor.getValue().vcs().get(0).state());
-        assertEquals(OFFLINE, evcsPutUserVCsDtoCaptor.getValue().vcs().get(0).provenance());
-        assertNull(evcsPutUserVCsDtoCaptor.getValue().si());
-
-        verify(mockEvcsClient, never()).storeUserVCs(any(), any());
-    }
-
-    @Test
     void updatePendingIdentityShouldUpdateStateToAbandoned() throws EvcsServiceException {
         EvcsGetUserVCsDto evcsGetUserVcsWithPendingAllExistingDto =
                 new EvcsGetUserVCsDto(

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityServiceTest.java
@@ -42,7 +42,7 @@ import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.L1A;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M2A;
 
 @ExtendWith(MockitoExtension.class)
-public class StoredIdentityServiceTest {
+class StoredIdentityServiceTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static final String USER_ID = "user-id";
@@ -152,7 +152,7 @@ public class StoredIdentityServiceTest {
     }
 
     @Test
-    void getStoredIdentityForEvcsShouldThrowIfMissingStongestVotMatch() throws Exception {
+    void getStoredIdentityForEvcsShouldThrowIfMissingStongestVotMatch() {
         // Arrange
         var testVot =
                 new VotMatchingResult(
@@ -172,7 +172,7 @@ public class StoredIdentityServiceTest {
     }
 
     @Test
-    void getStoredIdentityForEvcsShouldThrowIfMissingStongestRequestedVotMatch() throws Exception {
+    void getStoredIdentityForEvcsShouldThrowIfMissingStongestRequestedVotMatch() {
         // Arrange
         var testVot =
                 new VotMatchingResult(

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.library.evcs.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.ECKey;
@@ -8,25 +7,27 @@ import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.domain.UserClaims;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
-import uk.gov.di.ipv.core.library.gpg45.Gpg45Scores;
-import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.signing.LocalECDSASigner;
 import uk.gov.di.ipv.core.library.signing.SignerFactory;
 import uk.gov.di.ipv.core.library.useridentity.service.UserIdentityService;
 import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
+import uk.gov.di.model.PassportDetails;
 
 import java.text.ParseException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,7 +39,6 @@ import static uk.gov.di.ipv.core.library.enums.Vot.P1;
 import static uk.gov.di.ipv.core.library.enums.Vot.P2;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcWebPassportSuccessful;
-import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.L1A;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M2A;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,25 +48,32 @@ class StoredIdentityServiceTest {
     private static final String USER_ID = "user-id";
     private static final String MOCK_COMPONENT_ID = "mock-component-id";
     private static final String MOCK_SIS_COMPONENT_ID = "mock-sis-component-id";
-    private static final VotMatchingResult VOT_MATCHING_RESULT =
-            new VotMatchingResult(
-                    Optional.of(new VotMatchingResult.VotAndProfile(P2, Optional.of(M2A))),
-                    Optional.of(new VotMatchingResult.VotAndProfile(P1, Optional.of(L1A))),
-                    Gpg45Scores.builder().build());
+    private static final VotMatchingResult.VotAndProfile STRONGEST_MATCHED_VOT =
+            new VotMatchingResult.VotAndProfile(P2, Optional.of(M2A));
+    private static final PassportDetails PASSPORT_CLAIM =
+            PassportDetails.builder().withDocumentNumber("DOCNUM123").build();
 
     private static LocalECDSASigner signer;
-    private static ClientOAuthSessionItem clientOAuthSessionItem;
 
+    private static final Clock CURRENT_TIME =
+            Clock.fixed(Instant.parse("2025-01-01T00:00:00.00Z"), ZoneOffset.UTC);
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private UserIdentityService mockUserIdentityService;
-    @InjectMocks private StoredIdentityService storedIdentityService;
+
+    private StoredIdentityService storedIdentityService;
 
     @BeforeEach
     void setUp() throws ParseException, JOSEException {
         var privateKey = ECKey.parse(EC_PRIVATE_KEY_JWK);
         signer = new LocalECDSASigner(privateKey);
-        clientOAuthSessionItem = ClientOAuthSessionItem.builder().userId(USER_ID).build();
+
+        storedIdentityService =
+                new StoredIdentityService(
+                        mockConfigService,
+                        mockSignerFactory,
+                        mockUserIdentityService,
+                        CURRENT_TIME);
     }
 
     @Test
@@ -74,44 +81,47 @@ class StoredIdentityServiceTest {
         // Arrange
         var passportVc = vcWebPassportSuccessful();
         var vcs = List.of(passportVc);
-        var testMetadata = Map.of("some", "metadata");
+        var userClaims =
+                UserClaims.builder().passportClaim(List.of(PASSPORT_CLAIM, PASSPORT_CLAIM)).build();
 
         when(mockSignerFactory.getSigner()).thenReturn(signer);
         when(mockConfigService.getParameter(COMPONENT_ID)).thenReturn(MOCK_COMPONENT_ID);
         when(mockConfigService.getParameter(STORED_IDENTITY_SERVICE_COMPONENT_ID))
                 .thenReturn(MOCK_SIS_COMPONENT_ID);
-        when(mockUserIdentityService.getUserClaimsForStoredIdentity(
-                        VOT_MATCHING_RESULT.strongestRequestedMatch().get().vot(), vcs))
-                .thenReturn(List.of());
+        when(mockUserIdentityService.getUserClaimsForStoredIdentity(P2, vcs))
+                .thenReturn(userClaims);
 
         // Act
         var si =
                 storedIdentityService.getStoredIdentityForEvcs(
-                        clientOAuthSessionItem, vcs, VOT_MATCHING_RESULT, testMetadata);
+                        USER_ID, vcs, STRONGEST_MATCHED_VOT, P2);
 
         assertEquals(P2, si.vot());
-        assertEquals(testMetadata, si.metadata());
 
         var parsedJwt = SignedJWT.parse(si.jwt()).getJWTClaimsSet();
 
         assertEquals(USER_ID, parsedJwt.getSubject());
         assertEquals(MOCK_COMPONENT_ID, parsedJwt.getIssuer());
         assertEquals(List.of(MOCK_SIS_COMPONENT_ID), parsedJwt.getAudience());
-        assertEquals(P1, OBJECT_MAPPER.convertValue(parsedJwt.getClaim("vot"), Vot.class));
         assertEquals(
-                List.of(passportVc.getVcString()),
+                P2,
                 OBJECT_MAPPER.convertValue(
-                        parsedJwt.getClaim("credentials"), new TypeReference<>() {}));
+                        parsedJwt.getClaim(StoredIdentityService.VOT_CLAIM), Vot.class));
+        assertEquals(Date.from(Instant.now(CURRENT_TIME)), parsedJwt.getIssueTime());
+        assertEquals(Date.from(Instant.now(CURRENT_TIME)), parsedJwt.getNotBeforeTime());
         assertEquals(
-                List.of(),
-                OBJECT_MAPPER.convertValue(parsedJwt.getClaim("claims"), new TypeReference<>() {}));
+                List.of(passportVc.getSignedJwt().getSignature().toString()),
+                parsedJwt.getStringListClaim(StoredIdentityService.CREDENTIALS_CLAIM));
+        assertEquals(
+                OBJECT_MAPPER.writeValueAsString(userClaims),
+                OBJECT_MAPPER.writeValueAsString(
+                        parsedJwt.getClaim(StoredIdentityService.CLAIMS_CLAIM)));
     }
 
     @Test
     void getStoredIdentityForEvcsShouldThrowIfFailsToParseCredentials() throws Exception {
         // Arrange
-        when(mockUserIdentityService.getUserClaimsForStoredIdentity(
-                        VOT_MATCHING_RESULT.strongestRequestedMatch().get().vot(), List.of()))
+        when(mockUserIdentityService.getUserClaimsForStoredIdentity(P2, List.of()))
                 .thenThrow(new CredentialParseException("Failed to parse credentials"));
 
         // Act/Assert
@@ -120,10 +130,7 @@ class StoredIdentityServiceTest {
                         FailedToCreateStoredIdentityForEvcsException.class,
                         () ->
                                 storedIdentityService.getStoredIdentityForEvcs(
-                                        clientOAuthSessionItem,
-                                        List.of(),
-                                        VOT_MATCHING_RESULT,
-                                        null));
+                                        USER_ID, List.of(), STRONGEST_MATCHED_VOT, P2));
 
         assertEquals("Unable to parse user credentials", exception.getMessage());
     }
@@ -131,8 +138,7 @@ class StoredIdentityServiceTest {
     @Test
     void getStoredIdentityForEvcsShouldThrowIfFailsToGenerateClaims() throws Exception {
         // Arrange
-        when(mockUserIdentityService.getUserClaimsForStoredIdentity(
-                        VOT_MATCHING_RESULT.strongestRequestedMatch().get().vot(), List.of()))
+        when(mockUserIdentityService.getUserClaimsForStoredIdentity(P2, List.of()))
                 .thenThrow(
                         new HttpResponseExceptionWithErrorBody(
                                 500, ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM));
@@ -143,51 +149,21 @@ class StoredIdentityServiceTest {
                         FailedToCreateStoredIdentityForEvcsException.class,
                         () ->
                                 storedIdentityService.getStoredIdentityForEvcs(
-                                        clientOAuthSessionItem,
-                                        List.of(),
-                                        VOT_MATCHING_RESULT,
-                                        null));
+                                        USER_ID, List.of(), STRONGEST_MATCHED_VOT, P2));
 
         assertEquals("Failed to generate the identity claim", exception.getMessage());
     }
 
     @Test
-    void getStoredIdentityForEvcsShouldThrowIfMissingStongestVotMatch() {
-        // Arrange
-        var testVot =
-                new VotMatchingResult(
-                        Optional.empty(),
-                        Optional.of(new VotMatchingResult.VotAndProfile(P1, Optional.of(L1A))),
-                        Gpg45Scores.builder().build());
-
+    void getStoredIdentityForEvcsShouldThrowIfMissingStrongestVotMatch() {
         // Act/Assert
         var exception =
                 assertThrows(
                         FailedToCreateStoredIdentityForEvcsException.class,
                         () ->
                                 storedIdentityService.getStoredIdentityForEvcs(
-                                        clientOAuthSessionItem, List.of(), testVot, null));
+                                        USER_ID, List.of(), null, P1));
 
         assertEquals("No strongest matched vot found for user", exception.getMessage());
-    }
-
-    @Test
-    void getStoredIdentityForEvcsShouldThrowIfMissingStongestRequestedVotMatch() {
-        // Arrange
-        var testVot =
-                new VotMatchingResult(
-                        Optional.of(new VotMatchingResult.VotAndProfile(P1, Optional.of(L1A))),
-                        Optional.empty(),
-                        Gpg45Scores.builder().build());
-
-        // Act/Assert
-        var exception =
-                assertThrows(
-                        FailedToCreateStoredIdentityForEvcsException.class,
-                        () ->
-                                storedIdentityService.getStoredIdentityForEvcs(
-                                        clientOAuthSessionItem, List.of(), testVot, null));
-
-        assertEquals("No strongest requested matched vot found for user", exception.getMessage());
     }
 }

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityServiceTest.java
@@ -1,0 +1,193 @@
+package uk.gov.di.ipv.core.library.evcs.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.enums.Vot;
+import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
+import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
+import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.core.library.gpg45.Gpg45Scores;
+import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.signing.LocalECDSASigner;
+import uk.gov.di.ipv.core.library.signing.SignerFactory;
+import uk.gov.di.ipv.core.library.useridentity.service.UserIdentityService;
+import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.STORED_IDENTITY_SERVICE_COMPONENT_ID;
+import static uk.gov.di.ipv.core.library.enums.Vot.P1;
+import static uk.gov.di.ipv.core.library.enums.Vot.P2;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcWebPassportSuccessful;
+import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.L1A;
+import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M2A;
+
+@ExtendWith(MockitoExtension.class)
+public class StoredIdentityServiceTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String USER_ID = "user-id";
+    private static final String MOCK_COMPONENT_ID = "mock-component-id";
+    private static final String MOCK_SIS_COMPONENT_ID = "mock-sis-component-id";
+    private static final VotMatchingResult VOT_MATCHING_RESULT =
+            new VotMatchingResult(
+                    Optional.of(new VotMatchingResult.VotAndProfile(P2, Optional.of(M2A))),
+                    Optional.of(new VotMatchingResult.VotAndProfile(P1, Optional.of(L1A))),
+                    Gpg45Scores.builder().build());
+
+    private static LocalECDSASigner signer;
+    private static ClientOAuthSessionItem clientOAuthSessionItem;
+
+    @Mock private ConfigService mockConfigService;
+    @Mock private SignerFactory mockSignerFactory;
+    @Mock private UserIdentityService mockUserIdentityService;
+    @InjectMocks private StoredIdentityService storedIdentityService;
+
+    @BeforeEach
+    void setUp() throws ParseException, JOSEException {
+        var privateKey = ECKey.parse(EC_PRIVATE_KEY_JWK);
+        signer = new LocalECDSASigner(privateKey);
+        clientOAuthSessionItem = ClientOAuthSessionItem.builder().userId(USER_ID).build();
+    }
+
+    @Test
+    void getStoredIdentityForEvcsShouldReturnGeneratedStoredIdentity() throws Exception {
+        // Arrange
+        var passportVc = vcWebPassportSuccessful();
+        var vcs = List.of(passportVc);
+        var testMetadata = Map.of("some", "metadata");
+
+        when(mockSignerFactory.getSigner()).thenReturn(signer);
+        when(mockConfigService.getParameter(COMPONENT_ID)).thenReturn(MOCK_COMPONENT_ID);
+        when(mockConfigService.getParameter(STORED_IDENTITY_SERVICE_COMPONENT_ID))
+                .thenReturn(MOCK_SIS_COMPONENT_ID);
+        when(mockUserIdentityService.getUserClaimsForStoredIdentity(
+                        VOT_MATCHING_RESULT.strongestRequestedMatch().get().vot(), vcs))
+                .thenReturn(List.of());
+
+        // Act
+        var si =
+                storedIdentityService.getStoredIdentityForEvcs(
+                        clientOAuthSessionItem, vcs, VOT_MATCHING_RESULT, testMetadata);
+
+        assertEquals(P2, si.vot());
+        assertEquals(testMetadata, si.metadata());
+
+        var parsedJwt = SignedJWT.parse(si.jwt()).getJWTClaimsSet();
+
+        assertEquals(USER_ID, parsedJwt.getSubject());
+        assertEquals(MOCK_COMPONENT_ID, parsedJwt.getIssuer());
+        assertEquals(List.of(MOCK_SIS_COMPONENT_ID), parsedJwt.getAudience());
+        assertEquals(P1, OBJECT_MAPPER.convertValue(parsedJwt.getClaim("vot"), Vot.class));
+        assertEquals(
+                List.of(passportVc.getVcString()),
+                OBJECT_MAPPER.convertValue(
+                        parsedJwt.getClaim("credentials"), new TypeReference<>() {}));
+        assertEquals(
+                List.of(),
+                OBJECT_MAPPER.convertValue(parsedJwt.getClaim("claims"), new TypeReference<>() {}));
+    }
+
+    @Test
+    void getStoredIdentityForEvcsShouldThrowIfFailsToParseCredentials() throws Exception {
+        // Arrange
+        when(mockUserIdentityService.getUserClaimsForStoredIdentity(
+                        VOT_MATCHING_RESULT.strongestRequestedMatch().get().vot(), List.of()))
+                .thenThrow(new CredentialParseException("Failed to parse credentials"));
+
+        // Act/Assert
+        var exception =
+                assertThrows(
+                        FailedToCreateStoredIdentityForEvcsException.class,
+                        () ->
+                                storedIdentityService.getStoredIdentityForEvcs(
+                                        clientOAuthSessionItem,
+                                        List.of(),
+                                        VOT_MATCHING_RESULT,
+                                        null));
+
+        assertEquals("Unable to parse user credentials", exception.getMessage());
+    }
+
+    @Test
+    void getStoredIdentityForEvcsShouldThrowIfFailsToGenerateClaims() throws Exception {
+        // Arrange
+        when(mockUserIdentityService.getUserClaimsForStoredIdentity(
+                        VOT_MATCHING_RESULT.strongestRequestedMatch().get().vot(), List.of()))
+                .thenThrow(
+                        new HttpResponseExceptionWithErrorBody(
+                                500, ErrorResponse.FAILED_TO_GENERATE_IDENTITY_CLAIM));
+
+        // Act/Assert
+        var exception =
+                assertThrows(
+                        FailedToCreateStoredIdentityForEvcsException.class,
+                        () ->
+                                storedIdentityService.getStoredIdentityForEvcs(
+                                        clientOAuthSessionItem,
+                                        List.of(),
+                                        VOT_MATCHING_RESULT,
+                                        null));
+
+        assertEquals("Failed to generate the identity claim", exception.getMessage());
+    }
+
+    @Test
+    void getStoredIdentityForEvcsShouldThrowIfMissingStongestVotMatch() throws Exception {
+        // Arrange
+        var testVot =
+                new VotMatchingResult(
+                        Optional.empty(),
+                        Optional.of(new VotMatchingResult.VotAndProfile(P1, Optional.of(L1A))),
+                        Gpg45Scores.builder().build());
+
+        // Act/Assert
+        var exception =
+                assertThrows(
+                        FailedToCreateStoredIdentityForEvcsException.class,
+                        () ->
+                                storedIdentityService.getStoredIdentityForEvcs(
+                                        clientOAuthSessionItem, List.of(), testVot, null));
+
+        assertEquals("No strongest matched vot found for user", exception.getMessage());
+    }
+
+    @Test
+    void getStoredIdentityForEvcsShouldThrowIfMissingStongestRequestedVotMatch() throws Exception {
+        // Arrange
+        var testVot =
+                new VotMatchingResult(
+                        Optional.of(new VotMatchingResult.VotAndProfile(P1, Optional.of(L1A))),
+                        Optional.empty(),
+                        Gpg45Scores.builder().build());
+
+        // Act/Assert
+        var exception =
+                assertThrows(
+                        FailedToCreateStoredIdentityForEvcsException.class,
+                        () ->
+                                storedIdentityService.getStoredIdentityForEvcs(
+                                        clientOAuthSessionItem, List.of(), testVot, null));
+
+        assertEquals("No strongest requested matched vot found for user", exception.getMessage());
+    }
+}

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -285,6 +285,17 @@ public class UserIdentityService {
         ninoClaim.ifPresent(userIdentityBuilder::ninoClaim);
     }
 
+    public List<Object> getUserClaimsForStoredIdentity(
+            Vot achievedVot, List<VerifiableCredential> vcs)
+            throws HttpResponseExceptionWithErrorBody, CredentialParseException {
+        var userIdentityBuilder = UserIdentity.builder();
+        var profile = achievedVot.getProfileType();
+
+        addUserIdentityClaims(profile, vcs, userIdentityBuilder);
+
+        return userIdentityBuilder.build().getAllClaims();
+    }
+
     private boolean checkNameAndFamilyNameCorrelationInCredentials(List<VerifiableCredential> vcs)
             throws HttpResponseExceptionWithErrorBody {
         List<IdentityClaim> identityClaims = getIdentityClaimsForNameCorrelation(vcs);

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -288,7 +288,9 @@ public class UserIdentityService {
     public List<Object> getUserClaimsForStoredIdentity(
             Vot achievedVot, List<VerifiableCredential> vcs)
             throws HttpResponseExceptionWithErrorBody, CredentialParseException {
-        var userIdentityBuilder = UserIdentity.builder();
+        // Substituting arbitrary values into vcs, sub and vtm as they are required
+        // properties for the builder. We just need the builder to add claims to.
+        var userIdentityBuilder = UserIdentity.builder().vcs(List.of()).sub("").vtm("");
         var profile = achievedVot.getProfileType();
 
         addUserIdentityClaims(profile, vcs, userIdentityBuilder);

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
@@ -1700,6 +1700,54 @@ class UserIdentityServiceTest {
         assertFalse(result.isEmpty());
     }
 
+    @Test
+    void getUserClaimsForStoredIdentityShouldReturnListOfUserClaims() throws Exception {
+        // Arrange
+        var testVcs =
+                List.of(
+                        vcWebPassportSuccessful(),
+                        vcWebDrivingPermitDvlaValid(),
+                        vcNinoIdentityCheckSuccessful(),
+                        vcExperianFraudScoreTwo(),
+                        vcAddressOne());
+
+        // Act
+        var result = userIdentityService.getUserClaimsForStoredIdentity(Vot.P2, testVcs);
+
+        // Assert
+        assertEquals(5, result.size());
+        // First element in the array is the identity claim
+        assertEquals("KENNETH DECERQUEIRA", ((IdentityClaim) result.get(0)).getFullName());
+        // Second element in the array is the address claim if it exists
+        assertEquals("IDSWORTH ROAD", ((PostalAddress) result.get(1)).getStreetName());
+        // Third element is the passport claim if it exists
+        assertEquals("321654987", ((PassportDetails) result.get(2)).getDocumentNumber());
+        // Fourth element is the driving permit claim if it exists
+        assertEquals(
+                "PARKE710112PBFGA", ((DrivingPermitDetails) result.get(3)).getPersonalNumber());
+        // Fifth element if the nino claim if it exists
+        assertEquals(
+                "AA000003D", ((SocialSecurityRecordDetails) result.get(4)).getPersonalNumber());
+    }
+
+    @Test
+    void getUserClaimsForStoredIdentityShouldFilterMissingClaims() throws Exception {
+        // Arrange
+        var testVcs = List.of(vcWebPassportSuccessful(), vcExperianFraudScoreTwo(), vcAddressOne());
+
+        // Act
+        var result = userIdentityService.getUserClaimsForStoredIdentity(Vot.P2, testVcs);
+
+        // Assert
+        assertEquals(3, result.size());
+        // First element in the array is the identity claim
+        assertEquals("KENNETH DECERQUEIRA", ((IdentityClaim) result.get(0)).getFullName());
+        // Second element in the array is the address claim if it exists
+        assertEquals("IDSWORTH ROAD", ((PostalAddress) result.get(1)).getStreetName());
+        // Third element is the passport claim if it exists
+        assertEquals("321654987", ((PassportDetails) result.get(2)).getDocumentNumber());
+    }
+
     @Nested
     class AreNamesAndDobCorrelatedForReverification {
         @BeforeEach

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -79,7 +79,7 @@ core:
   evcs:
     applicationUrl: "https://evcs.stubs.account.gov.uk"
   storedIdentityService:
-    componentId: "PLACEHOLDER-VALUE"
+    componentId: "https://reuse-identity.build.account.gov.uk"
   credentialIssuers:
     address:
       id: address

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -78,6 +78,8 @@ core:
     apiBaseUrl: "https://cimit-api.stubs.account.gov.uk"
   evcs:
     applicationUrl: "https://evcs.stubs.account.gov.uk"
+  storedIdentityService:
+    componentId: "PLACEHOLDER-VALUE"
   credentialIssuers:
     address:
       id: address


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Updates core-back to use new PUT endpoint for EVCS when the `storedIdentityServiceEnabled` feature flag is enabled.

### Why did it change
There will be a new PUT endpoint for EVCS which allows storing a stored identity object (containing information about the user's identity and their highest achieved VOT currently supported by ipv core). Eventually, we'll use this endpoint instead of the POST + UPDATE ones.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8252](https://govukverify.atlassian.net/browse/PYIC-8252)

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated



[PYIC-8252]: https://govukverify.atlassian.net/browse/PYIC-8252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ