### PR TITLE
[PYIC 8251] Update IPV_IDENTITY_STORED Event for SIS Integration

### DIFF
--- a/api-tests/data/audit-events/delete-pending-f2f-journey.json
+++ b/api-tests/data/audit-events/delete-pending-f2f-journey.json
@@ -205,7 +205,8 @@
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
       "identity_type": "pending",
-      "vot": null
+      "vot": null,
+      "sis_record_created": false
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/dwp-kbv-successful-journey.json
+++ b/api-tests/data/audit-events/dwp-kbv-successful-journey.json
@@ -376,7 +376,8 @@
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
       "identity_type": "new",
-      "vot": "P2"
+      "vot": "P2",
+      "sis_record_created": false
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/new-identity-f2f-journey.json
+++ b/api-tests/data/audit-events/new-identity-f2f-journey.json
@@ -217,7 +217,8 @@
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
       "identity_type": "pending",
-      "vot": null
+      "vot": null,
+      "sis_record_created": false
     },
     "restricted": {
       "device_information": {}
@@ -477,7 +478,8 @@
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
       "identity_type": "new",
-      "vot": "P2"
+      "vot": "P2",
+      "sis_record_created": false
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/new-identity-p2-app-journey.json
+++ b/api-tests/data/audit-events/new-identity-p2-app-journey.json
@@ -253,7 +253,8 @@
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
       "identity_type": "new",
-      "vot": "P2"
+      "vot": "P2",
+      "sis_record_created": true
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/reprove-identity-journey.json
+++ b/api-tests/data/audit-events/reprove-identity-journey.json
@@ -305,7 +305,8 @@
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
       "identity_type": "new",
-      "vot": "P2"
+      "vot": "P2",
+      "sis_record_created": false
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
+++ b/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
@@ -302,7 +302,8 @@
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
       "identity_type": "new",
-      "vot": "P2"
+      "vot": "P2",
+      "sis_record_created": false
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -524,7 +524,8 @@
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
       "identity_type": "update",
-      "vot": "P2"
+      "vot": "P2",
+      "sis_record_created": false
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -1,5 +1,6 @@
 Feature: Audit Events
   Scenario: New identity - p2 app journey
+    Given I activate the 'storedIdentityService' feature set
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionCandidateIdentityType.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionCandidateIdentityType.java
@@ -8,5 +8,6 @@ import uk.gov.di.ipv.core.library.enums.Vot;
 @ExcludeFromGeneratedCoverageReport
 public record AuditExtensionCandidateIdentityType(
         @JsonProperty(value = "identity_type", required = true) CandidateIdentityType identityType,
+        @JsonProperty(value = "sis_record_created", required = true) Boolean sisRecordCreated,
         @JsonProperty(required = false) Vot vot)
         implements AuditExtensions {}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
@@ -107,7 +107,8 @@ public class EvcsClient {
         }
     }
 
-    public void storeUserVCs(EvcsPutUserVCsDto userVCsForEvcs) throws EvcsServiceException {
+    public HttpResponse<String> storeUserVCs(EvcsPutUserVCsDto userVCsForEvcs)
+            throws EvcsServiceException {
         LOGGER.info(LogHelper.buildLogMessage("Preparing to store user VCs using PUT method"));
 
         try {
@@ -122,7 +123,7 @@ public class EvcsClient {
                                     configService.getSecret(ConfigurationVariable.EVCS_API_KEY))
                             .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
 
-            sendHttpRequest(httpRequestBuilder.build());
+            return sendHttpRequest(httpRequestBuilder.build());
         } catch (URISyntaxException e) {
             throw new EvcsServiceException(
                     HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_CONSTRUCT_EVCS_URI);
@@ -132,8 +133,8 @@ public class EvcsClient {
         }
     }
 
-    public void storeUserVCs(String userId, List<EvcsCreateUserVCsDto> userVCsForEvcs)
-            throws EvcsServiceException {
+    public HttpResponse<String> storeUserVCs(
+            String userId, List<EvcsCreateUserVCsDto> userVCsForEvcs) throws EvcsServiceException {
         LOGGER.info(
                 LogHelper.buildLogMessage(
                         "Preparing to store %d user VCs".formatted(userVCsForEvcs.size())));
@@ -149,7 +150,7 @@ public class EvcsClient {
                                     configService.getSecret(ConfigurationVariable.EVCS_API_KEY))
                             .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
 
-            sendHttpRequest(httpRequestBuilder.build());
+            return sendHttpRequest(httpRequestBuilder.build());
         } catch (URISyntaxException e) {
             throw new EvcsServiceException(
                     HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_CONSTRUCT_EVCS_URI);

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -180,7 +180,7 @@ public class EvcsService {
     }
 
     public void storePendingIdentityWithPut(String userId, List<VerifiableCredential> credentials)
-            throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
+            throws EvcsServiceException {
         var putUserVcsDto = createPendingPutUserVcsDto(userId, credentials);
         evcsClient.storeUserVCs(putUserVcsDto);
     }
@@ -258,32 +258,6 @@ public class EvcsService {
                         .toList();
         if (!CollectionUtils.isEmpty(existingEvcsUserVCs))
             updateExistingUserVCs(userId, credentials, existingEvcsUserVCs, isPendingIdentity);
-        if (!userVCsToStore.isEmpty()) evcsClient.storeUserVCs(userId, userVCsToStore);
-    }
-
-    public void storeCompletedIdentityWithPost(
-            String userId,
-            List<VerifiableCredential> credentials,
-            List<EvcsGetUserVCDto> existingEvcsUserVCs)
-            throws EvcsServiceException {
-        List<EvcsCreateUserVCsDto> userVCsToStore =
-                credentials.stream()
-                        .filter(
-                                credential ->
-                                        existingEvcsUserVCs.stream()
-                                                .noneMatch(
-                                                        evcsVC ->
-                                                                evcsVC.vc()
-                                                                        .equals(
-                                                                                credential
-                                                                                        .getVcString())))
-                        .map(
-                                vc ->
-                                        new EvcsCreateUserVCsDto(
-                                                vc.getVcString(), CURRENT, null, ONLINE))
-                        .toList();
-        if (!CollectionUtils.isEmpty(existingEvcsUserVCs))
-            updateExistingUserVCs(userId, credentials, existingEvcsUserVCs, false);
         if (!userVCsToStore.isEmpty()) evcsClient.storeUserVCs(userId, userVCsToStore);
     }
 

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -340,8 +340,7 @@ class EvcsServiceTest {
             var testVcs = List.of(VC_ADDRESS_TEST);
 
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPut(
-                    TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT, true);
+            evcsService.storePendingIdentityWithPut(TEST_USER_ID, testVcs);
 
             // Assert
             verify(mockEvcsClient).storeUserVCs(evcsPutUserVCsDtoCaptor.capture());
@@ -369,8 +368,8 @@ class EvcsServiceTest {
                     .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
 
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPut(
-                    TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT, false);
+            evcsService.storeCompletedIdentityWithPut(
+                    TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT);
 
             // Assert
             verify(mockEvcsClient).storeUserVCs(evcsPutUserVCsDtoCaptor.capture());


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update the existing IPV_IDENTITY_STORED TxMA event emitted by IPV Core when VCs are written to EVCS.

### Why did it change

The sis_record_created attribute will allow the Data and Analytics team to reliably track the volume of stored identity records being created during and after rollout.  
Updating the vot value ensures the event reflects the user's actual identity strength, aligned with what is stored in SIS. These changes improve visibility, auditability, and help assess the effectiveness and adoption of the Stored Identity Service over time.

Related PR for event catalogue: [PYIC-8251 Updated event catalogue for IPV_IDENTITY_STORED](https://github.com/govuk-one-login/event-catalogue/pull/414) 



### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8251](https://govukverify.atlassian.net/browse/PYIC-8251)

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated


[PYIC-8251]: https://govukverify.atlassian.net/browse/PYIC-8251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ