### PR TITLE
BAU: Add dynatrace trace id to logs

### DIFF
--- a/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
+++ b/lambdas/build-client-oauth-response/src/main/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandler.java
@@ -98,7 +98,7 @@ public class BuildClientOauthResponseHandler
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
     public Map<String, Object> handleRequest(JourneyRequest input, Context context) {
-
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
 
         try {

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -149,6 +149,7 @@ public class BuildCriOauthRequestHandler
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
     public Map<String, Object> handleRequest(CriJourneyRequest input, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
         try {
             // Parse input

--- a/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
+++ b/lambdas/build-proven-user-identity-details/src/main/java/uk/gov/di/ipv/core/buildprovenuseridentitydetails/BuildProvenUserIdentityDetailsHandler.java
@@ -76,6 +76,7 @@ public class BuildProvenUserIdentityDetailsHandler
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
         ProvenUserIdentityDetails.ProvenUserIdentityDetailsBuilder
                 provenUserIdentityDetailsBuilder = ProvenUserIdentityDetails.builder();

--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandler.java
@@ -97,6 +97,8 @@ public class BuildUserIdentityHandler extends UserIdentityRequestHandler
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachTraceId();
+        LogHelper.attachComponentId(configService);
 
         try {
             var ipvSessionItem = super.validateAccessTokenAndGetIpvSession(input);

--- a/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandler.java
+++ b/lambdas/call-dcmaw-async-cri/src/main/java/uk/gov/di/ipv/core/calldcmawasynccri/CallDcmawAsyncCriHandler.java
@@ -95,6 +95,7 @@ public class CallDcmawAsyncCriHandler
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
     public Map<String, Object> handleRequest(ProcessRequest request, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
         LogHelper.attachCriIdToLogs(DCMAW_ASYNC);
         List<String> featureSets = RequestHelper.getFeatureSet(request);

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -198,6 +198,7 @@ public class CheckExistingIdentityHandler
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
     public Map<String, Object> handleRequest(JourneyRequest event, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
 
         try {

--- a/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
+++ b/lambdas/check-gpg45-score/src/main/java/uk/gov/di/ipv/core/checkgpg45score/CheckGpg45ScoreHandler.java
@@ -86,6 +86,7 @@ public class CheckGpg45ScoreHandler implements RequestHandler<ProcessRequest, Ma
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
     public Map<String, Object> handleRequest(ProcessRequest event, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
 
         try {

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -101,6 +101,9 @@ public class CheckMobileAppVcReceiptHandler
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachTraceId();
+        LogHelper.attachComponentId(configService);
+
         try {
             var request = parseRequest(input);
 
@@ -192,7 +195,6 @@ public class CheckMobileAppVcReceiptHandler
                 clientOAuthSessionItem.getGovukSigninJourneyId());
         LogHelper.attachIpvSessionIdToLogs(request.getIpvSessionId());
         LogHelper.attachFeatureSetToLogs(request.getFeatureSet());
-        LogHelper.attachComponentId(configService);
 
         // Retrieve and validate cri response and vc
         var criResponseItem = criResponseService.getCriResponseItem(userId, DCMAW_ASYNC);

--- a/lambdas/check-reverification-identity/src/main/java/uk/gov/di/ipv/core/checkreverificationidentity/CheckReverificationIdentityHandler.java
+++ b/lambdas/check-reverification-identity/src/main/java/uk/gov/di/ipv/core/checkreverificationidentity/CheckReverificationIdentityHandler.java
@@ -99,6 +99,7 @@ public class CheckReverificationIdentityHandler
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
     public Map<String, Object> handleRequest(JourneyRequest request, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
         configService.setFeatureSet(RequestHelper.getFeatureSet(request));
 

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -145,6 +145,7 @@ public class InitialiseIpvSessionHandler
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
 
         try {

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/IssueClientAccessTokenHandler.java
@@ -88,6 +88,7 @@ public class IssueClientAccessTokenHandler
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
         try {
             tokenRequestValidator.authenticateClient(input.getBody());

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -96,6 +96,7 @@ public class ProcessAsyncCriCredentialHandler
     @Metrics(captureColdStart = true)
     public SQSBatchResponse handleRequest(SQSEvent event, Context context) {
         try {
+            LogHelper.attachTraceId();
             LogHelper.attachComponentId(configService);
             var failedRecords = new ArrayList<SQSBatchResponse.BatchItemFailure>();
 

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -201,6 +201,7 @@ public class ProcessCandidateIdentityHandler
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
     public Map<String, Object> handleRequest(ProcessRequest request, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
         configService.setFeatureSet(RequestHelper.getFeatureSet(request));
 

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -149,6 +149,8 @@ public class ProcessCriCallbackHandler
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachTraceId();
+        LogHelper.attachComponentId(configService);
         CriCallbackRequest callbackRequest = null;
 
         try {
@@ -323,7 +325,6 @@ public class ProcessCriCallbackHandler
         LogHelper.attachIpvSessionIdToLogs(callbackRequest.getIpvSessionId());
         LogHelper.attachFeatureSetToLogs(callbackRequest.getFeatureSet());
         LogHelper.attachCriIdToLogs(callbackRequest.getCredentialIssuer());
-        LogHelper.attachComponentId(configService);
         LogHelper.attachCriSessionIdToLogs(callbackRequest.getState());
 
         EmbeddedMetricHelper.criReturn(callbackRequest.getCredentialIssuerId());

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -138,6 +138,7 @@ public class ProcessJourneyEventHandler
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
     public Map<String, Object> handleRequest(JourneyRequest journeyRequest, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
 
         try {

--- a/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
+++ b/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
@@ -87,6 +87,9 @@ public class ProcessMobileAppCallbackHandler
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachTraceId();
+        LogHelper.attachComponentId(configService);
+
         try {
             var callbackRequest = parseCallbackRequest(input);
 
@@ -150,7 +153,6 @@ public class ProcessMobileAppCallbackHandler
         // Attach variables to logs
         LogHelper.attachIpvSessionIdToLogs(callbackRequest.getIpvSessionId());
         LogHelper.attachFeatureSetToLogs(callbackRequest.getFeatureSet());
-        LogHelper.attachComponentId(configService);
 
         // Validate CRI state
         var criState = callbackRequest.getState();

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -91,6 +91,7 @@ public class ResetSessionIdentityHandler
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
     public Map<String, Object> handleRequest(ProcessRequest input, Context context) {
+        LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);
         configService.setFeatureSet(RequestHelper.getFeatureSet(input));
 

--- a/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
+++ b/lambdas/user-reverification/src/main/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandler.java
@@ -91,6 +91,8 @@ public class UserReverificationHandler extends UserIdentityRequestHandler
     @Metrics(captureColdStart = true)
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        LogHelper.attachTraceId();
+        LogHelper.attachComponentId(configService);
 
         try {
             var ipvSessionItem = super.validateAccessTokenAndGetIpvSession(input);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.helpers;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import io.opentelemetry.api.trace.Span;
 import org.apache.logging.log4j.message.StringMapMessage;
 import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.lambda.powertools.logging.LoggingUtils;
@@ -78,7 +79,9 @@ public class LogHelper {
         LOG_SCORE_TYPE("scoreType"),
         LOG_SECRET_ID("secretId"),
         LOG_SHA256_ACCESS_TOKEN("sha256AccessToken"),
+        LOG_SPAN_ID("dt.span_id"),
         LOG_STATUS_CODE("statusCode"),
+        LOG_TRACE_ID("dt.trace_id"),
         LOG_UNCORRELATABLE_DATA("uncorrelatableData"),
         LOG_USER_STATE("userState"),
         LOG_VOT("vot");
@@ -96,6 +99,16 @@ public class LogHelper {
 
     private LogHelper() {
         throw new IllegalStateException("Utility class");
+    }
+
+    public static void attachTraceId() {
+        // Adapted from
+        // https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-log-enrichment#retrieve-span-and-trace-ids
+        var spanContext = Span.current().getSpanContext();
+        if (spanContext.isValid()) {
+            attachFieldToLogs(LogField.LOG_TRACE_ID, spanContext.getTraceId());
+            attachFieldToLogs(LogField.LOG_SPAN_ID, spanContext.getSpanId());
+        }
     }
 
     public static void attachComponentId(ConfigService configService) {


### PR DESCRIPTION
## Proposed changes

### What changed

Add trace id (and span id, for completeness) to the logs

### Why did it change

So we can link traces in dynatrace with specific logs

We should also update https://team-manual.account.gov.uk/teams/IPV-Core-team/How-IPV-Core-Works/distributed-tracing/