### PR TITLE
PYIC-8252: fallback to post method if put fails

### DIFF
--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
@@ -217,6 +217,36 @@ class StoreIdentityServiceTest {
             verify(evcsService, times(1))
                     .storeCompletedOrPendingIdentityWithPost(USER_ID, VCS, List.of(), true);
         }
+
+        @Test
+        void
+                shouldSendAuditEventWithNullVotAndIdentityTypeExtensionWhenIdentityPendingWithFailedVot()
+                        throws Exception {
+            // Act
+            storeIdentityService.storeIdentity(
+                    USER_ID,
+                    VCS,
+                    List.of(),
+                    P0,
+                    STRONGEST_MATCHED_VOT,
+                    CandidateIdentityType.PENDING,
+                    sharedAuditEventParameters);
+
+            // Assert
+            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
+            var auditEvent = auditEventCaptor.getValue();
+
+            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
+            assertNull(((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).vot());
+            assertEquals(
+                    CandidateIdentityType.PENDING,
+                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
+                            .identityType());
+            assertEquals(COMPONENT_ID, auditEvent.getComponentId());
+            assertEquals(testAuditEventUser, auditEvent.getUser());
+            verify(evcsService, times(1))
+                    .storeCompletedOrPendingIdentityWithPost(any(), any(), any(), anyBoolean());
+        }
     }
 
     @Test

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
@@ -196,7 +196,7 @@ class StoreIdentityServiceTest {
                     USER_ID,
                     VCS,
                     List.of(),
-                    P2,
+                    P0,
                     STRONGEST_MATCHED_VOT,
                     CandidateIdentityType.PENDING,
                     sharedAuditEventParameters);
@@ -205,8 +205,7 @@ class StoreIdentityServiceTest {
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
             var auditEvent = auditEventCaptor.getValue();
             assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertEquals(
-                    P2, ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).vot());
+            assertNull(((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).vot());
             assertEquals(
                     CandidateIdentityType.PENDING,
                     ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Update storing VCs to EVCS to use POST if constructing the SI or using the PUT method fails.

### Why did it change
To fulfil AC 3 on the ticket.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8252](https://govukverify.atlassian.net/browse/PYIC-8252)

## Checklists
<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated


[PYIC-8252]: https://govukverify.atlassian.net/browse/PYIC-8252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ