### PR TITLE
BAU: Fix IOException alarm namespace

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3232,7 +3232,7 @@ Resources:
           ReturnData: true
           MetricStat:
             Metric:
-              Namespace: AWS/Lambda
+              Namespace: Custom/Lambda
               MetricName: IOExceptionCount
             Period: 60
             Stat: Sum


### PR DESCRIPTION
## Proposed changes

### What changed

- Fix IOException alarm to reference the correct namespace

### Why did it change

- Before, it was looking for the metric in an incorrect namespace

### Issue tracking

- [PYIC-8222](https://govukverify.atlassian.net/browse/PYIC-8222)

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated

<!-- Delete if changes don't apply -->
- [x] Production changes appropriately staged out


[PYIC-8222]: https://govukverify.atlassian.net/browse/PYIC-8222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ