### PR TITLE
PYIC-8327: Remove kidJarHeaderEnabled feature flag.

### DIFF
--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -64,7 +64,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.KID_JAR_HEADER;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.Cri.DWP_KBV;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
@@ -378,12 +377,8 @@ public class BuildCriOauthRequestHandler
 
         RSAEncrypter rsaEncrypter = new RSAEncrypter(encKey);
 
-        if (configService.enabled(KID_JAR_HEADER)) {
-            return AuthorizationRequestHelper.createJweObject(
-                    rsaEncrypter, signedJWT, encKey.getKeyID());
-        }
-
-        return AuthorizationRequestHelper.createJweObject(rsaEncrypter, signedJWT, null);
+        return AuthorizationRequestHelper.createJweObject(
+                rsaEncrypter, signedJWT, encKey.getKeyID());
     }
 
     private EvidenceRequest getEvidenceRequestForF2F(

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -88,7 +88,7 @@ public class AuthorizationRequestHelper {
         }
 
         try {
-            return createSignedJwt(claimsSetBuilder.build(), signer, true);
+            return createSignedJwt(claimsSetBuilder.build(), signer);
         } catch (JOSEException e) {
             LOGGER.error(LogHelper.buildErrorMessage("Failed to sign shared attributes", e));
             throw new HttpResponseExceptionWithErrorBody(

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelper.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.KID_JAR_HEADER;
 import static uk.gov.di.ipv.core.library.helpers.JwtHelper.createSignedJwt;
 
 public class AuthorizationRequestHelper {
@@ -89,8 +88,7 @@ public class AuthorizationRequestHelper {
         }
 
         try {
-            return createSignedJwt(
-                    claimsSetBuilder.build(), signer, configService.enabled(KID_JAR_HEADER));
+            return createSignedJwt(claimsSetBuilder.build(), signer, true);
         } catch (JOSEException e) {
             LOGGER.error(LogHelper.buildErrorMessage("Failed to sign shared attributes", e));
             throw new HttpResponseExceptionWithErrorBody(

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -55,7 +55,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.KID_JAR_HEADER;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PRIVATE_KEY;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
@@ -110,7 +109,6 @@ class AuthorizationRequestHelperTest {
             throws JOSEException, ParseException, HttpResponseExceptionWithErrorBody {
         setupCredentialIssuerConfigMock();
         setupConfigurationServiceMock();
-        when(configService.enabled(KID_JAR_HEADER)).thenReturn(true);
         when(oauthCriConfig.getComponentId()).thenReturn(AUDIENCE);
         when(oauthCriConfig.getClientCallbackUrl()).thenReturn(URI.create(TEST_REDIRECT_URI));
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -8,7 +8,6 @@ public enum CoreFeatureFlag implements FeatureFlag {
     MFA_RESET("mfaResetEnabled"),
     P1_JOURNEYS_ENABLED("p1JourneysEnabled"),
     SQS_ASYNC("sqsAsync"),
-    KID_JAR_HEADER("kidJarHeaderEnabled"),
     DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
     STORED_IDENTITY_SERVICE("storedIdentityServiceEnabled"),
     AIS_ENABLED("accountInterventionsEnabled");

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/JwtHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/JwtHelper.java
@@ -13,9 +13,9 @@ import uk.gov.di.ipv.core.library.signing.CoreSigner;
 public class JwtHelper {
     private JwtHelper() {}
 
-    public static SignedJWT createSignedJwt(
-            JWTClaimsSet claimsSet, CoreSigner signer, boolean includeKid) throws JOSEException {
-        JWSHeader jwsHeader = generateHeader(includeKid ? signer.getKid() : null);
+    public static SignedJWT createSignedJwt(JWTClaimsSet claimsSet, CoreSigner signer)
+            throws JOSEException {
+        JWSHeader jwsHeader = generateHeader(signer.getKid());
         SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
         signedJWT.sign(signer);
         return signedJWT;

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/JwtHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/JwtHelperTest.java
@@ -13,8 +13,6 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.core.library.signing.LocalECDSASigner;
 
@@ -23,7 +21,6 @@ import java.time.Instant;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.DER_SIGNATURE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
@@ -33,13 +30,12 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.TEST_EC_PUBLIC_JW
 class JwtHelperTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void shouldCreateValidSignedJWT(boolean includeKid) throws Exception {
+    @Test
+    void shouldCreateValidSignedJWT() throws Exception {
         var signer = new LocalECDSASigner(getPrivateKey());
         var exampleClaimsSet = new JWTClaimsSet.Builder().claim("exampleField", "test").build();
 
-        var signedJWT = JwtHelper.createSignedJwt(exampleClaimsSet, signer, includeKid);
+        var signedJWT = JwtHelper.createSignedJwt(exampleClaimsSet, signer);
         var generatedClaims = signedJWT.getJWTClaimsSet();
 
         assertTrue(signedJWT.verify(new ECDSAVerifier(ECKey.parse(TEST_EC_PUBLIC_JWK))));
@@ -47,11 +43,7 @@ class JwtHelperTest {
         var claimsSet = OBJECT_MAPPER.readTree(generatedClaims.toString());
         assertEquals("test", claimsSet.get("exampleField").asText());
 
-        if (includeKid) {
-            assertEquals("test-fixtures-ec-key", signedJWT.getHeader().getKeyID());
-        } else {
-            assertNull(signedJWT.getHeader().getKeyID());
-        }
+        assertEquals("test-fixtures-ec-key", signedJWT.getHeader().getKeyID());
     }
 
     @Test

--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -52,7 +52,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Objects;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.KID_JAR_HEADER;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ENVIRONMENT;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.Cri.DWP_KBV;
@@ -196,10 +195,7 @@ public class CriApiService {
                             .build();
 
             var signedClientJwt =
-                    JwtHelper.createSignedJwt(
-                            clientAuthClaimsSet,
-                            signerFactory.getSigner(),
-                            configService.enabled(KID_JAR_HEADER));
+                    JwtHelper.createSignedJwt(clientAuthClaimsSet, signerFactory.getSigner(), true);
             var clientAuthentication = new PrivateKeyJWT(signedClientJwt);
             var redirectionUri = criConfig.getClientCallbackUrl();
             var authorizationGrant = new AuthorizationCodeGrant(authorizationCode, redirectionUri);

--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -195,7 +195,7 @@ public class CriApiService {
                             .build();
 
             var signedClientJwt =
-                    JwtHelper.createSignedJwt(clientAuthClaimsSet, signerFactory.getSigner(), true);
+                    JwtHelper.createSignedJwt(clientAuthClaimsSet, signerFactory.getSigner());
             var clientAuthentication = new PrivateKeyJWT(signedClientJwt);
             var redirectionUri = criConfig.getClientCallbackUrl();
             var authorizationGrant = new AuthorizationCodeGrant(authorizationCode, redirectionUri);

--- a/libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java
+++ b/libs/cri-api-service/src/test/java/uk/gov/di/ipv/core/library/criapiservice/CriApiServiceTest.java
@@ -50,7 +50,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.JWT_TTL_SECONDS;
@@ -319,7 +318,7 @@ class CriApiServiceTest {
 
         try (MockedStatic<JwtHelper> mockedJwtHelper = Mockito.mockStatic(JwtHelper.class)) {
             mockedJwtHelper
-                    .when(() -> JwtHelper.createSignedJwt(any(), any(), anyBoolean()))
+                    .when(() -> JwtHelper.createSignedJwt(any(), any()))
                     .thenThrow(new JOSEException("Test JOSE Exception"));
             when(mockConfigService.getLongParameter(JWT_TTL_SECONDS)).thenReturn(900L);
             when(mockSignerFactory.getSigner()).thenReturn(new LocalECDSASigner(getPrivateKey()));

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityService.java
@@ -94,7 +94,7 @@ public class StoredIdentityService {
         try {
             var storedIdentity = createStoredIdentityJwt(userId, vcs, achievedVot);
 
-            return createSignedJwt(storedIdentity, signerFactory.getSigner(), false).serialize();
+            return createSignedJwt(storedIdentity, signerFactory.getSigner()).serialize();
         } catch (CredentialParseException e) {
             LOGGER.error(LogHelper.buildLogMessage("Unable to parse user credentials"));
             throw new FailedToCreateStoredIdentityForEvcsException(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Features Set - KID_JAR_HEADER removed and cleaned places that depends on it.

### Why did it change

As kidJarHeaderEnabled feature flag is enabled across all environments, it can be removed from the project.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8327](https://govukverify.atlassian.net/browse/PYIC-8327)
- [ipv-core-common-infra](https://github.com/govuk-one-login/ipv-core-common-infra/pull/1228)

## Checklists

<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated


[PYIC-8327]: https://govukverify.atlassian.net/browse/PYIC-8327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ