### PR TITLE
BAU Re-enable isolated DT lambda and switch off debug logging

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -127,9 +127,6 @@ Conditions:
   IsDevOrBuildOrStaging: !Or
     - !Condition IsDevOrBuild
     - !Condition IsStaging
-  IsBuildOrStaging: !Or
-    - !Condition IsBuild
-    - !Condition IsStaging
   IsProduction: !Equals [ !Ref Environment, "production" ]
   IsStagingIntProd: !Or
     - !Equals [ !Ref Environment, staging ]
@@ -1161,15 +1158,6 @@ Resources:
             - UseDynatrace
             - /opt/dynatrace
             - !Ref AWS::NoValue
-          # PYIC-8242 Turn on DT debug logging for single build lambda
-          DT_LOGGING_DESTINATION: !If
-            - IsBuild
-            - "stdout"
-            - !Ref AWS::NoValue
-          DT_LOGGING_JAVA_FLAGS: !If
-            - IsBuild
-            - "log-Transformer=true,log-OpenTelemetryUtils=true,log-AsyncClassRetransformer=true,log-ClassValue=true"
-            - !Ref AWS::NoValue
       Layers:
         - !If
           - UseDynatrace
@@ -2129,22 +2117,16 @@ Resources:
           # https://govukverify.atlassian.net/browse/PYIC-8220
           AWS_LAMBDA_EXEC_WRAPPER: !If
             - UseDynatrace
-            - !If
-              - IsBuildOrStaging
-              - !Ref AWS::NoValue
-              - /opt/dynatrace
+            - /opt/dynatrace
             - !Ref AWS::NoValue
       Layers:
         - !If
           - UseDynatrace
-          - !If
-            - IsBuildOrStaging
-            - !Ref AWS::NoValue
-            - !FindInMap [
-              EnvironmentConfiguration,
-              !Ref 'AWS::AccountId',
-              dynatraceLayerArn,
-            ]
+          - !FindInMap [
+            EnvironmentConfiguration,
+            !Ref 'AWS::AccountId',
+            dynatraceLayerArn,
+          ]
           - !Ref AWS::NoValue
       VpcConfig:
         SubnetIds:


### PR DESCRIPTION
## Proposed changes

### What changed

Re-enable dynatrace in check-existing-identity build/staging lambda
Switch off dynatrace debug logging in process-cri-callback build lambda

### Why did it change

We had tried this to see if we could reproduce the segfault/IOException issue in (a) a lambda with DT disabled and (b) a lambda with DT debug logging switched on. We have not seen an occurrence in either in the past 2 months (while the issue has recurred across other lambdas in the same period). I don't think we're going to gather any further evidence out of this

### Issue tracking
- [PYIC-7888](https://govukverify.atlassian.net/browse/PYIC-7888)



[PYIC-7888]: https://govukverify.atlassian.net/browse/PYIC-7888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ