### PR TITLE
PYIC-8390: Abandon DCMAW Async VCs on REMOVE_DCMAW_FROM_SESSION

### DIFF
--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
@@ -93,7 +93,6 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity
 
-    @MikeC
     Scenario: Auth check abandoned, retry with CI
       When I call the CRI stub and get an 'access_denied' OAuth error
       Then I get a 'uk-driving-licence-details-not-correct' page response with context 'strategicApp'

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
@@ -93,6 +93,29 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity
 
+    @MikeC
+    Scenario: Auth check abandoned, retry with CI
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'uk-driving-licence-details-not-correct' page response with context 'strategicApp'
+      When I submit a 'next' event
+
+      # Reattempt
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'pyi-no-match' page response
+
     Scenario: CI on auth check asks for alternative document
       When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
         | Attribute | Values          |

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-handle-result.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-handle-result.yaml
@@ -54,7 +54,7 @@ nestedJourneyStates:
       type: process
       lambda: reset-session-identity
       lambdaInput:
-        resetType: PENDING_DCMAW_ALL
+        resetType: PENDING_DCMAW_ASYNC_ALL
     events:
       next:
         targetState: DL_DETAILS_INCORRECT_PAGE
@@ -64,7 +64,7 @@ nestedJourneyStates:
       type: process
       lambda: reset-session-identity
       lambdaInput:
-        resetType: DCMAW
+        resetType: DCMAW_ASYNC
     events:
       next:
         exitEventToEmit: failedDlAuthCheckInvalidDl

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-handle-result.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-handle-result.yaml
@@ -54,7 +54,7 @@ nestedJourneyStates:
       type: process
       lambda: reset-session-identity
       lambdaInput:
-        resetType: DCMAW
+        resetType: PENDING_DCMAW_ALL
     events:
       next:
         targetState: DL_DETAILS_INCORRECT_PAGE

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -8,6 +8,7 @@ import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.criresponse.service.CriResponseService;
+import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.JourneyErrorResponse;
 import uk.gov.di.ipv.core.library.domain.JourneyResponse;
 import uk.gov.di.ipv.core.library.domain.ProcessRequest;
@@ -30,10 +31,12 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredential
 import java.io.UncheckedIOException;
 import java.util.Map;
 
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
+import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_DCMAW_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.REINSTATE;
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
@@ -127,7 +130,11 @@ public class ResetSessionIdentityHandler
             }
 
             if (sessionCredentialsResetType.equals(PENDING_F2F_ALL)) {
-                doResetForPendingF2f(clientOAuthSessionItem);
+                doResetForPendingVc(clientOAuthSessionItem, F2F);
+            }
+
+            if (sessionCredentialsResetType.equals(PENDING_DCMAW_ALL)) {
+                doResetForPendingVc(clientOAuthSessionItem, DCMAW_ASYNC);
             }
 
             return JOURNEY_NEXT;
@@ -169,10 +176,10 @@ public class ResetSessionIdentityHandler
         }
     }
 
-    private void doResetForPendingF2f(ClientOAuthSessionItem clientOAuthSessionItem)
+    private void doResetForPendingVc(ClientOAuthSessionItem clientOAuthSessionItem, Cri asyncCri)
             throws EvcsServiceException {
         var userId = clientOAuthSessionItem.getUserId();
-        criResponseService.deleteCriResponseItem(userId, F2F);
+        criResponseService.deleteCriResponseItem(userId, asyncCri);
         evcsService.abandonPendingIdentity(userId, clientOAuthSessionItem.getEvcsAccessToken());
         LOGGER.info(LogHelper.buildLogMessage("Reset done for F2F pending identity."));
     }

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -181,6 +181,8 @@ public class ResetSessionIdentityHandler
         var userId = clientOAuthSessionItem.getUserId();
         criResponseService.deleteCriResponseItem(userId, asyncCri);
         evcsService.abandonPendingIdentity(userId, clientOAuthSessionItem.getEvcsAccessToken());
-        LOGGER.info(LogHelper.buildLogMessage("Reset done for F2F pending identity."));
+        LOGGER.info(
+                LogHelper.buildLogMessage(
+                        String.format("Reset done for %s pending identity.", asyncCri.getId())));
     }
 }

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -36,7 +36,7 @@ import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
-import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_DCMAW_ALL;
+import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_DCMAW_ASYNC_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.REINSTATE;
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
@@ -133,7 +133,7 @@ public class ResetSessionIdentityHandler
                 doResetForPendingVc(clientOAuthSessionItem, F2F);
             }
 
-            if (sessionCredentialsResetType.equals(PENDING_DCMAW_ALL)) {
+            if (sessionCredentialsResetType.equals(PENDING_DCMAW_ASYNC_ALL)) {
                 doResetForPendingVc(clientOAuthSessionItem, DCMAW_ASYNC);
             }
 

--- a/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
+++ b/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
@@ -50,7 +50,7 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_IPV_SESSIO
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.NAME_ONLY_CHANGE;
-import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_DCMAW_ALL;
+import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_DCMAW_ASYNC_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.REINSTATE;
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
@@ -209,7 +209,7 @@ class ResetSessionIdentityHandlerTest {
                 ProcessRequest.processRequestBuilder()
                         .ipvSessionId(TEST_SESSION_ID)
                         .featureSet(TEST_FEATURE_SET)
-                        .lambdaInput(Map.of("resetType", PENDING_DCMAW_ALL.name()))
+                        .lambdaInput(Map.of("resetType", PENDING_DCMAW_ASYNC_ALL.name()))
                         .build();
 
         // Act
@@ -223,7 +223,7 @@ class ResetSessionIdentityHandlerTest {
 
         verify(mockSessionCredentialsService)
                 .deleteSessionCredentialsForResetType(
-                        ipvSessionItem.getIpvSessionId(), PENDING_DCMAW_ALL);
+                        ipvSessionItem.getIpvSessionId(), PENDING_DCMAW_ASYNC_ALL);
         verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, DCMAW_ASYNC);
         verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
 

--- a/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
+++ b/lambdas/reset-session-identity/src/test/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandlerTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_AT_EVCS_HTTP_REQUEST_SEND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_DELETE_CREDENTIAL;
@@ -49,6 +50,7 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_IPV_SESSIO
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.NAME_ONLY_CHANGE;
+import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_DCMAW_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.REINSTATE;
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
@@ -195,6 +197,37 @@ class ResetSessionIdentityHandlerTest {
         assertEquals(500, journeyResponse.get(STATUS_CODE));
         assertEquals(FAILED_AT_EVCS_HTTP_REQUEST_SEND.getCode(), journeyResponse.get("code"));
         assertEquals(FAILED_AT_EVCS_HTTP_REQUEST_SEND.getMessage(), journeyResponse.get("message"));
+    }
+
+    @Test
+    void handleRequestShouldCleanupVcsAndReturnNextForPendingDcmaw() throws Exception {
+        // Arrange
+        when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        var event =
+                ProcessRequest.processRequestBuilder()
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .featureSet(TEST_FEATURE_SET)
+                        .lambdaInput(Map.of("resetType", PENDING_DCMAW_ALL.name()))
+                        .build();
+
+        // Act
+        var journeyResponse =
+                OBJECT_MAPPER.convertValue(
+                        resetSessionIdentityHandler.handleRequest(event, mockContext),
+                        JourneyResponse.class);
+
+        // Assert
+        verifyVotSetToP0();
+
+        verify(mockSessionCredentialsService)
+                .deleteSessionCredentialsForResetType(
+                        ipvSessionItem.getIpvSessionId(), PENDING_DCMAW_ALL);
+        verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, DCMAW_ASYNC);
+        verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+
+        assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
@@ -6,5 +6,6 @@ public enum SessionCredentialsResetType {
     NAME_ONLY_CHANGE,
     ADDRESS_ONLY_CHANGE,
     PENDING_F2F_ALL,
+    PENDING_DCMAW_ALL,
     REINSTATE
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
@@ -3,9 +3,10 @@ package uk.gov.di.ipv.core.library.enums;
 public enum SessionCredentialsResetType {
     ALL,
     DCMAW,
+    DCMAW_ASYNC,
     NAME_ONLY_CHANGE,
     ADDRESS_ONLY_CHANGE,
     PENDING_F2F_ALL,
-    PENDING_DCMAW_ALL,
+    PENDING_DCMAW_ASYNC_ALL,
     REINSTATE
 }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -100,7 +100,7 @@ public class SessionCredentialsService {
             var sessionCredentialItems = dataStore.getItems(ipvSessionId);
             var vcsToDelete =
                     switch (resetType) {
-                        case ALL, PENDING_F2F_ALL, PENDING_DCMAW_ASYNC_ALL, REINSTATE ->
+                        case ALL, PENDING_F2F_ALL, REINSTATE ->
                                 sessionCredentialItems;
                         case ADDRESS_ONLY_CHANGE ->
                                 sessionCredentialItems.stream()
@@ -115,7 +115,7 @@ public class SessionCredentialsService {
                                 sessionCredentialItems.stream()
                                         .filter(item -> DCMAW.getId().equals(item.getCriId()))
                                         .toList();
-                        case DCMAW_ASYNC ->
+                        case DCMAW_ASYNC, PENDING_DCMAW_ASYNC_ALL ->
                                 sessionCredentialItems.stream()
                                         .filter(item -> DCMAW_ASYNC.getId().equals(item.getCriId()))
                                         .toList();

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -100,8 +100,7 @@ public class SessionCredentialsService {
             var sessionCredentialItems = dataStore.getItems(ipvSessionId);
             var vcsToDelete =
                     switch (resetType) {
-                        case ALL, PENDING_F2F_ALL, REINSTATE ->
-                                sessionCredentialItems;
+                        case ALL, PENDING_F2F_ALL, REINSTATE -> sessionCredentialItems;
                         case ADDRESS_ONLY_CHANGE ->
                                 sessionCredentialItems.stream()
                                         .filter(

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -109,7 +109,7 @@ public class SessionCredentialsService {
                                                                         EXPERIAN_FRAUD.getId())
                                                                 .contains(item.getCriId()))
                                         .toList();
-                        case DCMAW ->
+                        case DCMAW, PENDING_DCMAW_ALL ->
                                 sessionCredentialItems.stream()
                                         .filter(item -> DCMAW.getId().equals(item.getCriId()))
                                         .toList();

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.SESSION_CREDENTIALS_TTL;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_FRAUD;
 
 public class SessionCredentialsService {
@@ -99,7 +100,8 @@ public class SessionCredentialsService {
             var sessionCredentialItems = dataStore.getItems(ipvSessionId);
             var vcsToDelete =
                     switch (resetType) {
-                        case ALL, PENDING_F2F_ALL, REINSTATE -> sessionCredentialItems;
+                        case ALL, PENDING_F2F_ALL, PENDING_DCMAW_ASYNC_ALL, REINSTATE ->
+                                sessionCredentialItems;
                         case ADDRESS_ONLY_CHANGE ->
                                 sessionCredentialItems.stream()
                                         .filter(
@@ -109,9 +111,13 @@ public class SessionCredentialsService {
                                                                         EXPERIAN_FRAUD.getId())
                                                                 .contains(item.getCriId()))
                                         .toList();
-                        case DCMAW, PENDING_DCMAW_ALL ->
+                        case DCMAW ->
                                 sessionCredentialItems.stream()
                                         .filter(item -> DCMAW.getId().equals(item.getCriId()))
+                                        .toList();
+                        case DCMAW_ASYNC ->
+                                sessionCredentialItems.stream()
+                                        .filter(item -> DCMAW_ASYNC.getId().equals(item.getCriId()))
                                         .toList();
                         case NAME_ONLY_CHANGE ->
                                 sessionCredentialItems.stream()

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -291,7 +291,7 @@ class SessionCredentialsServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(names = {"ALL", "PENDING_F2F_ALL", "PENDING_DCMAW_ASYNC_ALL", "REINSTATE"})
+        @EnumSource(names = {"ALL", "PENDING_F2F_ALL", "REINSTATE"})
         void deleteSessionCredentialsForResetTypeShouldDeleteAllVcs(
                 SessionCredentialsResetType resetType) throws Exception {
             var addressVc =
@@ -352,9 +352,10 @@ class SessionCredentialsServiceTest {
             verify(mockDataStore).delete(List.of(sessionDcmawCredentialItem));
         }
 
-        @Test
-        void deleteSessionCredentialsForResetTypePendingDcmawAsyncAllShouldDeleteDcmawAsyncVcs()
-                throws Exception {
+        @ParameterizedTest
+        @EnumSource(names = {"DCMAW_ASYNC", "PENDING_DCMAW_ASYNC_ALL"})
+        void deleteSessionCredentialsForResetTypePendingDcmawAsyncAllShouldDeleteDcmawAsyncVcs(
+                SessionCredentialsResetType resetType) throws Exception {
             var addressVc =
                     generateVerifiableCredential("userId", ADDRESS, vcClaimFailedWithCis(null));
             var fraudVc =
@@ -375,8 +376,7 @@ class SessionCredentialsServiceTest {
                                     sessionAddressCredentialItem,
                                     sessionDcmawCredentialItem));
 
-            sessionCredentialService.deleteSessionCredentialsForResetType(
-                    SESSION_ID, SessionCredentialsResetType.DCMAW_ASYNC);
+            sessionCredentialService.deleteSessionCredentialsForResetType(SESSION_ID, resetType);
 
             verify(mockDataStore).getItems(SESSION_ID);
             verify(mockDataStore).delete(List.of(sessionDcmawCredentialItem));

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_FRAUD;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_DELETE_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
@@ -290,7 +291,7 @@ class SessionCredentialsServiceTest {
         }
 
         @ParameterizedTest
-        @EnumSource(names = {"ALL", "PENDING_F2F_ALL", "REINSTATE"})
+        @EnumSource(names = {"ALL", "PENDING_F2F_ALL", "PENDING_DCMAW_ASYNC_ALL", "REINSTATE"})
         void deleteSessionCredentialsForResetTypeShouldDeleteAllVcs(
                 SessionCredentialsResetType resetType) throws Exception {
             var addressVc =
@@ -352,7 +353,7 @@ class SessionCredentialsServiceTest {
         }
 
         @Test
-        void deleteSessionCredentialsForResetTypePendingDcmawAllShouldDeleteDcmawVcs()
+        void deleteSessionCredentialsForResetTypePendingDcmawAsyncAllShouldDeleteDcmawAsyncVcs()
                 throws Exception {
             var addressVc =
                     generateVerifiableCredential("userId", ADDRESS, vcClaimFailedWithCis(null));
@@ -360,7 +361,8 @@ class SessionCredentialsServiceTest {
                     generateVerifiableCredential(
                             "userId", EXPERIAN_FRAUD, vcClaimFailedWithCis(null));
 
-            var dcmawVc = generateVerifiableCredential("userId", DCMAW, vcClaimFailedWithCis(null));
+            var dcmawVc =
+                    generateVerifiableCredential("userId", DCMAW_ASYNC, vcClaimFailedWithCis(null));
 
             var sessionFraudCredentialItem = fraudVc.toSessionCredentialItem(SESSION_ID, true);
             var sessionAddressCredentialItem = addressVc.toSessionCredentialItem(SESSION_ID, true);
@@ -374,7 +376,7 @@ class SessionCredentialsServiceTest {
                                     sessionDcmawCredentialItem));
 
             sessionCredentialService.deleteSessionCredentialsForResetType(
-                    SESSION_ID, SessionCredentialsResetType.PENDING_DCMAW_ALL);
+                    SESSION_ID, SessionCredentialsResetType.DCMAW_ASYNC);
 
             verify(mockDataStore).getItems(SESSION_ID);
             verify(mockDataStore).delete(List.of(sessionDcmawCredentialItem));

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -324,7 +324,7 @@ class SessionCredentialsServiceTest {
         }
 
         @Test
-        void deleteSessionCredentialsForResetTypeShouldDeleteDcmawVcs() throws Exception {
+        void deleteSessionCredentialsForResetTypeDcmawShouldDeleteDcmawVcs() throws Exception {
             var addressVc =
                     generateVerifiableCredential("userId", ADDRESS, vcClaimFailedWithCis(null));
             var fraudVc =
@@ -346,6 +346,35 @@ class SessionCredentialsServiceTest {
 
             sessionCredentialService.deleteSessionCredentialsForResetType(
                     SESSION_ID, SessionCredentialsResetType.DCMAW);
+
+            verify(mockDataStore).getItems(SESSION_ID);
+            verify(mockDataStore).delete(List.of(sessionDcmawCredentialItem));
+        }
+
+        @Test
+        void deleteSessionCredentialsForResetTypePendingDcmawAllShouldDeleteDcmawVcs()
+                throws Exception {
+            var addressVc =
+                    generateVerifiableCredential("userId", ADDRESS, vcClaimFailedWithCis(null));
+            var fraudVc =
+                    generateVerifiableCredential(
+                            "userId", EXPERIAN_FRAUD, vcClaimFailedWithCis(null));
+
+            var dcmawVc = generateVerifiableCredential("userId", DCMAW, vcClaimFailedWithCis(null));
+
+            var sessionFraudCredentialItem = fraudVc.toSessionCredentialItem(SESSION_ID, true);
+            var sessionAddressCredentialItem = addressVc.toSessionCredentialItem(SESSION_ID, true);
+            var sessionDcmawCredentialItem = dcmawVc.toSessionCredentialItem(SESSION_ID, true);
+
+            when(mockDataStore.getItems(SESSION_ID))
+                    .thenReturn(
+                            List.of(
+                                    sessionFraudCredentialItem,
+                                    sessionAddressCredentialItem,
+                                    sessionDcmawCredentialItem));
+
+            sessionCredentialService.deleteSessionCredentialsForResetType(
+                    SESSION_ID, SessionCredentialsResetType.PENDING_DCMAW_ALL);
 
             verify(mockDataStore).getItems(SESSION_ID);
             verify(mockDataStore).delete(List.of(sessionDcmawCredentialItem));


### PR DESCRIPTION
## Proposed changes

### What changed

- Abandon DCMAW Async VCs on REMOVE_DCMAW_FROM_SESSION

(The API test didn't pass before, now it does)

### Why did it change

- Bug

### Issue tracking

- [PYIC-8390](https://govukverify.atlassian.net/browse/PYIC-8390)

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated

<!-- Delete if changes don't apply -->
- [x] Production changes appropriately staged out


[PYIC-8390]: https://govukverify.atlassian.net/browse/PYIC-8390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ