### PR TITLE
BAU: Double API test timeout in pre-merge-checks

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -72,7 +72,7 @@ jobs:
 
   api-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       id-token: write
       packages: read

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -44,7 +44,7 @@ import {
   primeResponseForUser,
 } from "../clients/ais-management-api.js";
 
-const RETRY_DELAY_MILLIS = 2000;
+const RETRY_DELAY_MILLIS = 5000;
 const MAX_ATTEMPTS = 5;
 
 const addressCredential = "https://vocab.account.gov.uk/v1/address";


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Double API test timeout in pre-merge-checks

### Why did it change

- API tests take too long due to polling for Async VCs?