### PR TITLE
PYIC-8258: store reuse identities with PUT evcs endpoint

### DIFF
--- a/api-tests/data/audit-events/inherited-identity-journey-identity-stored.json
+++ b/api-tests/data/audit-events/inherited-identity-journey-identity-stored.json
@@ -1,0 +1,123 @@
+[
+  {
+    "event_name": "IPV_INHERITED_IDENTITY_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://orch.stubs.account.gov.uk/migration/v1",
+      "evidence": [],
+      "vot": "PCL200",
+      "age": "type[number]"
+    },
+    "restricted": {
+      "name": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "Alice"
+            },
+            {
+              "type": "GivenName",
+              "value": "Jane"
+            },
+            {
+              "type": "FamilyName",
+              "value": "Doe"
+            }
+          ]
+        }
+      ],
+      "birthDate": [
+        {
+          "value": "1970-01-01"
+        }
+      ],
+      "socialSecurityRecord": null,
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2", "PCL200", "PCL250"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "OPERATIONAL_PROFILE_MIGRATION"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "existing",
+      "vot": "PCL200",
+      "sis_record_created": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_ISSUED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "levelOfConfidence": "PCL200",
+      "ciFail": false,
+      "hasMitigations": false,
+      "returnCodes": []
+    }
+  }
+]

--- a/api-tests/data/audit-events/reuse-journey-identity-stored.json
+++ b/api-tests/data/audit-events/reuse-journey-identity-stored.json
@@ -1,0 +1,108 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "reprove_identity": false,
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "journey_type": "REUSE_EXISTING_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 3
+      },
+      "vcTxnIds": []
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "existing",
+      "vot": "P2",
+      "sis_record_created": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_ISSUED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "levelOfConfidence": "P2",
+      "ciFail": false,
+      "hasMitigations": false,
+      "returnCodes": []
+    }
+  }
+]

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -38,6 +38,21 @@ Feature: Audit Events
     Then I get a 'P2' identity
     And audit events for 'reuse-journey' are recorded [local only]
 
+  Scenario: Reuse journey - identity is stored when SIS is enabled
+    Given the subject already has the following credentials
+      | CRI     | scenario                     |
+      | dcmaw   | kenneth-driving-permit-valid |
+      | address | kenneth-current              |
+      | fraud   | kenneth-score-2              |
+    And I activate the 'storedIdentityService' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-reuse' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And audit events for 'reuse-journey-identity-stored' are recorded [local only]
+
   Scenario: New identity - via F2F journey
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
@@ -237,6 +252,14 @@ Feature: Audit Events
     When I use the OAuth response to get my identity
     Then I get a 'PCL200' identity
     And audit events for 'inherited-identity-journey' are recorded [local only]
+
+  Scenario: Inherited identity journey - identity stored
+    Given I activate the 'storedIdentityService' feature set
+    And I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL200' identity
+    And audit events for 'inherited-identity-journey-identity-stored' are recorded [local only]
 
   Scenario: International address journey
     And I start a new 'medium-confidence' journey

--- a/api-tests/features/stored-identity/inherited-identities.feature
+++ b/api-tests/features/stored-identity/inherited-identities.feature
@@ -1,3 +1,4 @@
+@Build
 Feature: Inherited Identity journeys
   Background: Enable stored identity service feature flag
     Given I activate the 'storedIdentityService,disableStrategicApp' feature set

--- a/api-tests/features/stored-identity/inherited-identities.feature
+++ b/api-tests/features/stored-identity/inherited-identities.feature
@@ -1,8 +1,8 @@
 Feature: Inherited Identity journeys
   Background: Enable stored identity service feature flag
-    Given I activate the 'storedIdentityService' feature set
+    Given I activate the 'storedIdentityService,disableStrategicApp' feature set
 
-  Scenario Outline: Inherited Identity Scenarios
+  Scenario Outline: Inherited Identity Reuse
     Given I start a new '<journey-type>' journey with inherited identity '<inherited-identity>'
     Then I get an OAuth response
     When I use the OAuth response to get my identity
@@ -21,14 +21,14 @@ Feature: Inherited Identity journeys
       | medium-confidence-pcl200-pcl250 | alice-vot-pcl200-no-evidence      | PCL200            |
       | medium-confidence-pcl200-pcl250 | alice-vot-pcl250-no-evidence      | PCL250            |
 
-  Scenario: Stronger inherited identity overrides initial weaker identity
+  Scenario: Stronger inherited identity overrides initial weaker inherited identity
     Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'PCL200' identity
     And I have a 'HMRC' stored identity record type with a 'PCL200' vot
 
-    # New journey with stronger stored identity
+    # New journey with stronger inherited identity
     When I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
     Then I get an OAuth response
     When I use the OAuth response to get my identity
@@ -42,7 +42,7 @@ Feature: Inherited Identity journeys
     Then I get a 'PCL250' identity
     And I have a 'HMRC' stored identity record type with a 'PCL250' vot
 
-    # New journey with weaker stored identity
+    # New journey with weaker inherited identity
     When I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
     Then I get an OAuth response
     When I use the OAuth response to get my identity

--- a/api-tests/features/stored-identity/inherited-identities.feature
+++ b/api-tests/features/stored-identity/inherited-identities.feature
@@ -1,0 +1,80 @@
+Feature: Inherited Identity journeys
+  Background: Enable stored identity service feature flag
+    Given I activate the 'storedIdentityService' feature set
+
+  Scenario Outline: Inherited Identity Scenarios
+    Given I start a new '<journey-type>' journey with inherited identity '<inherited-identity>'
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a '<expected-identity>' identity
+    And I have a 'HMRC' stored identity record type with a '<expected-identity>' vot
+
+    # Inherited identity reuse
+    When I start a new '<journey-type>' journey
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a '<expected-identity>' identity
+    And I have a 'HMRC' stored identity record type with a '<expected-identity>' vot
+
+    Examples:
+      | journey-type                    | inherited-identity                | expected-identity |
+      | medium-confidence-pcl200-pcl250 | alice-vot-pcl200-no-evidence      | PCL200            |
+      | medium-confidence-pcl200-pcl250 | alice-vot-pcl250-no-evidence      | PCL250            |
+
+  Scenario: Stronger inherited identity overrides initial weaker identity
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL200' identity
+    And I have a 'HMRC' stored identity record type with a 'PCL200' vot
+
+    # New journey with stronger stored identity
+    When I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    And I have a 'HMRC' stored identity record type with a 'PCL250' vot
+
+  Scenario: Stronger inherited identity is kept if new inherited identity is weaker
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    And I have a 'HMRC' stored identity record type with a 'PCL250' vot
+
+    # New journey with weaker stored identity
+    When I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl200-no-evidence'
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'PCL250' identity
+    And I have a 'HMRC' stored identity record type with a 'PCL250' vot
+
+  Scenario: P2 identity takes priority over successfully migrated inherited identity
+    Given I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And I have a 'GPG45' stored identity record type with a 'P2' vot
+
+    # New journey with inherited identity
+    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
+    Then I get a 'page-ipv-reuse' page response
+    When I submit an 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And I have a 'GPG45' stored identity record type with a 'P2' vot

--- a/api-tests/features/stored-identity/p1-reuse-existing-identity.feature
+++ b/api-tests/features/stored-identity/p1-reuse-existing-identity.feature
@@ -9,46 +9,57 @@ Feature: Stored Identity - Update Existing Identity
       | fraud   | kenneth-score-2              |
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-reuse' page response
-    When I submit a 'update-details' event
-    Then I get a 'update-details' page response
 
-  Scenario: Address Update
-    When I submit a 'address-only' event
-    Then I get a 'address' CRI response
-    When I submit 'kenneth-changed' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
-    Then I get a 'page-ipv-success' page response with context 'updateIdentity'
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P1' identity
-    And I have a 'GPG45' stored identity record type with a 'P2' vot
+  Rule: Non-update journey
+    Scenario: Reuse journey with no update
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P1' identity
+      And I have a 'GPG45' stored identity record type with a 'P2' vot
 
-  Scenario Outline: Successful Name Change - <selected-name-change>
-    When I submit a '<selected-name-change>' event
-    Then I get a 'page-update-name' page response
-    When I submit a 'update-name' event
-    Then I get a 'dcmaw' CRI response
-    When I submit '<details>' details to the CRI stub
-    Then I get a 'drivingLicence' CRI response
-    When I submit '<details>' details with attributes to the CRI stub
-      | Attribute | Values          |
-      | context   | "check_details" |
-    Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
-    When I submit a 'next' event
-    Then I get a 'fraud' CRI response
-    When I submit '<fraud-details>' details to the CRI stub
-    Then I get a 'page-ipv-success' page response with context 'updateIdentity'
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I get a 'P1' identity
-    And my identity 'GivenName' is '<expected-given-name>'
-    And my identity 'FamilyName' is '<expected-family-name>'
-    And I have a 'GPG45' stored identity record type with a 'P2' vot
+  Rule: Update journeys
+    Background: Continue to update details
+      When I submit a 'update-details' event
+      Then I get a 'update-details' page response
 
-    Examples:
-      | selected-name-change | details                                          | fraud-details                       | expected-given-name | expected-family-name |
-      | family-name-only     | kenneth-changed-family-name-driving-permit-valid | kenneth-changed-family-name-score-2 | Kenneth             | Smith                |
-      | given-names-only     | kenneth-changed-given-name-driving-permit-valid  | kenneth-changed-given-name-score-2  | Ken                 | Decerqueira          |
+    Scenario: Address Update
+      When I submit a 'address-only' event
+      Then I get a 'address' CRI response
+      When I submit 'kenneth-changed' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'page-ipv-success' page response with context 'updateIdentity'
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P1' identity
+      And I have a 'GPG45' stored identity record type with a 'P2' vot
+
+    Scenario Outline: Successful Name Change - <selected-name-change>
+      When I submit a '<selected-name-change>' event
+      Then I get a 'page-update-name' page response
+      When I submit a 'update-name' event
+      Then I get a 'dcmaw' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I submit '<details>' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit '<fraud-details>' details to the CRI stub
+      Then I get a 'page-ipv-success' page response with context 'updateIdentity'
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P1' identity
+      And my identity 'GivenName' is '<expected-given-name>'
+      And my identity 'FamilyName' is '<expected-family-name>'
+      And I have a 'GPG45' stored identity record type with a 'P2' vot
+
+      Examples:
+        | selected-name-change | details                                          | fraud-details                       | expected-given-name | expected-family-name |
+        | family-name-only     | kenneth-changed-family-name-driving-permit-valid | kenneth-changed-family-name-score-2 | Kenneth             | Smith                |
+        | given-names-only     | kenneth-changed-given-name-driving-permit-valid  | kenneth-changed-given-name-score-2  | Ken                 | Decerqueira          |

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -120,6 +120,7 @@ Feature: Stored Identity - P2 journeys
       | dcmaw   | kenneth-passport-valid |
       | address | kenneth-current        |
       | fraud   | kenneth-score-2        |
+    And I don't have a stored identity in EVCS
 
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -113,3 +113,18 @@ Feature: Stored Identity - P2 journeys
       When I use the OAuth response to get my identity
       Then I get a 'P2' identity
       And I have a 'GPG45' stored identity record type with a 'P2' vot
+
+  Scenario: Reuse journey - identity is stored to EVCS
+    Given the subject already has the following credentials
+      | CRI     | scenario               |
+      | dcmaw   | kenneth-passport-valid |
+      | address | kenneth-current        |
+      | fraud   | kenneth-score-2        |
+
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-reuse' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+    And I have a 'GPG45' stored identity record type with a 'P2' vot

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -145,6 +145,8 @@ public class ProcessCandidateIdentityHandler
 
     // Candidate identities that should store the given identity (if successful)
     @SuppressWarnings("java:S116") // Field names should comply with a naming convention
+    // When SIS goes live, we can remove the above suppression as we can
+    // permanently add the EXISTING enum and set this to static
     private final Set<CandidateIdentityType> STORE_IDENTITY_TYPES =
             EnumSet.of(NEW, PENDING, UPDATE);
 

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -79,6 +79,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static java.lang.Boolean.TRUE;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CREDENTIAL_ISSUER_ENABLED;
@@ -563,14 +564,22 @@ public class ProcessCandidateIdentityHandler
     }
 
     private boolean requiresVotMatchingResult(CandidateIdentityType processIdentityType) {
-        return (shouldStoreIdentity(processIdentityType) && !PENDING.equals(processIdentityType))
-                || PROFILE_MATCHING_TYPES.contains(processIdentityType);
+        if (shouldStoreExistingIdentity(processIdentityType)) {
+            return true;
+        }
+
+        var typesRequiringVotMatchingResult =
+                Stream.concat(PROFILE_MATCHING_TYPES.stream(), STORE_IDENTITY_TYPES.stream())
+                        .filter(identityType -> !identityType.equals(PENDING))
+                        .distinct()
+                        .toList();
+
+        return typesRequiringVotMatchingResult.contains(processIdentityType);
     }
 
     private boolean requiresExistingVcsFromEvcs(CandidateIdentityType processIdentityType) {
         return COI_CHECK_TYPES.contains(processIdentityType)
-                || shouldStoreIdentity(processIdentityType)
-                || PENDING.equals(processIdentityType);
+                || shouldStoreIdentity(processIdentityType);
     }
 
     private boolean shouldStoreIdentity(CandidateIdentityType identityType) {

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -487,6 +487,9 @@ class ProcessCandidateIdentityHandlerTest {
                     .thenReturn(P2_M1A_VOT_MATCH_RESULT);
             when(configService.enabled(AIS_ENABLED)).thenReturn(false);
             when(configService.enabled(STORED_IDENTITY_SERVICE)).thenReturn(true);
+            when(cimitUtilityService.getParsedSecurityCheckCredential(
+                            SIGNED_CIMIT_VC_NO_CI, USER_ID))
+                    .thenReturn(CIMIT_VC);
 
             var request =
                     requestBuilder
@@ -503,7 +506,7 @@ class ProcessCandidateIdentityHandlerTest {
             verify(storeIdentityService, times(1))
                     .storeIdentity(
                             eq(USER_ID),
-                            eq(List.of()),
+                            eq(List.of(CIMIT_VC)),
                             eq(List.of()),
                             eq(P2),
                             eq(STRONGEST_MATCHED_VOT),

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -181,7 +181,6 @@ class ProcessCandidateIdentityHandlerTest {
             when(ipvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
             when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                     .thenReturn(clientOAuthSessionItem);
-            when(configService.enabled(STORED_IDENTITY_SERVICE)).thenReturn(false);
         }
 
         @Test
@@ -474,6 +473,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
             when(votMatcher.findStrongestMatches(List.of(P2), List.of(), List.of(), true))
                     .thenReturn(P2_M1A_VOT_MATCH_RESULT);
+            when(configService.enabled(AIS_ENABLED)).thenReturn(false);
             when(configService.enabled(STORED_IDENTITY_SERVICE)).thenReturn(true);
 
             var request =

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -71,6 +71,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CREDENTIAL_ISSUER_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.AIS_ENABLED;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.STORED_IDENTITY_SERVICE;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.ERROR_PROCESSING_TICF_CRI_RESPONSE;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_AT_EVCS_HTTP_REQUEST_SEND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC;
@@ -180,6 +181,7 @@ class ProcessCandidateIdentityHandlerTest {
             when(ipvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
             when(clientOAuthSessionDetailsService.getClientOAuthSession(any()))
                     .thenReturn(clientOAuthSessionItem);
+            when(configService.enabled(STORED_IDENTITY_SERVICE)).thenReturn(false);
         }
 
         @Test
@@ -454,6 +456,47 @@ class ProcessCandidateIdentityHandlerTest {
 
             verify(storeIdentityService, times(0))
                     .storeIdentity(any(), any(), any(), any(), any(), any(), any());
+            verify(checkCoiService, times(0))
+                    .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        void shouldStoreExistingIdentityIfStoredIdentityServiceFeatureFlagIsEnabled()
+                throws Exception {
+            // Arrange
+            var ticfVcs = List.of(vcTicf());
+            when(configService.getBooleanParameter(CREDENTIAL_ISSUER_ENABLED, Cri.TICF.getId()))
+                    .thenReturn(true);
+            when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
+                    .thenReturn(ticfVcs);
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(List.of());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
+            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+            when(votMatcher.findStrongestMatches(List.of(P2), List.of(), List.of(), true))
+                    .thenReturn(P2_M1A_VOT_MATCH_RESULT);
+            when(configService.enabled(STORED_IDENTITY_SERVICE)).thenReturn(true);
+
+            var request =
+                    requestBuilder
+                            .lambdaInput(
+                                    Map.of(
+                                            PROCESS_IDENTITY_TYPE,
+                                            CandidateIdentityType.EXISTING.name()))
+                            .build();
+
+            // Act
+            processCandidateIdentityHandler.handleRequest(request, context);
+
+            // Assert
+            verify(storeIdentityService, times(1))
+                    .storeIdentity(
+                            eq(USER_ID),
+                            eq(List.of()),
+                            eq(List.of()),
+                            eq(P2),
+                            eq(STRONGEST_MATCHED_VOT),
+                            eq(CandidateIdentityType.EXISTING),
+                            any());
             verify(checkCoiService, times(0))
                     .isCoiCheckSuccessful(any(), any(), any(), any(), any(), any());
         }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Store reuse identities (inc inherited identities)

### Why did it change
Returning users will have valid credentials that will need to have a corresponding Stored Identity Record. During phase 1, we aren't able to query SIS so IPV Core must assume that a returning user does not have an existing record and write one proactively so that when SIS is rolled out, returning users do not have to go through an identity proofing journey again.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8258](https://govukverify.atlassian.net/browse/PYIC-8258)

## Checklists

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated


[PYIC-8258]: https://govukverify.atlassian.net/browse/PYIC-8258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ