### PR TITLE
PYIC-8361: turn on strategic app

### DIFF
--- a/api-tests/features/account-intervention/journey-ending-interventions.feature
+++ b/api-tests/features/account-intervention/journey-ending-interventions.feature
@@ -2,7 +2,7 @@
 Feature: Journey ending interventions
 
   Scenario Outline: <intervention> intervention at <when> of identity proving journey
-    Given I activate the 'accountInterventions' feature set
+    Given I activate the 'accountInterventions,disableStrategicApp' feature set
     And The AIS stub will return an '<first_ais_response>' result
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
@@ -32,7 +32,7 @@ Feature: Journey ending interventions
       | Password reset and reprove identity | end   | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY |
 
   Scenario Outline: <intervention> intervention at <when> of reprove identity journey
-    Given I activate the 'accountInterventions' feature set
+    Given I activate the 'accountInterventions,disableStrategicApp' feature set
     And the subject already has the following credentials
       | CRI     | scenario                     |
       | dcmaw   | kenneth-driving-permit-valid |
@@ -121,6 +121,3 @@ Feature: Journey ending interventions
     When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
     And I submit 'kenneth-score-2' details to the CRI stub
     Then I get an OAuth response with error code 'session_invalidated'
-
-
-

--- a/api-tests/features/account-intervention/p2-reprove-identity.feature
+++ b/api-tests/features/account-intervention/p2-reprove-identity.feature
@@ -1,5 +1,8 @@
 @Build
 Feature: Reprove Identity Journey
+    Background: Disable strategic app
+        Given I activate the 'disableStrategicApp' feature set
+
     Scenario: User reproves identity
         Given the subject already has the following credentials
             | CRI     | scenario                     |

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -1,4 +1,7 @@
 Feature: Audit Events
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
+
   Scenario: New identity - p2 app journey
     Given I activate the 'storedIdentityService' feature set
     And I start a new 'medium-confidence' journey
@@ -245,7 +248,7 @@ Feature: Audit Events
     And audit events for 'international-address-journey' are recorded [local only]
 
   Scenario: Strategic app journey
-    Given I activate the 'strategicApp' feature set
+    Given I override the existing feature sets and activate the 'strategicApp' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
@@ -262,7 +265,7 @@ Feature: Audit Events
 
   @InitialisesDCMAWSessionState
   Scenario: MAM journey cross-browser scenario
-    Given I activate the 'strategicApp' feature set
+    Given I override the existing feature sets and activate the 'strategicApp' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event

--- a/api-tests/features/cimit/p1-alternate-doc.feature
+++ b/api-tests/features/cimit/p1-alternate-doc.feature
@@ -1,5 +1,8 @@
 @Build
 Feature: P1 CIMIT - Alternate doc
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
+
   Rule: No existing identity
     Background:
       Given I start a new 'low-confidence' journey

--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
@@ -3,7 +3,8 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
 
   Background:
     # Navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
-    Given I start a new 'low-confidence' journey
+    Given I activate the 'disableStrategicApp' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response

--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-f2f.feature
@@ -1,7 +1,8 @@
 @Build
 Feature: Mitigating CIs with enhanced verification using the F2F CRI
   Background:
-    Given I start a new 'low-confidence' journey
+    Given I activate the 'disableStrategicApp' feature set
+    When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response

--- a/api-tests/features/cimit/p2-alternate-doc.feature
+++ b/api-tests/features/cimit/p2-alternate-doc.feature
@@ -1,5 +1,8 @@
 @Build
 Feature: P2 CIMIT - Alternate doc
+  Background: Disable strategic app
+    Given I activate the 'disableStrategicApp' feature set
+
   Rule: No existing identity
     Background:
       Given I start a new 'medium-confidence' journey

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
@@ -3,7 +3,8 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
 
   Background:
     # Navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'disableStrategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
@@ -1,7 +1,8 @@
 @Build
 Feature: Mitigating CIs with enhanced verification using the F2F CRI
   Background:
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'disableStrategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -1,5 +1,7 @@
 @Build
 Feature: Disabled CRI journeys
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
   Rule: DCMAW is disabled
 

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -1,5 +1,7 @@
 @Build
 Feature: Authoritative source checks with driving licence CRI
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
   Scenario: Journey through DCMAW with driving licence requires authoritative source check low-confidence
     Given I activate the 'drivingLicenceAuthCheck,p1Journeys' feature sets

--- a/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
@@ -1,9 +1,9 @@
 @Build
 Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to incorrect details)
   Background: Activate the featureSet
-    Given I activate the 'drivingLicenceAuthCheck,p1Journeys' feature sets
+    Given I activate the 'drivingLicenceAuthCheck,p1Journeys,disableStrategicApp' feature sets
 
-  Scenario Outline: User backs out of driving licence CRI is able to return to DCMAW and re-scan their DL low-confidence
+  Scenario: User backs out of driving licence CRI is able to return to DCMAW and re-scan their DL low-confidence
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -23,7 +23,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       | context   | "check_details" |
     Then I get a 'page-dcmaw-success' page response
 
-  Scenario Outline: User backs out of driving licence CRI is able to return to DCMAW and re-scan their DL medium-confidence
+  Scenario: User backs out of driving licence CRI is able to return to DCMAW and re-scan their DL medium-confidence
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
@@ -45,7 +45,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       | context   | "check_details" |
     Then I get a 'page-dcmaw-success' page response
 
-  Scenario Outline: User backs out of driving licence CRI and returns to DCMAW with a passport P1 - identity has only one DCMAW VC
+  Scenario: User backs out of driving licence CRI and returns to DCMAW with a passport P1 - identity has only one DCMAW VC
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -72,7 +72,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     Then I get a 'P1' identity
     And I have a dcmaw VC without 'drivingPermit' details
 
-    Scenario Outline: User backs out of driving licence CRI and returns to DCMAW with a passport P2 - identity has only one DCMAW VC
+    Scenario: User backs out of driving licence CRI and returns to DCMAW with a passport P2 - identity has only one DCMAW VC
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
@@ -101,7 +101,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     Then I get a 'P2' identity
     And I have a dcmaw VC without 'drivingPermit' details
 
-  Scenario Outline: User backs out of driving licence CRI is able to prove their identity another way P1 - via F2F and has no dcmaw VC
+  Scenario: User backs out of driving licence CRI is able to prove their identity another way P1 - via F2F and has no dcmaw VC
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -136,7 +136,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     When I use the OAuth response to get my identity
     Then I get a 'P1' identity without a 'dcmaw' VC
 
-  Scenario Outline: User backs out of driving licence CRI is able to prove their identity another way P2 - via F2F and has no dcmaw VC
+  Scenario: User backs out of driving licence CRI is able to prove their identity another way P2 - via F2F and has no dcmaw VC
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
@@ -173,7 +173,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity without a 'dcmaw' VC
 
-  Scenario Outline: User backs out of DL CRI and selects to return to the RP - should not have a DCMAW VC low-confidence
+  Scenario: User backs out of DL CRI and selects to return to the RP - should not have a DCMAW VC low-confidence
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -191,7 +191,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     When I use the OAuth response to get my identity
     Then I get a 'P0' identity
 
-  Scenario Outline: User backs out of DL CRI and selects to return to the RP - should not have a DCMAW VC medium-confidence
+  Scenario: User backs out of DL CRI and selects to return to the RP - should not have a DCMAW VC medium-confidence
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event

--- a/api-tests/features/inherited-identity/extended-scenarios.feature
+++ b/api-tests/features/inherited-identity/extended-scenarios.feature
@@ -1,5 +1,8 @@
 @Build
 Feature: Inherited identity extended scenarios
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
+
   Scenario: Successful enhanced verification mitigation with a PCL250 HMRC profile and receives a P2
     Given I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response

--- a/api-tests/features/inherited-identity/inherited-identity.feature
+++ b/api-tests/features/inherited-identity/inherited-identity.feature
@@ -44,7 +44,8 @@ Feature: Inherited Identity
     Then I get a 'PCL250' identity
 
   Scenario Outline: P2 identity takes priority over successfully migrated PCL200
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'disableStrategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
@@ -99,7 +100,8 @@ Feature: Inherited Identity
     | PCL250       | alice-vot-pcl250-no-evidence   | Alice             | PCL250           | PCL200       | kenneth-vot-pcl200-no-evidence       | Alice             | PCL250           | not replaced |
 
   Scenario: Previous PCL250 inherited identity is replaced with new P2 identity for the same user
-    Given I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
+    Given I activate the 'disableStrategicApp' feature set
+    When I start a new 'medium-confidence-pcl200-pcl250' journey with inherited identity 'alice-vot-pcl250-no-evidence'
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I get a 'PCL250' identity

--- a/api-tests/features/m1c-journeys.feature
+++ b/api-tests/features/m1c-journeys.feature
@@ -1,5 +1,7 @@
 @Build
 Feature: M1C Unavailable Journeys
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
   Rule: New identities
 

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -9,6 +9,7 @@ Feature: MFA reset journey
         | fraud   | kenneth-score-2              |
 
       # Start MFA reset journey
+      And I activate the 'disableStrategicApp' feature set
       When I start a new 'reverification' journey
       Then I get a 'you-can-change-security-code-method' page response
 

--- a/api-tests/features/p1-app-journey.feature
+++ b/api-tests/features/p1-app-journey.feature
@@ -1,5 +1,7 @@
 @Build
 Feature: P1 app journey
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
   Scenario: P1 App Journey
     Given I activate the 'p1Journeys' feature set

--- a/api-tests/features/p1-f2f-journey.feature
+++ b/api-tests/features/p1-f2f-journey.feature
@@ -1,5 +1,7 @@
 @Build
 Feature: P1 F2F journey
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
   Scenario: P1 Face to Face after DCMAW dropout
     Given I activate the 'p1Journeys' feature set

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -33,7 +33,7 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No Photo Id after DCMAW dropout Journey
-    Given I activate the 'p1Journeys' feature set
+    Given I activate the 'p1Journeys,disableStrategicApp' feature set
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
@@ -83,7 +83,7 @@ Feature: P1 No Photo Id Journey
     Then I get a 'no-photo-id-abandon-find-another-way' page response
 
   Scenario: P1 No Photo Id Journey - DCMAW after Experian KBV thin file
-    Given I activate the 'p1Journeys' feature set
+    Given I activate the 'p1Journeys,disableStrategicApp' feature set
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -227,7 +227,7 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No Photo Id Journey - DWP KBV transition page dropout
-    Given I activate the 'p1Journeys,dwpKbvTest' feature sets
+    Given I activate the 'p1Journeys,dwpKbvTest,disableStrategicApp' feature sets
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event

--- a/api-tests/features/p1-web-journey.feature
+++ b/api-tests/features/p1-web-journey.feature
@@ -1,7 +1,7 @@
 @Build
 Feature: P1 Web Journeys
   Background: Start P1 journey ineligible for app
-    Given I activate the 'p1Journeys' feature set
+    Given I activate the 'p1Journeys,disableStrategicApp' feature set
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -3,7 +3,8 @@
 Feature: P2 App journey
 
   Background:
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'disableStrategicApp' feature set
+    And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -91,7 +91,8 @@ Feature: P2 F2F journey
 
     Scenario Outline: Successful P2 identity via F2F using <doc> - DCMAW access_denied
       # Initial journey
-      Given I start a new 'medium-confidence' journey
+      Given I activate the 'disableStrategicApp' feature set
+      And I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
@@ -178,7 +179,8 @@ Feature: P2 F2F journey
 
   Rule: F2F evidence requested strength score
     Background: User has pending F2F verification
-      Given I start a new 'medium-confidence' journey
+      Given I activate the 'disableStrategicApp' feature set
+      And I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
       When I submit an 'appTriage' event

--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -1,8 +1,8 @@
 @Build
-Feature: P2 App journey
+Feature: P2 International Address
 
   Background:
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'disableStrategicApp' feature set
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
 

--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -186,9 +186,14 @@ Feature: P2 no photo id journey
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
       Then I get a 'no-photo-id-abandon-find-another-way' page response
 
-    Scenario: P2 no photo id journey - Abandon - Strategic app
+    Scenario: P2 no photo id journey - Abandon - DCMAW
+      Given I activate the 'disableStrategicApp' feature set
       When I submit an 'mobileApp' event
       Then I get a 'dcmaw' CRI response
+
+    Scenario: P2 no photo id journey - Abandon - Strategic app
+      When I submit an 'mobileApp' event
+      Then I get a 'identify-device' page response
 
     Scenario: P2 no photo id journey - Abandon - Passport
       When I submit an 'passport' event
@@ -272,9 +277,14 @@ Feature: P2 no photo id journey
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
       Then I get a 'no-photo-id-security-questions-find-another-way' page response
 
-    Scenario: P2 no photo id journey - KBV mitigation - Strategic app
+    Scenario: P2 no photo id journey - KBV mitigation - DCMAW
+      Given I activate the 'disableStrategicApp' feature set
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
+
+    Scenario: P2 no photo id journey - KBV mitigation - Strategic app
+      When I submit an 'appTriage' event
+      Then I get a 'identify-device' page response
 
     Scenario: P2 no photo id journey - KBV mitigation - F2F
       When I submit an 'f2f' event
@@ -314,9 +324,14 @@ Feature: P2 no photo id journey
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
       Then I get a 'no-photo-id-security-questions-find-another-way' page response with context 'dropout'
 
-    Scenario: P2 no photo id journey - KBV dropout - Strategic app
+    Scenario: P2 no photo id journey - KBV dropout - DCMAW
+      Given I activate the 'disableStrategicApp' feature set
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
+
+    Scenario: P2 no photo id journey - KBV dropout - Strategic app
+      When I submit an 'appTriage' event
+      Then I get a 'identify-device' page response
 
     Scenario: P2 no photo id journey - KBV dropout - F2F
       When I submit an 'f2f' event

--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -192,6 +192,7 @@ Feature: P2 no photo id journey
       Then I get a 'dcmaw' CRI response
 
     Scenario: P2 no photo id journey - Abandon - Strategic app
+      Given I activate the 'strategicApp' feature set
       When I submit an 'mobileApp' event
       Then I get a 'identify-device' page response
 
@@ -283,6 +284,7 @@ Feature: P2 no photo id journey
       Then I get a 'dcmaw' CRI response
 
     Scenario: P2 no photo id journey - KBV mitigation - Strategic app
+      Given I activate the 'strategicApp' feature set
       When I submit an 'appTriage' event
       Then I get a 'identify-device' page response
 
@@ -330,6 +332,7 @@ Feature: P2 no photo id journey
       Then I get a 'dcmaw' CRI response
 
     Scenario: P2 no photo id journey - KBV dropout - Strategic app
+      Given I activate the 'strategicApp' feature set
       When I submit an 'appTriage' event
       Then I get a 'identify-device' page response
 

--- a/api-tests/features/p2-reuse-journey.feature
+++ b/api-tests/features/p2-reuse-journey.feature
@@ -4,7 +4,8 @@ Feature: P2 Reuse journey
   @TrafficGeneration
   Scenario: Successful P2 reuse journey
     # First identity proving journey
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'disableStrategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -2,7 +2,8 @@
 @TrafficGeneration
 Feature: P2 Web document journey
   Background: Start P2 journey and ineligible for the app
-    Given I start a new 'medium-confidence' journey
+    Given I activate the 'disableStrategicApp' feature set
+    When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/recovery-journeys.feature
+++ b/api-tests/features/recovery-journeys.feature
@@ -1,5 +1,7 @@
 @Build
 Feature: Recovery journeys
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
   Scenario: Recovery event from page state - the same page is returned
     When I start a new 'medium-confidence' journey

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -1,5 +1,7 @@
 @Build
 Feature: Repeat fraud check failures
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
   Rule: Given name change only
 

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
@@ -1,5 +1,7 @@
 @Build
 Feature: Repeat fraud check journeys
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
   Scenario: User is sent on RFC journey to remedy unavailable fraud check
     Given the subject already has the following credentials

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -1,5 +1,8 @@
 @Build
 Feature: Return exit codes
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
+
   Scenario: Successful journey with identity and no CIs - no return codes
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -9,6 +9,7 @@ Feature: Identity reuse update details failures
                 | dcmaw   | kenneth-driving-permit-valid |
                 | address | kenneth-current              |
                 | fraud   | kenneth-score-2              |
+            And I activate the 'disableStrategicApp' feature set
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
             When I submit an 'update-details' event

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
@@ -7,6 +7,7 @@ Feature: International identity reuse update details
             | dcmaw   | kenneth-passport-valid |
             | address | kenneth-current        |
             | fraud   | kenneth-no-applicable   |
+        And I activate the 'disableStrategicApp' feature set
         When I start a new 'medium-confidence' journey
         Then I get a 'page-ipv-reuse' page response
         When I activate the 'internationalAddress' feature sets

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
@@ -7,6 +7,7 @@ Feature: Identity reuse update details
             | dcmaw   | kenneth-driving-permit-valid |
             | address | kenneth-current              |
             | fraud   | kenneth-score-2              |
+        And I activate the 'disableStrategicApp' feature set
         When I start a new 'medium-confidence' journey
         Then I get a 'page-ipv-reuse' page response
         When I submit a 'update-details' event

--- a/api-tests/features/stored-identity/cimit-journeys.feature
+++ b/api-tests/features/stored-identity/cimit-journeys.feature
@@ -1,7 +1,7 @@
 @Build
 Feature: Stored Identity Service - CIMIT journeys
   Background:
-    Given I activate the 'storedIdentityService' feature set
+    Given I activate the 'storedIdentityService,disableStrategicApp' feature set
 
   Rule: P1 - D02 Mitigation
     Background:

--- a/api-tests/features/stored-identity/m1c-journeys.feature
+++ b/api-tests/features/stored-identity/m1c-journeys.feature
@@ -1,7 +1,7 @@
 @Build
 Feature: Stored Identity - M1C Outcomes
   Background:
-    Given I activate the 'storedIdentityService' feature set
+    Given I activate the 'storedIdentityService,disableStrategicApp' feature set
 
   Rule: New Identities - UK Address
     Background:

--- a/api-tests/features/stored-identity/p1-journeys.feature
+++ b/api-tests/features/stored-identity/p1-journeys.feature
@@ -1,7 +1,7 @@
 @Build
 Feature: Stored Identity - P1 journeys
   Background: Enabled stored identity service flag and start p1 journey
-    Given I activate the 'p1Journeys,storedIdentityService' feature sets
+    Given I activate the 'p1Journeys,storedIdentityService,disableStrategicApp' feature sets
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
 

--- a/api-tests/features/stored-identity/p1-repat-fraud-check.feature
+++ b/api-tests/features/stored-identity/p1-repat-fraud-check.feature
@@ -1,7 +1,7 @@
 @Build
 Feature: Stored Identity - repeat fraud check
   Background:
-    Given I activate the 'storedIdentityService' feature set
+    Given I activate the 'storedIdentityService,disableStrategicApp' feature set
     And the subject already has the following credentials
       | CRI     | scenario                     |
       | dcmaw   | kenneth-driving-permit-valid |

--- a/api-tests/features/stored-identity/p1-reuse-existing-identity.feature
+++ b/api-tests/features/stored-identity/p1-reuse-existing-identity.feature
@@ -1,7 +1,7 @@
 @Build
 Feature: Stored Identity - Update Existing Identity
   Background:
-    Given I activate the 'storedIdentityService' feature set
+    Given I activate the 'storedIdentityService,disableStrategicApp' feature set
     And the subject already has the following credentials
       | CRI     | scenario                     |
       | dcmaw   | kenneth-driving-permit-valid |

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -1,7 +1,7 @@
 @Build
 Feature: Stored Identity - P2 journeys
   Background: Enabled stored identity service flag and start p1 journey
-    Given I activate the 'storedIdentityService' feature sets
+    Given I activate the 'storedIdentityService,disableStrategicApp' feature sets
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
 

--- a/api-tests/features/stored-identity/reprove-identity-journeys.feature
+++ b/api-tests/features/stored-identity/reprove-identity-journeys.feature
@@ -2,7 +2,7 @@
 Feature: Reprove Identity Journey
 
   Background:
-    Given I activate the 'storedIdentityService' feature set
+    Given I activate the 'storedIdentityService,disableStrategicApp' feature set
 
   Rule: P2 Journeys
     Background:

--- a/api-tests/features/ticf/failed-ticf-responses.feature
+++ b/api-tests/features/ticf/failed-ticf-responses.feature
@@ -1,5 +1,8 @@
 @Build
 Feature: Failed TICF responses
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
+
   Scenario Outline: TICF CRI returns a <statusCode> during identity proving
     Given TICF CRI will respond with default parameters and
       | statusCode    | <statusCode>                 |

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -1,5 +1,7 @@
 @Build
 Feature: TICF failed/error journeys
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
   Rule: Via enhanced-verification journey
     Background: Start TICF enhanced verification journey

--- a/api-tests/features/ticf/ticf-successful-responses.feature
+++ b/api-tests/features/ticf/ticf-successful-responses.feature
@@ -1,5 +1,8 @@
 @Build
 Feature: TICF successful responses
+  Background: Disable the strategic app
+    Given I activate the 'disableStrategicApp' feature set
+
   Rule: TICF returns CI
     Scenario: New P2 identity journey via app - TICF returns a CI
       Given TICF CRI will respond with default parameters and

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -357,7 +357,7 @@ core:
   featureFlags:
     resetIdentity: false
     pendingF2FResetEnabled: false
-    strategicAppEnabled: false
+    strategicAppEnabled: true
     internationalAddressEnabled: true
     inheritedIdentity: true
     repeatFraudCheckEnabled: true
@@ -392,6 +392,9 @@ core:
     strategicApp:
       featureFlags:
         strategicAppEnabled: true
+    disableStrategicApp:
+      featureFlags:
+        strategicAppEnabled: false
     inheritedIdentity:
       featureFlags:
         inheritedIdentity: true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Reverts the revert for this PR (#3202) and fixes the failing tests in the pipeline

### Why did it change
We want the api tests to work once the strategic app is turned on

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8361](https://govukverify.atlassian.net/browse/PYIC-8361)

## Checklists
<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated


[PYIC-8361]: https://govukverify.atlassian.net/browse/PYIC-8361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ