### PR TITLE
BAU: Prevent highlighting when dragging journey map

### DIFF
--- a/journey-map/package-lock.json
+++ b/journey-map/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ipv-core-journey-map",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ipv-core-journey-map",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "express": "5.0.1",

--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -72,6 +72,7 @@ body {
   right: 0;
   bottom: 0;
   flex: 1 1 auto;
+  user-select: none;
 }
 #diagram > * {
   height: 100%;


### PR DESCRIPTION
## Proposed changes

### What changed

Added `user-select: none` to the journey map diagram

### Why did it change

When dragging the journey map it often highlights text undesirably
