### PR TITLE
PYIC-7807: Modify API tests for consistency and reduced repetition

### DIFF
--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
@@ -1,8 +1,6 @@
 @Build
 Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
-
-  Background:
-    # Navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
+  Background: Navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
     Given I activate the 'disableStrategicApp' feature set
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
@@ -26,7 +24,6 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
     Then I get a 'photo-id-security-questions-find-another-way' page response
 
   Rule: Same session journeys
-
     Scenario Outline: Same session DCMAW enhanced verification mitigation - successful
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
@@ -65,12 +62,13 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'P0' identity
 
   Rule: Separate session journeys
-
-    Scenario: Separate session DCMAW enhanced verification mitigation - successful - passport
+    Background:
       When I start a new 'low-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
+
+    Scenario: Separate session DCMAW enhanced verification mitigation - successful - passport
       When I submit 'kenneth-passport-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
       Then I get a 'page-dcmaw-success' page response
       When I submit a 'next' event
@@ -85,10 +83,6 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'P1' identity
 
     Scenario: Separate session DCMAW enhanced verification mitigation - successful - DL
-      When I start a new 'low-confidence' journey
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'appTriage' event
-      Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
@@ -107,10 +101,6 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'P1' identity
 
     Scenario: Separate session DCMAW enhanced verification mitigation - breaching CI received from DCMAW
-      When I start a new 'low-confidence' journey
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'appTriage' event
-      Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
       Then I get a 'pyi-no-match' page response
       When I submit a 'next' event

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
@@ -1,6 +1,5 @@
 @Build
 Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
-
   Background:
     # Navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
     Given I activate the 'disableStrategicApp' feature set

--- a/api-tests/features/m1c-journeys.feature
+++ b/api-tests/features/m1c-journeys.feature
@@ -4,7 +4,6 @@ Feature: M1C Unavailable Journeys
     Given I activate the 'disableStrategicApp' feature set
 
   Rule: New identities
-
     Background:
       Given I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
@@ -58,7 +57,6 @@ Feature: M1C Unavailable Journeys
       Then I get a 'P0' identity
 
   Rule: Returning existing M1C unavailable user goes through details confirmation
-
     Background:
       Given the subject already has the following credentials
         | CRI           | scenario                     |
@@ -167,7 +165,6 @@ Feature: M1C Unavailable Journeys
       Then I get a 'P2' identity
 
   Rule: Existing non-M1C identity returns
-
     Background:
       Given the subject already has the following credentials
         | CRI           | scenario                     |

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -7,9 +7,9 @@ Feature: MFA reset journey
         | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
+      And I activate the 'disableStrategicApp' feature set
 
       # Start MFA reset journey
-      And I activate the 'disableStrategicApp' feature set
       When I start a new 'reverification' journey
       Then I get a 'you-can-change-security-code-method' page response
 

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -1,7 +1,6 @@
 @Build
 @TrafficGeneration
 Feature: P2 App journey
-
   Background:
     Given I activate the 'disableStrategicApp' feature set
     And I start a new 'medium-confidence' journey
@@ -53,12 +52,6 @@ Feature: P2 App journey
     Then I get a 'page-multiple-doc-check' page response
 
   Scenario Outline: <error> from DCMAW
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
     When I call the CRI stub and get an '<error>' OAuth error
     Then I get a '<expected_page>' page response
 
@@ -72,11 +65,5 @@ Feature: P2 App journey
       | invalid_scope             | pyi-technical           |
 
   Scenario: Fail DCMAW with no CI
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-passport-fail-no-ci' details to the CRI stub
     Then I get a 'page-multiple-doc-check' page response

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -1,6 +1,5 @@
 @Build
 Feature: P2 F2F journey
-
   Rule: Pending F2F journey
     Background: User has pending f2f verification
       Given I start a new 'medium-confidence' journey

--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -1,6 +1,5 @@
 @Build
 Feature: P2 International Address
-
   Background:
     Given I activate the 'disableStrategicApp' feature set
     And I start a new 'medium-confidence' journey

--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -12,9 +12,9 @@ Feature: P2 no photo id journey
       When I submit an 'end' event
       Then I get a 'prove-identity-no-photo-id' page response
       When I submit an 'next' event
+      Then I get a 'claimedIdentity' CRI response
 
     Scenario: P2 no photo id journey - Experian - Happy path
-      Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
@@ -41,7 +41,6 @@ Feature: P2 no photo id journey
       Then I get a 'P2' identity
 
     Scenario: P2 no photo id journey - Experian - BAV dropout:
-      Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
@@ -50,7 +49,6 @@ Feature: P2 no photo id journey
       Then I get a 'no-photo-id-abandon-find-another-way' page response
 
     Scenario: P2 no photo id journey - Experian - Breaching BAV CI
-      Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
@@ -59,7 +57,6 @@ Feature: P2 no photo id journey
       Then I get a 'pyi-no-match' page response with context 'bankAccount'
 
     Scenario: P2 no photo id journey - Experian - NINO dropout:
-      Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
@@ -72,7 +69,6 @@ Feature: P2 no photo id journey
       Then I get a 'no-photo-id-abandon-find-another-way' page response
 
     Scenario: P2 no photo id journey - Experian - Breaching NINO CI
-      Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
@@ -85,7 +81,6 @@ Feature: P2 no photo id journey
       Then I get a 'pyi-no-match' page response with context 'nino'
 
     Scenario: P2 no photo id journey - Experian - Drops out via thin file or failed checks
-      Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
@@ -108,7 +103,6 @@ Feature: P2 no photo id journey
       Then I get a 'no-photo-id-security-questions-find-another-way' page response with context 'dropout'
 
     Scenario: P2 no photo id journey - Experian - Breaching KBV CI
-      Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
@@ -131,7 +125,6 @@ Feature: P2 no photo id journey
       Then I get a 'pyi-no-match' page response
 
     Scenario: P2 no photo id journey - Experian - KBV CI mitigation:
-      Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
@@ -154,7 +147,6 @@ Feature: P2 no photo id journey
       Then I get a 'no-photo-id-security-questions-find-another-way' page response
 
     Scenario: P2 no photo id journey - Experian - Breaching BAV CI
-      Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -4,7 +4,6 @@ Feature: Repeat fraud check failures
     Given I activate the 'disableStrategicApp' feature set
 
   Rule: Given name change only
-
     Background:
       Given the subject already has the following credentials
         | CRI     | scenario                     |

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
@@ -172,7 +172,9 @@ Feature: Repeat fraud check journeys
         | CRI     | scenario               |
         | dcmaw   | kenneth-passport-valid |
         | address | kenneth-current        |
-        | fraud   | kenneth-no-applicable  |
+      And the subject already has the following expired credentials
+        | CRI   | scenario              |
+        | fraud | kenneth-no-applicable |
       When I start a new 'medium-confidence' journey
       Then I get a 'confirm-your-details' page response
 

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
@@ -14,8 +14,7 @@ Feature: Repeat fraud check journeys
     Then I get a 'confirm-your-details' page response
 
   Rule: Match M1B
-
-    Background:
+    Background: Start journey with expired fraud check
       Given the subject already has the following credentials
         | CRI     | scenario                     |
         | dcmaw   | kenneth-driving-permit-valid |
@@ -168,15 +167,12 @@ Feature: Repeat fraud check journeys
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion'
 
   Rule: Match M1C Fraud Check Not Applicable
-
     Background:
       Given the subject already has the following credentials
         | CRI     | scenario               |
         | dcmaw   | kenneth-passport-valid |
         | address | kenneth-current        |
-      And the subject already has the following expired credentials
-        | CRI   | scenario              |
-        | fraud | kenneth-no-applicable |
+        | fraud   | kenneth-no-applicable  |
       When I start a new 'medium-confidence' journey
       Then I get a 'confirm-your-details' page response
 
@@ -245,7 +241,6 @@ Feature: Repeat fraud check journeys
       Then I get a 'P2' identity
 
   Rule: Match M1C Fraud Check Unavailable
-
     Background:
       Given the subject already has the following credentials
         | CRI     | scenario               |

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -1,8 +1,6 @@
 @Build
 Feature: Identity reuse update details failures
-
     Rule: Update given name only
-
         Background:
             Given the subject already has the following credentials
                 | CRI     | scenario                     |
@@ -147,7 +145,6 @@ Feature: Identity reuse update details failures
             Then I get a 'page-ipv-reuse' page response
 
     Rule: Update address only
-
         Background:
             Given the subject already has the following credentials
                 | CRI     | scenario                     |

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
@@ -1,6 +1,5 @@
 @Build
 Feature: International identity reuse update details
-
     Background:
         Given the subject already has the following credentials
             | CRI     | scenario               |

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
@@ -1,6 +1,5 @@
 @Build
 Feature: Identity reuse update details
-
     Background:
         Given the subject already has the following credentials
             | CRI     | scenario                     |

--- a/api-tests/features/stored-identity/reprove-identity-journeys.feature
+++ b/api-tests/features/stored-identity/reprove-identity-journeys.feature
@@ -1,6 +1,5 @@
 @Build
 Feature: Reprove Identity Journey
-
   Background:
     Given I activate the 'storedIdentityService,disableStrategicApp' feature set
 

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -1,6 +1,5 @@
 @Build @InitialisesDCMAWSessionState
 Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI and driving licence authoritative source check
-
   Background:
     # Submit web passport details, then navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
     Given I activate the 'strategicApp,drivingLicenceAuthCheck' feature set

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
@@ -1,6 +1,5 @@
 @Build @InitialisesDCMAWSessionState
 Feature: M2B Strategic App Journeys with DL authoritative source check
-
   Background: Get to the DL check
     Given I activate the 'strategicApp,drivingLicenceAuthCheck' feature set
     When I start a new 'low-confidence' journey

--- a/api-tests/features/strategic-app/p1-strategic-app.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app.feature
@@ -1,6 +1,5 @@
 @Build @InitialisesDCMAWSessionState
 Feature: M2B Strategic App Journeys
-
   Rule: Photo ID
     Background: Start journey
       Given I activate the 'strategicApp' feature set

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -1,6 +1,5 @@
 @Build @InitialisesDCMAWSessionState
 Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI and driving licence authoritative source check
-
   Background:
     # Submit web passport details, then navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
     Given I activate the 'strategicApp,drivingLicenceAuthCheck' feature set

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
@@ -1,6 +1,5 @@
 @Build @InitialisesDCMAWSessionState
 Feature: M2B Strategic App Journeys with DL authoritative source check
-
   Rule: Uk user
     Background: Get to the DL check
       Given I activate the 'strategicApp,drivingLicenceAuthCheck' feature set

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -1,6 +1,5 @@
 @Build @InitialisesDCMAWSessionState
 Feature: M2B Strategic App Journeys
-
   Rule: UK user
     Background: Start journey
       Given I activate the 'strategicApp' feature set


### PR DESCRIPTION
## Proposed changes

### What changed

- Fix to M1C test
- Consistency & conciseness
- Remove redundant steps

### Why did it change

- Easier to read & faster to use
- I did not change anymore as I think this ticket refers to setting featureSets, though this is not an inefficient step and can be done at any point as all it does is set a local variable to include in requests: (I have checked all of the background blocks to ensure they're not being inefficient)

```
this.featureSet = ...
```

### Issue tracking

- [PYIC-7807](https://govukverify.atlassian.net/browse/PYIC-7807)

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated

<!-- Delete if changes don't apply -->
- [x] Production changes appropriately staged out


[PYIC-7807]: https://govukverify.atlassian.net/browse/PYIC-7807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ