### PR TITLE
PYIC-8361: add journey id and ip address to headers when making a pos…

### DIFF
--- a/api-tests/src/clients/cimit-stub-client.ts
+++ b/api-tests/src/clients/cimit-stub-client.ts
@@ -5,6 +5,7 @@ import {
 } from "../types/cimit-stub.js";
 
 export const postDetectCi = async (
+  journeyId: string,
   body: CimitStubDetectRequest,
 ): Promise<void> => {
   const response = await fetch(
@@ -13,6 +14,8 @@ export const postDetectCi = async (
       headers: {
         "x-api-key": config.cimit.internalApiKey,
         "content-type": "application/json",
+        "govuk-signin-journey-id": journeyId,
+        "ip-address": "192.168.1.1",
       },
       method: "POST",
       body: JSON.stringify(body),

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -461,7 +461,9 @@ When(
       generatePostVcsBody(credentials),
     );
     for (const credential of credentials) {
-      await cimitStubClient.postDetectCi({ signed_jwt: credential });
+      await cimitStubClient.postDetectCi(getRandomString(16), {
+        signed_jwt: credential,
+      });
     }
   },
 );


### PR DESCRIPTION
…t request to /contra-indicators/detect endpoint

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Adding `govuk-signin-journey-id` and `ip-address` to headers when making a request to `/contra-indicators/detect`

### Why did it change
The above headers are required when making a request to the cimit stub's `/contra-indicator/detect` endpoint. They weren't failing previously as it was never enforced although they're [marked as required in the schema](https://github.com/govuk-one-login/ipv-stubs/blob/bfe92ce553da6b92797fac829d0eab88fe81a3ed/di-ipv-cimit-stub/openAPI/cimit-internal.yaml#L86-L98). With the upcoming fix to this, some api tests will fail unless these are added.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8361](https://govukverify.atlassian.net/browse/PYIC-8361)

## Checklists
<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated


[PYIC-8361]: https://govukverify.atlassian.net/browse/PYIC-8361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ