### PR TITLE
PYIC-8402: Add user to MISSING_CONTEXT audit event

### DIFF
--- a/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
+++ b/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
@@ -39,6 +39,13 @@
     }
   },
   {
+    "event_name": "IPV_APP_MISSING_CONTEXT",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_ASYNC_CRI_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
@@ -324,13 +331,6 @@
       "ciFail": false,
       "hasMitigations": false,
       "returnCodes": []
-    }
-  },
-  {
-    "event_name": "IPV_APP_MISSING_CONTEXT",
-    "component_id": "https://identity.local.account.gov.uk",
-    "restricted": {
-      "device_information": {}
     }
   }
 ]

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -514,11 +514,6 @@ Then(
       const expectedEvents = await getAuditEventsForJourneyType(journeyName);
       const actualEvents = await auditClient.getAuditEvents(this.userId);
 
-      if (journeyName === "strategic-app-cross-browser-journey") {
-        // Find events with no userId (only IPV_APP_MISSING_CONTEXT)
-        actualEvents.push(...(await auditClient.getAuditEvents(undefined)));
-      }
-
       const comparisonResult = compareAuditEvents(actualEvents, expectedEvents);
       assert.ok(
         comparisonResult.isPartiallyEqual,

--- a/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
+++ b/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
@@ -99,6 +99,14 @@ class ProcessMobileAppCallbackHandlerTest {
                         3600);
         when(criOAuthSessionService.getCriOauthSessionItem(TEST_OAUTH_STATE))
                 .thenReturn(criOAuthSessionItem);
+        var clientOAuthSessionItem = new ClientOAuthSessionItem();
+        clientOAuthSessionItem.setUserId(TEST_USER_ID);
+        when(clientOAuthSessionDetailsService.getClientOAuthSession(TEST_CLIENT_OAUTH_SESSION_ID))
+                .thenReturn(clientOAuthSessionItem);
+        var previousIpvSessionItem = new IpvSessionItem();
+        previousIpvSessionItem.setIpvSessionId(TEST_IPV_SESSION_ID);
+        when(ipvSessionService.getIpvSessionByClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID))
+                .thenReturn(previousIpvSessionItem);
 
         // Act
         var lambdaResponse =
@@ -115,6 +123,9 @@ class ProcessMobileAppCallbackHandlerTest {
         assertEquals(
                 AuditEventTypes.IPV_APP_MISSING_CONTEXT,
                 auditEventArgumentCaptor.getValue().getEventName());
+        assertEquals(TEST_USER_ID, auditEventArgumentCaptor.getValue().getUser().getUserId());
+        assertEquals(
+                TEST_IPV_SESSION_ID, auditEventArgumentCaptor.getValue().getUser().getSessionId());
     }
 
     @Test

--- a/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
+++ b/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
@@ -129,7 +129,8 @@ class ProcessMobileAppCallbackHandlerTest {
     }
 
     @Test
-    void shouldReturnErrorWhenCallbackRequestMissingIpvSessionIdAndClientOAuthSession() throws Exception {
+    void shouldReturnErrorWhenCallbackRequestMissingIpvSessionIdAndClientOAuthSession()
+            throws Exception {
         // Arrange
         var requestEvent = buildValidRequestEventWithState(TEST_OAUTH_STATE);
         requestEvent.setHeaders(Map.of());

--- a/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
+++ b/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
@@ -322,13 +322,6 @@ class ProcessMobileAppCallbackHandlerTest {
         return event;
     }
 
-    private IpvSessionItem buildValidIpvSessionItem() {
-        var ipvSessionItem = new IpvSessionItem();
-        ipvSessionItem.setIpvSessionId(TEST_IPV_SESSION_ID);
-        ipvSessionItem.setClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID);
-        return ipvSessionItem;
-    }
-
     private CriOAuthSessionItem buildValidCriOAuthSessionItem() {
         return CriOAuthSessionItem.builder()
                 .clientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID)

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/LocalAuditService.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/service/LocalAuditService.java
@@ -22,14 +22,9 @@ public class LocalAuditService implements AuditService {
     public static List<AuditEvent> getAuditEvents(String userId) {
         return AUDIT_EVENTS.stream()
                 .filter(
-                        event -> {
-                            if (userId == null) {
-                                // Only expected once, to fetch IPV_APP_MISSING_CONTEXT
-                                return event.getUser() == null;
-                            }
-                            return event.getUser() != null
-                                    && userId.equals(event.getUser().getUserId());
-                        })
+                        event ->
+                                event.getUser() != null
+                                        && userId.equals(event.getUser().getUserId()))
                 .toList();
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Add user to MISSING_CONTEXT audit event

### Why did it change

- More data for 

### Issue tracking

- [PYIC-8402](https://govukverify.atlassian.net/browse/PYIC-8402)

## Checklists

<!-- Delete if changes in READMEs or documentation are not required -->
- [x] All READMEs and documentation updated where necessary

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs

<!-- Delete if changes don't apply -->
- [x] API/unit/contract tests have been written/updated

<!-- Delete if changes don't apply -->
- [x] Production changes appropriately staged out


[PYIC-8402]: https://govukverify.atlassian.net/browse/PYIC-8402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ