### PR TITLE
PYIC-8363: Check TICF VC for relevant interventions

### DIFF
--- a/api-tests/features/account-intervention/journey-ending-interventions.feature
+++ b/api-tests/features/account-intervention/journey-ending-interventions.feature
@@ -17,19 +17,26 @@ Feature: Journey ending interventions
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
     When The AIS stub will return an '<second_ais_response>' result
+    And TICF CRI will respond with default parameters and
+      | interventionCode | <ticf_intervention_code> |
     And I submit 'kenneth-score-2' details to the CRI stub
     Then I get an OAuth response with error code 'session_invalidated'
 
     Examples:
-      | intervention                        | when  | first_ais_response             | second_ais_response                                |
-      | Blocked                             | start | AIS_ACCOUNT_BLOCKED            | AIS_NO_INTERVENTION                                |
-      | Suspended                           | start | AIS_ACCOUNT_SUSPENDED          | AIS_NO_INTERVENTION                                |
-      | Password reset                      | start | AIS_FORCED_USER_PASSWORD_RESET | AIS_NO_INTERVENTION                                |
-      | Blocked                             | end   | AIS_NO_INTERVENTION            | AIS_ACCOUNT_BLOCKED                                |
-      | Suspended                           | end   | AIS_NO_INTERVENTION            | AIS_ACCOUNT_SUSPENDED                              |
-      | Password reset                      | end   | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET                     |
-      | Reprove identity                    | end   | AIS_NO_INTERVENTION            | AIS_FORCED_USER_IDENTITY_VERIFY                    |
-      | Password reset and reprove identity | end   | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY |
+      | intervention                        | when  | first_ais_response             | second_ais_response                                | ticf_intervention_code |
+      | Blocked                             | start | AIS_ACCOUNT_BLOCKED            | AIS_NO_INTERVENTION                                | 00                     |
+      | Suspended                           | start | AIS_ACCOUNT_SUSPENDED          | AIS_NO_INTERVENTION                                | 00                     |
+      | Password reset                      | start | AIS_FORCED_USER_PASSWORD_RESET | AIS_NO_INTERVENTION                                | 00                     |
+      | Blocked                             | end   | AIS_NO_INTERVENTION            | AIS_ACCOUNT_BLOCKED                                | 00                     |
+      | Suspended                           | end   | AIS_NO_INTERVENTION            | AIS_ACCOUNT_SUSPENDED                              | 00                     |
+      | Password reset                      | end   | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET                     | 00                     |
+      | Reprove identity                    | end   | AIS_NO_INTERVENTION            | AIS_FORCED_USER_IDENTITY_VERIFY                    | 00                     |
+      | Password reset and reprove identity | end   | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY | 00                     |
+      | Blocked                             | end   | AIS_NO_INTERVENTION            | AIS_NO_INTERVENTION                                | 03                     |
+      | Suspended                           | end   | AIS_NO_INTERVENTION            | AIS_NO_INTERVENTION                                | 01                     |
+      | Password reset                      | end   | AIS_NO_INTERVENTION            | AIS_NO_INTERVENTION                                | 04                     |
+      | Reprove identity                    | end   | AIS_NO_INTERVENTION            | AIS_NO_INTERVENTION                                | 05                     |
+      | Password reset and reprove identity | end   | AIS_NO_INTERVENTION            | AIS_NO_INTERVENTION                                | 06                     |
 
   Scenario Outline: <intervention> intervention at <when> of reprove identity journey
     Given I activate the 'accountInterventions,disableStrategicApp' feature set

--- a/api-tests/features/ticf/ticf-successful-responses.feature
+++ b/api-tests/features/ticf/ticf-successful-responses.feature
@@ -76,6 +76,59 @@ Feature: TICF successful responses
         | cis  | BREACHING                    |
         | type | RiskAssessment               |
 
+  Rule: TICF responds with intervention
+    Scenario: No intervention
+      Given I activate the 'accountInterventions' feature set
+      And The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      And TICF CRI will respond with default parameters and
+        | interventionCode | 00 |
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Blocked
+      Given I activate the 'accountInterventions' feature set
+      And The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      And TICF CRI will respond with default parameters and
+        | interventionCode | 03 |
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details to the CRI stub
+      Then I get an OAuth response with error code 'session_invalidated'
+
   Rule: TICF response delay less than 2s
     Scenario: Via app - TICF request has a response delay less than 5s
       Given TICF CRI will respond with default parameters

--- a/api-tests/src/clients/ticf-management-api.ts
+++ b/api-tests/src/clients/ticf-management-api.ts
@@ -7,11 +7,13 @@ export const parseTableForTicfManagementParameters = (table: DataTable) => {
   const rowsHash = table.rowsHash();
   const responseDelay = parseInt(rowsHash.responseDelay) || 0;
   const cis = rowsHash.cis && rowsHash.cis.split(",");
+  const interventionCode = rowsHash.interventionCode;
   const statusCode = parseInt(rowsHash.statusCode) || 200;
 
   return {
     evidence: {
       ci: cis || undefined,
+      intervention: interventionCode ? { interventionCode } : undefined,
       type: rowsHash.type || "RiskAssessment",
       txn: rowsHash.txn === "" ? undefined : getRandomString(16),
     },

--- a/api-tests/src/types/ticf-management-api.ts
+++ b/api-tests/src/types/ticf-management-api.ts
@@ -2,6 +2,7 @@ export interface TicfManagementParameters {
   evidence: {
     type: string;
     ci: string[] | undefined;
+    intervention: { interventionCode: string } | undefined;
     txn: string | undefined;
   };
   responseDelay: number;

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -40,7 +40,6 @@ import uk.gov.di.ipv.core.initialiseipvsession.domain.Essential;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.JarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.validation.JarValidator;
-import uk.gov.di.ipv.core.library.ais.dto.AccountInterventionStatusDto;
 import uk.gov.di.ipv.core.library.ais.exception.AisClientException;
 import uk.gov.di.ipv.core.library.ais.service.AisService;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -360,8 +359,7 @@ class InitialiseIpvSessionHandlerTest {
         when(mockConfigService.enabled(any(FeatureFlag.class))).thenReturn(false);
         when(mockConfigService.enabled(AIS_ENABLED)).thenReturn(true);
         when(mockAisService.fetchAccountState(TEST_USER_ID))
-                .thenReturn(
-                        new AccountInterventionStatusDto.AccountState(false, false, true, false));
+                .thenReturn(new AccountInterventionState(false, false, true, false));
         var accountInterventionState = new AccountInterventionState(false, false, true, false);
         when(mockIpvSessionService.generateIpvSession(
                         any(), any(), any(), anyBoolean(), eq(accountInterventionState)))

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -133,6 +133,16 @@ public class ProcessCandidateIdentityHandler
             new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
     private static final JourneyResponse JOURNEY_ACCOUNT_INTERVENTION =
             new JourneyResponse(JOURNEY_ACCOUNT_INTERVENTION_PATH);
+    private static final Map<String, AisInterventionType> interventionCodeTypes =
+            Map.of(
+                    "00", AIS_NO_INTERVENTION,
+                    "01", AIS_ACCOUNT_SUSPENDED,
+                    "02", AIS_ACCOUNT_UNSUSPENDED,
+                    "03", AIS_ACCOUNT_BLOCKED,
+                    "04", AIS_FORCED_USER_PASSWORD_RESET,
+                    "05", AIS_FORCED_USER_IDENTITY_VERIFY,
+                    "06", AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
+                    "07", AIS_ACCOUNT_UNBLOCKED);
 
     private final ConfigService configService;
     private final ClientOAuthSessionDetailsService clientOAuthSessionDetailsService;
@@ -749,16 +759,6 @@ public class ProcessCandidateIdentityHandler
 
     private boolean checkHasRelevantIntervention(
             IpvSessionItem ipvSessionItem, List<VerifiableCredential> ticfVcs) {
-        Map<String, AisInterventionType> interventionCodeTypes =
-                Map.of(
-                        "00", AIS_NO_INTERVENTION,
-                        "01", AIS_ACCOUNT_SUSPENDED,
-                        "02", AIS_ACCOUNT_UNSUSPENDED,
-                        "03", AIS_ACCOUNT_BLOCKED,
-                        "04", AIS_FORCED_USER_PASSWORD_RESET,
-                        "05", AIS_FORCED_USER_IDENTITY_VERIFY,
-                        "06", AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
-                        "07", AIS_ACCOUNT_UNBLOCKED);
 
         return ticfVcs.stream()
                 .filter(vc -> vc.getCredential() instanceof RiskAssessmentCredential)
@@ -773,8 +773,7 @@ public class ProcessCandidateIdentityHandler
                 .map(
                         interventionCode ->
                                 aisService.getStateByIntervention(
-                                        interventionCodeTypes.getOrDefault(
-                                                interventionCode, AIS_NO_INTERVENTION)))
+                                        interventionCodeTypes.get(interventionCode)))
                 .anyMatch(
                         interventionState ->
                                 midJourneyInterventionDetected(

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -228,6 +228,7 @@ public class ProcessCandidateIdentityHandler
     @Override
     @Logging(clearState = true)
     @Metrics(captureColdStart = true)
+    @SuppressWarnings("java:S3776")
     public Map<String, Object> handleRequest(ProcessRequest request, Context context) {
         LogHelper.attachTraceId();
         LogHelper.attachComponentId(configService);

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -10,7 +10,7 @@ import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
-import uk.gov.di.ipv.core.library.ais.dto.AccountInterventionStatusDto;
+import uk.gov.di.ipv.core.library.ais.enums.AisInterventionType;
 import uk.gov.di.ipv.core.library.ais.exception.AisClientException;
 import uk.gov.di.ipv.core.library.ais.service.AisService;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -71,6 +71,9 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredential
 import uk.gov.di.ipv.core.processcandidateidentity.domain.SharedAuditEventParameters;
 import uk.gov.di.ipv.core.processcandidateidentity.service.CheckCoiService;
 import uk.gov.di.ipv.core.processcandidateidentity.service.StoreIdentityService;
+import uk.gov.di.model.Intervention;
+import uk.gov.di.model.RiskAssessment;
+import uk.gov.di.model.RiskAssessmentCredential;
 
 import java.io.UncheckedIOException;
 import java.text.ParseException;
@@ -81,6 +84,14 @@ import java.util.Objects;
 import java.util.Set;
 
 import static java.lang.Boolean.TRUE;
+import static uk.gov.di.ipv.core.library.ais.enums.AisInterventionType.AIS_ACCOUNT_BLOCKED;
+import static uk.gov.di.ipv.core.library.ais.enums.AisInterventionType.AIS_ACCOUNT_SUSPENDED;
+import static uk.gov.di.ipv.core.library.ais.enums.AisInterventionType.AIS_ACCOUNT_UNBLOCKED;
+import static uk.gov.di.ipv.core.library.ais.enums.AisInterventionType.AIS_ACCOUNT_UNSUSPENDED;
+import static uk.gov.di.ipv.core.library.ais.enums.AisInterventionType.AIS_FORCED_USER_IDENTITY_VERIFY;
+import static uk.gov.di.ipv.core.library.ais.enums.AisInterventionType.AIS_FORCED_USER_PASSWORD_RESET;
+import static uk.gov.di.ipv.core.library.ais.enums.AisInterventionType.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY;
+import static uk.gov.di.ipv.core.library.ais.enums.AisInterventionType.AIS_NO_INTERVENTION;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.CREDENTIAL_ISSUER_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.AIS_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.STORED_IDENTITY_SERVICE;
@@ -238,13 +249,15 @@ public class ProcessCandidateIdentityHandler
 
             String userId = clientOAuthSessionItem.getUserId();
 
-            if (configService.enabled(AIS_ENABLED)
-                    && midJourneyInterventionDetected(
-                            userId, ipvSessionItem.getInitialAccountInterventionState())) {
-                ipvSessionItem.setErrorCode("session_invalidated");
-                ipvSessionItem.setErrorDescription("Account intervention detected");
+            if (configService.enabled(AIS_ENABLED)) {
+                var interventionState = aisService.fetchAccountState(userId);
+                if (midJourneyInterventionDetected(
+                        ipvSessionItem.getInitialAccountInterventionState(), interventionState)) {
+                    updateIpvSessionWithIntervention(ipvSessionItem);
+                    return JOURNEY_ACCOUNT_INTERVENTION.toObjectMap();
+                }
+                ipvSessionItem.setInitialAccountInterventionState(interventionState);
                 ipvSessionService.updateIpvSession(ipvSessionItem);
-                return JOURNEY_ACCOUNT_INTERVENTION.toObjectMap();
             }
 
             var sessionVcs =
@@ -335,11 +348,15 @@ public class ProcessCandidateIdentityHandler
         }
     }
 
-    private boolean midJourneyInterventionDetected(
-            String userId, AccountInterventionState initialAccountInterventionState)
-            throws AisClientException {
-        var currentAccountInterventionState = aisService.fetchAccountState(userId);
+    private void updateIpvSessionWithIntervention(IpvSessionItem ipvSessionItem) {
+        ipvSessionItem.setErrorCode("session_invalidated");
+        ipvSessionItem.setErrorDescription("Account intervention detected");
+        ipvSessionService.updateIpvSession(ipvSessionItem);
+    }
 
+    private boolean midJourneyInterventionDetected(
+            AccountInterventionState initialAccountInterventionState,
+            AccountInterventionState currentAccountInterventionState) {
         // If no intervention flags are set then there can't have been an intervention
         if (!initialAccountInterventionState.isBlocked()
                 && !initialAccountInterventionState.isSuspended()
@@ -394,7 +411,7 @@ public class ProcessCandidateIdentityHandler
 
     private boolean notBlockedAndNotPasswordReset(
             AccountInterventionState initialAccountInterventionState,
-            AccountInterventionStatusDto.AccountState currentAccountInterventionState) {
+            AccountInterventionState currentAccountInterventionState) {
         return !initialAccountInterventionState.isBlocked()
                 && !initialAccountInterventionState.isResetPassword()
                 && !currentAccountInterventionState.isBlocked()
@@ -669,6 +686,12 @@ public class ProcessCandidateIdentityHandler
                     List.of(),
                     sharedAuditEventParameters.auditEventUser());
 
+            if (configService.enabled(AIS_ENABLED)
+                    && checkHasRelevantIntervention(ipvSessionItem, ticfVcs)) {
+                updateIpvSessionWithIntervention(ipvSessionItem);
+                return JOURNEY_ACCOUNT_INTERVENTION;
+            }
+
             if (!clientOAuthSessionItem.isReverification()) {
                 // Get mitigations from old CIMIT VC to compare against the mitigations on the new
                 // CIs
@@ -721,6 +744,41 @@ public class ProcessCandidateIdentityHandler
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     ERROR_PROCESSING_TICF_CRI_RESPONSE);
         }
+    }
+
+    private boolean checkHasRelevantIntervention(
+            IpvSessionItem ipvSessionItem, List<VerifiableCredential> ticfVcs) {
+        Map<String, AisInterventionType> interventionCodeTypes =
+                Map.of(
+                        "00", AIS_NO_INTERVENTION,
+                        "01", AIS_ACCOUNT_SUSPENDED,
+                        "02", AIS_ACCOUNT_UNSUSPENDED,
+                        "03", AIS_ACCOUNT_BLOCKED,
+                        "04", AIS_FORCED_USER_PASSWORD_RESET,
+                        "05", AIS_FORCED_USER_IDENTITY_VERIFY,
+                        "06", AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
+                        "07", AIS_ACCOUNT_UNBLOCKED);
+
+        return ticfVcs.stream()
+                .filter(vc -> vc.getCredential() instanceof RiskAssessmentCredential)
+                .flatMap(
+                        vc ->
+                                ((RiskAssessmentCredential) vc.getCredential())
+                                        .getEvidence().stream())
+                .map(RiskAssessment::getIntervention)
+                .filter(Objects::nonNull)
+                .map(Intervention::getInterventionCode)
+                .filter(Objects::nonNull)
+                .map(
+                        interventionCode ->
+                                aisService.getStateByIntervention(
+                                        interventionCodeTypes.getOrDefault(
+                                                interventionCode, AIS_NO_INTERVENTION)))
+                .anyMatch(
+                        interventionState ->
+                                midJourneyInterventionDetected(
+                                        ipvSessionItem.getInitialAccountInterventionState(),
+                                        interventionState));
     }
 
     private void sendProfileMatchedAuditEvent(

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/dto/AccountInterventionStatusDto.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/dto/AccountInterventionStatusDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.di.ipv.core.library.ais.enums.AisAuditLevel;
 import uk.gov.di.ipv.core.library.ais.enums.AisInterventionType;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.dto.AccountInterventionState;
 
 @ExcludeFromGeneratedCoverageReport
 @Data
@@ -15,7 +16,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @AllArgsConstructor
 public class AccountInterventionStatusDto {
     private Intervention intervention;
-    private AccountState state;
+    private AccountInterventionState state;
     private AisAuditLevel auditLevel;
     private InterventionHistory[] history;
 
@@ -31,17 +32,6 @@ public class AccountInterventionStatusDto {
         private Long reprovedIdentityAt;
         private Long resetPasswordAt;
         private Long accountDeletedAt;
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class AccountState {
-        private boolean blocked;
-        private boolean suspended;
-        private boolean reproveIdentity;
-        private boolean resetPassword;
     }
 
     @Data

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/service/AisService.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/service/AisService.java
@@ -25,6 +25,7 @@ public class AisService {
         return interventionDetails.getState();
     }
 
+    @ExcludeFromGeneratedCoverageReport
     public AccountInterventionState getStateByIntervention(AisInterventionType interventionType) {
         switch (interventionType) {
             case AIS_NO_INTERVENTION, AIS_ACCOUNT_UNSUSPENDED, AIS_ACCOUNT_UNBLOCKED -> {
@@ -45,9 +46,7 @@ public class AisService {
             case AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY -> {
                 return new AccountInterventionState(false, true, true, true);
             }
+            default -> { return new AccountInterventionState(false, false, false, false); }
         }
-
-        throw new RuntimeException(
-                "AisInterventionType has no corresponding account intervention state");
     }
 }

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/service/AisService.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/service/AisService.java
@@ -1,9 +1,10 @@
 package uk.gov.di.ipv.core.library.ais.service;
 
 import uk.gov.di.ipv.core.library.ais.client.AisClient;
-import uk.gov.di.ipv.core.library.ais.dto.AccountInterventionStatusDto;
+import uk.gov.di.ipv.core.library.ais.enums.AisInterventionType;
 import uk.gov.di.ipv.core.library.ais.exception.AisClientException;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.dto.AccountInterventionState;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 public class AisService {
@@ -19,9 +20,34 @@ public class AisService {
         this.aisClient = aisClient;
     }
 
-    public AccountInterventionStatusDto.AccountState fetchAccountState(String userId)
-            throws AisClientException {
+    public AccountInterventionState fetchAccountState(String userId) throws AisClientException {
         var interventionDetails = aisClient.getAccountInterventionStatus(userId);
         return interventionDetails.getState();
+    }
+
+    public AccountInterventionState getStateByIntervention(AisInterventionType interventionType) {
+        switch (interventionType) {
+            case AIS_NO_INTERVENTION, AIS_ACCOUNT_UNSUSPENDED, AIS_ACCOUNT_UNBLOCKED -> {
+                return new AccountInterventionState(false, false, false, false);
+            }
+            case AIS_ACCOUNT_SUSPENDED -> {
+                return new AccountInterventionState(false, true, false, false);
+            }
+            case AIS_ACCOUNT_BLOCKED -> {
+                return new AccountInterventionState(true, false, false, false);
+            }
+            case AIS_FORCED_USER_PASSWORD_RESET -> {
+                return new AccountInterventionState(false, true, false, true);
+            }
+            case AIS_FORCED_USER_IDENTITY_VERIFY -> {
+                return new AccountInterventionState(false, true, true, false);
+            }
+            case AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY -> {
+                return new AccountInterventionState(false, true, true, true);
+            }
+        }
+
+        throw new RuntimeException(
+                "AisInterventionType has no corresponding account intervention state");
     }
 }

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/service/AisService.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/service/AisService.java
@@ -46,7 +46,9 @@ public class AisService {
             case AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY -> {
                 return new AccountInterventionState(false, true, true, true);
             }
-            default -> { return new AccountInterventionState(false, false, false, false); }
+            default -> {
+                return new AccountInterventionState(false, false, false, false);
+            }
         }
     }
 }

--- a/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/TestData.java
+++ b/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/TestData.java
@@ -3,6 +3,7 @@ package uk.gov.di.ipv.core.library.ais;
 import uk.gov.di.ipv.core.library.ais.dto.AccountInterventionStatusDto;
 import uk.gov.di.ipv.core.library.ais.enums.AisAuditLevel;
 import uk.gov.di.ipv.core.library.ais.enums.AisInterventionType;
+import uk.gov.di.ipv.core.library.dto.AccountInterventionState;
 
 public class TestData {
     public static final String AIS_RESPONSE_NO_INTERVENTION =
@@ -38,13 +39,7 @@ public class TestData {
                                     .resetPasswordAt(1696875903456L)
                                     .accountDeletedAt(1696969359935L)
                                     .build())
-                    .state(
-                            AccountInterventionStatusDto.AccountState.builder()
-                                    .blocked(false)
-                                    .suspended(false)
-                                    .reproveIdentity(false)
-                                    .resetPassword(false)
-                                    .build())
+                    .state(new AccountInterventionState(false, false, false, false))
                     .auditLevel(AisAuditLevel.STANDARD)
                     .history(new AccountInterventionStatusDto.InterventionHistory[0])
                     .build();
@@ -82,13 +77,7 @@ public class TestData {
                                     .resetPasswordAt(1696875903456L)
                                     .accountDeletedAt(1696969359935L)
                                     .build())
-                    .state(
-                            AccountInterventionStatusDto.AccountState.builder()
-                                    .blocked(false)
-                                    .suspended(true)
-                                    .reproveIdentity(true)
-                                    .resetPassword(false)
-                                    .build())
+                    .state(new AccountInterventionState(false, true, true, false))
                     .auditLevel(AisAuditLevel.STANDARD)
                     .history(new AccountInterventionStatusDto.InterventionHistory[0])
                     .build();

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -12,6 +12,7 @@ import uk.gov.di.model.DrivingPermitDetails;
 import uk.gov.di.model.IdentityCheck;
 import uk.gov.di.model.IdentityCheckCredential;
 import uk.gov.di.model.IdentityCheckSubject;
+import uk.gov.di.model.Intervention;
 import uk.gov.di.model.Name;
 import uk.gov.di.model.NamePart;
 import uk.gov.di.model.PassportDetails;
@@ -1232,6 +1233,14 @@ public interface VcFixtures {
     static VerifiableCredential vcTicfWithCi() {
         var vcClaim = vcClaimTicf();
         vcClaim.getEvidence().get(0).setCi(List.of("test"));
+
+        return generateVerifiableCredential(
+                TEST_SUBJECT, TICF, vcClaim, TICF_ISSUER, Instant.ofEpochSecond(1704822570));
+    }
+
+    static VerifiableCredential generateTicfVcWithIntervention(Intervention intervention) {
+        var vcClaim = vcClaimTicf();
+        vcClaim.getEvidence().get(0).setIntervention(intervention);
 
         return generateVerifiableCredential(
                 TEST_SUBJECT, TICF, vcClaim, TICF_ISSUER, Instant.ofEpochSecond(1704822570));


### PR DESCRIPTION
## Proposed changes

### What changed

- Check TICF VC for relevant interventions

### Why did it change

- TICF can return account interventions we must deal with

### Issue tracking

- [PYIC-8363](https://govukverify.atlassian.net/browse/PYIC-8363)

## Checklists

- [x] All READMEs and documentation updated where necessary
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs
- [x] API/unit/contract tests have been written/updated
- [x] Production changes appropriately staged out


[PYIC-8363]: https://govukverify.atlassian.net/browse/PYIC-8363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ