### PR TITLE
PYIC-8375: add logging to say how many VCs are stored using PUT method

### DIFF
--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
@@ -109,7 +109,10 @@ public class EvcsClient {
 
     public HttpResponse<String> storeUserVCs(EvcsPutUserVCsDto userVCsForEvcs)
             throws EvcsServiceException {
-        LOGGER.info(LogHelper.buildLogMessage("Preparing to store user VCs using PUT method"));
+        LOGGER.info(
+                LogHelper.buildLogMessage(
+                        "Preparing to store %d user VCs using PUT method"
+                                .formatted(userVCsForEvcs.vcs().size())));
 
         try {
             HttpRequest.Builder httpRequestBuilder =


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Improving logging for PUT method to also log how many VCs are stored to EVCS (matches POST method logging)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8375](https://govukverify.atlassian.net/browse/PYIC-8375)

## Checklists

<!-- Delete if changes don't include risk of credentials being exposed -->
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs



[PYIC-8375]: https://govukverify.atlassian.net/browse/PYIC-8375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ