### PR TITLE
BAU: Cleanup PR template comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,6 @@
 ## Checklists
 
 - [ ] READMEs and documentation up-to-date
-- [ ] API/ unit/ contract tests are up-to-date
+- [ ] API/ unit/ contract tests have been written/ updated
 - [ ] No risk of exposure: PII, credentials, etc through logs/ code
 - [ ] Production changes appropriately staged out

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,20 @@
-<!-- Provide a general summary of your changes in the Title above -->
-<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->
-
 ## Proposed changes
-
 ### What changed
 
-<!-- Describe the changes in detail - the "what"-->
+- 
 
 ### Why did it change
 
-<!-- Describe the reason these changes were made - the "why" -->
+- 
 
 ### Issue tracking
-<!-- List any related Jira tickets or GitHub issues -->
-<!-- List any related ADRs or RFCs -->
-<!-- Delete/copy as appropriate -->
+<!-- Jira ticket & other docs, like RFCs -->
 
 - [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)
 
 ## Checklists
 
-<!-- Delete if changes in READMEs or documentation are not required -->
-- [ ] All READMEs and documentation updated where necessary
-
-<!-- Delete if changes don't include risk of credentials being exposed -->
-- [ ] No risk of PII, credentials or anything else sensitive being exposed through logs
-
-<!-- Delete if changes don't apply -->
-- [ ] API/unit/contract tests have been written/updated
-
-<!-- Delete if changes don't apply -->
+- [ ] READMEs and documentation up-to-date
+- [ ] API/ unit/ contract tests are up-to-date
+- [ ] No risk of exposure: PII, credentials, etc through logs/ code
 - [ ] Production changes appropriately staged out


### PR DESCRIPTION
## Proposed changes

### What changed

- Cleanup PR template comments

### Why did it change

- Reduce noise & repetitive line deletions
- Comments not needed when obvious

### Issue tracking

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

- [x] All READMEs and documentation updated where necessary
- [x] No risk of PII, credentials or anything else sensitive being exposed through logs
- [x] API/unit/contract tests have been written/updated
- [x] Production changes appropriately staged out
