### PR TITLE
BAU Improve observability of async VC processing

### DIFF
--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -29,10 +29,12 @@ import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.UnrecognisedVotException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
+import uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
+import uk.gov.di.ipv.core.library.tracing.InstrumentationHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.helpers.VcHelper;
 import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialValidator;
 import uk.gov.di.ipv.core.processasynccricredential.domain.ErrorAsyncCriResponse;
@@ -44,6 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAudit;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAuditWithCriId;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForAsync;
@@ -98,6 +101,10 @@ public class ProcessAsyncCriCredentialHandler
         try {
             LogHelper.attachTraceId();
             LogHelper.attachComponentId(configService);
+            String queueName = extractQueueName(event);
+            LogHelper.attachQueueNameToLogs(queueName);
+            InstrumentationHelper.setSpanAttribute("sqs.queue.name", queueName);
+
             var failedRecords = new ArrayList<SQSBatchResponse.BatchItemFailure>();
 
             for (var sqsMessage : event.getRecords()) {
@@ -131,6 +138,12 @@ public class ProcessAsyncCriCredentialHandler
                 | EvcsServiceException
                 | HttpResponseExceptionWithErrorBody e) {
             LOGGER.error(LogHelper.buildErrorMessage("Failed to process VC response message.", e));
+            if (e instanceof AsyncVerifiableCredentialException asyncVcException
+                    && asyncVcException
+                            .getErrorResponse()
+                            .equals(UNEXPECTED_ASYNC_VERIFIABLE_CREDENTIAL)) {
+                EmbeddedMetricHelper.asyncCriResponseUnexpected(extractQueueName(message));
+            }
             return List.of(new SQSBatchResponse.BatchItemFailure(message.getMessageId()));
         } catch (VerifiableCredentialException e) {
             LOGGER.error(
@@ -152,8 +165,10 @@ public class ProcessAsyncCriCredentialHandler
 
         criResponseItem.ifPresent(
                 responseItem -> {
-                    if (CriResponseService.ERROR_ACCESS_DENIED.equals(
-                            errorAsyncCriResponse.getError())) {
+                    Cri cri = Cri.fromId(responseItem.getCredentialIssuer());
+                    String errorCode = errorAsyncCriResponse.getError();
+                    EmbeddedMetricHelper.asyncCriErrorResponse(cri.getId(), errorCode);
+                    if (CriResponseService.ERROR_ACCESS_DENIED.equals(errorCode)) {
                         responseItem.setStatus(CriResponseService.STATUS_ABANDON);
                     } else {
                         responseItem.setStatus(CriResponseService.STATUS_ERROR);
@@ -313,5 +328,27 @@ public class ProcessAsyncCriCredentialHandler
 
     private void postMitigatingVc(VerifiableCredential vc) throws CiPostMitigationsException {
         cimitService.submitMitigatingVcList(List.of(vc), null, null);
+    }
+
+    private String extractQueueName(SQSEvent event) {
+        var records = event.getRecords();
+        if (!isNullOrEmpty(records)) {
+            SQSMessage firstMessage =
+                    records.get(0); // Batched messages should all come from same queue
+            return extractQueueName(firstMessage);
+        }
+        return "unknown";
+    }
+
+    private String extractQueueName(SQSMessage message) {
+        try {
+            if (message != null) {
+                String arn = message.getEventSourceArn();
+                return arn.substring(arn.lastIndexOf(":") + 1);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to extract queue name from SQS message", e);
+        }
+        return "unknown";
     }
 }

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/exceptions/AsyncVerifiableCredentialException.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/exceptions/AsyncVerifiableCredentialException.java
@@ -13,4 +13,8 @@ public class AsyncVerifiableCredentialException extends RuntimeException {
     public String getMessage() {
         return errorResponse.getMessage();
     }
+
+    public ErrorResponse getErrorResponse() {
+        return errorResponse;
+    }
 }

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -299,9 +300,12 @@ class ProcessAsyncCriCredentialHandlerTest {
 
         // Assert
         assertEquals("Test error", thrown.getMessage());
-        var logMessage = logCollector.getLogMessages().get(0);
-        assertThat(logMessage, containsString("Unhandled lambda exception"));
-        assertThat(logMessage, containsString("Test error"));
+        Optional<String> logMessage =
+                logCollector.getLogMessages().stream()
+                        .filter(msg -> msg.contains("Unhandled lambda exception"))
+                        .findFirst();
+        assertTrue(logMessage.isPresent());
+        assertThat(logMessage.get(), containsString("Test error"));
     }
 
     private SQSEvent createErrorTestEvent(String errorType) throws JsonProcessingException {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/EmbeddedMetricHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/EmbeddedMetricHelper.java
@@ -2,6 +2,8 @@ package uk.gov.di.ipv.core.library.helpers;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
@@ -11,19 +13,26 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import java.util.Map;
 
 import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Dimension.CRI;
+import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Dimension.ERROR_CODE;
+import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Dimension.QUEUE_NAME;
+import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.ASYNC_CRI_ERROR_RESPONSE;
+import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.ASYNC_CRI_RESPONSE_MESSAGE_UNEXPECTED;
 import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.CRI_REDIRECT;
 import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.CRI_RETURN;
 
 @ExcludeFromGeneratedCoverageReport
 public class EmbeddedMetricHelper {
     private static final MetricsLogger METRICS_LOGGER = MetricsUtils.metricsLogger();
+    private static final Logger LOGGER = LogManager.getLogger();
 
     @Getter
     @AllArgsConstructor
     @ExcludeFromGeneratedCoverageReport
     public enum Metric {
         CRI_REDIRECT("criRedirect"),
-        CRI_RETURN("criReturn");
+        CRI_RETURN("criReturn"),
+        ASYNC_CRI_RESPONSE_MESSAGE_UNEXPECTED("asyncCriResponseMessageUnexpected"),
+        ASYNC_CRI_ERROR_RESPONSE("asyncCriErrorResponse");
 
         private final String name;
     }
@@ -32,25 +41,43 @@ public class EmbeddedMetricHelper {
     @AllArgsConstructor
     @ExcludeFromGeneratedCoverageReport
     public enum Dimension {
-        CRI("cri");
+        CRI("cri"),
+        QUEUE_NAME("queueName"),
+        ERROR_CODE("errorCode"),
+        ERROR_MESSAGE("errorMessage");
 
         private final String name;
     }
 
-    public static void criRedirect(String cri) {
-        recordMetric(Map.of(CRI, cri), Map.of(CRI_REDIRECT, 1.0));
+    public static void criRedirect(String criId) {
+        recordMetric(Map.of(CRI, criId), Map.of(CRI_REDIRECT, 1.0));
     }
 
-    public static void criReturn(String cri) {
-        recordMetric(Map.of(CRI, cri), Map.of(CRI_RETURN, 1.0));
+    public static void criReturn(String criId) {
+        recordMetric(Map.of(CRI, criId), Map.of(CRI_RETURN, 1.0));
+    }
+
+    public static void asyncCriResponseUnexpected(String queueName) {
+        recordMetric(
+                Map.of(QUEUE_NAME, queueName), Map.of(ASYNC_CRI_RESPONSE_MESSAGE_UNEXPECTED, 1.0));
+    }
+
+    public static void asyncCriErrorResponse(String criId, String errorCode) {
+        recordMetric(
+                Map.of(CRI, criId, ERROR_CODE, errorCode), Map.of(ASYNC_CRI_ERROR_RESPONSE, 1.0));
     }
 
     private static void recordMetric(
             Map<Dimension, String> dimensions, Map<Metric, Double> metrics) {
-        ThreadContext.getContext().forEach(METRICS_LOGGER::putProperty);
-        dimensions.forEach(
-                (dimension, value) ->
-                        METRICS_LOGGER.putDimensions(DimensionSet.of(dimension.getName(), value)));
-        metrics.forEach((metric, value) -> METRICS_LOGGER.putMetric(metric.getName(), value));
+        try {
+            ThreadContext.getContext().forEach(METRICS_LOGGER::putProperty);
+            dimensions.forEach(
+                    (dimension, value) ->
+                            METRICS_LOGGER.putDimensions(
+                                    DimensionSet.of(dimension.getName(), value)));
+            metrics.forEach((metric, value) -> METRICS_LOGGER.putMetric(metric.getName(), value));
+        } catch (Exception e) {
+            LOGGER.warn("Failed to record embedded metric", e);
+        }
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -18,6 +18,7 @@ import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_CODE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
+import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_QUEUE_NAME;
 
 @ExcludeFromGeneratedCoverageReport
 public class LogHelper {
@@ -70,6 +71,7 @@ public class LogHelper {
         LOG_PARAMETER_PATH("parameterPath"),
         LOG_PAYLOAD("payload"),
         LOG_PROFILE("profile"),
+        LOG_QUEUE_NAME("queueName"),
         LOG_REDIRECT_URI("redirectUri"),
         LOG_RESET_TYPE("resetType"),
         LOG_RESPONSE_CONTENT_TYPE("responseContentType"),
@@ -148,6 +150,14 @@ public class LogHelper {
                     LogField.LOG_GOVUK_SIGNIN_JOURNEY_ID, GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE);
         } else {
             attachFieldToLogs(LogField.LOG_GOVUK_SIGNIN_JOURNEY_ID, govukSigninJourneyId);
+        }
+    }
+
+    public static void attachQueueNameToLogs(String queueName) {
+        if (StringUtils.isBlank(queueName)) {
+            LogHelper.attachFieldToLogs(LOG_QUEUE_NAME, "unknown");
+        } else {
+            LogHelper.attachFieldToLogs(LOG_QUEUE_NAME, queueName);
         }
     }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/InstrumentationHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/InstrumentationHelper.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.core.library.tracing;
+
+import io.opentelemetry.api.trace.Span;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class InstrumentationHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private InstrumentationHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static void setSpanAttribute(String name, String value) {
+        try {
+            Span span = Span.current();
+            span.setAttribute(name, value);
+        } catch (Exception e) {
+            LOGGER.warn(String.format("Failed to instrument span attribute: %s", name));
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes
### What changed

Improve observability of async VC processing
- attach queue name to logs and tracing
- record metric for error response message received
- record metric for unexpected message received
- make metrics recording fail open

### Why did it change

So we can distinguish logs and tracing based on source of queue message now that we have two sources - F2F and dcmawAsync. Also trial recording useful metrics that we can track through e.g. Dynatrace.

