### PR TITLE
BAU: Switch to apache client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ uuid_results
 
 libs/test-helpers/bin
 local-running/bin/
+libs/common-services/bin
+libs/ticf-cri-service/bin
 
 # User-specific secrets
 secrets.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,6 @@ spotless {
 
 subprojects {
 	task allDeps(type: DependencyReportTask) {}
-	configurations.all {
-		exclude group: 'software.amazon.awssdk', module: 'apache-client'
-	}
 
 	tasks.withType(Test) {
 		// Configures environment variables to avoid errors in AWS X-Ray and EMF loggers

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ awsSdkDynamodb = { module = "software.amazon.awssdk:dynamodb" }
 awsSdkDynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
 awsSdkKms = { module = "software.amazon.awssdk:kms" }
 awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
-awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
+awsSdkApacheHttpClient = { module = "software.amazon.awssdk:apache-client" }
 awsSdkAppConfigData = { module = "software.amazon.awssdk:appconfigdata" }
 commonsCodec = "commons-codec:commons-codec:1.18.0"
 commonsCollections = "org.apache.commons:commons-collections4:4.5.0-M2"

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation libs.bundles.awsLambda,
 			libs.awsSdkKms,
 			libs.powertoolsParameters,
+			libs.awsSdkApacheHttpClient,
 			project(":libs:ais-service"),
 			project(":libs:audit-service"),
 			project(":libs:common-services"),

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -12,7 +12,7 @@ import com.nimbusds.jose.util.Base64URL;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import software.amazon.awssdk.services.kms.model.DecryptResponse;
@@ -47,7 +47,7 @@ public class KmsRsaDecrypter implements JWEDecrypter {
         this.kmsClient =
                 KmsClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .httpClientBuilder(ApacheHttpClient.builder())
                         .build();
     }
 

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -7,7 +7,6 @@ plugins {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsSdkUrlConnectionClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -8,7 +8,6 @@ plugins {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.apacheHttpCore,
-			libs.awsSdkUrlConnectionClient,
 			libs.jacksonDatabind,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 			libs.awsSdkDynamodbEnhanced,
 			libs.awsSdkKms,
 			libs.awsSdkAppConfigData,
+			libs.awsSdkApacheHttpClient,
 			libs.commonsCodec,
 			libs.commonsCollections,
 			libs.jacksonDatabind,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStore.java
@@ -15,7 +15,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
@@ -57,7 +57,7 @@ public class DynamoDataStore<T extends PersistenceItem> implements DataStore<T> 
         var client =
                 DynamoDbClient.builder()
                         .region(EU_WEST_2)
-                        .httpClient(UrlConnectionHttpClient.create())
+                        .httpClient(ApacheHttpClient.create())
                         .build();
 
         return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.DecryptionFailureException;
@@ -55,7 +55,7 @@ public class AppConfigService extends YamlParametersConfigService {
         appConfigProvider =
                 ParamManager.getAppConfigProvider(
                                 AppConfigDataClient.builder()
-                                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                                        .httpClientBuilder(ApacheHttpClient.builder())
                                         .build(),
                                 environmentId,
                                 applicationId)
@@ -64,7 +64,7 @@ public class AppConfigService extends YamlParametersConfigService {
         secretsProvider =
                 ParamManager.getSecretsProvider(
                                 SecretsManagerClient.builder()
-                                        .httpClient(UrlConnectionHttpClient.create())
+                                        .httpClient(ApacheHttpClient.create())
                                         .build())
                         .defaultMaxAge(cacheDuration, MINUTES);
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringMapMessage;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.DecryptionFailureException;
 import software.amazon.awssdk.services.secretsmanager.model.InternalServiceErrorException;
@@ -62,15 +62,13 @@ public class SsmConfigService extends ConfigService {
 
         this.ssmProvider =
                 ParamManager.getSsmProvider(
-                                SsmClient.builder()
-                                        .httpClient(UrlConnectionHttpClient.create())
-                                        .build())
+                                SsmClient.builder().httpClient(ApacheHttpClient.create()).build())
                         .defaultMaxAge(cacheDuration, MINUTES);
 
         this.secretsProvider =
                 ParamManager.getSecretsProvider(
                                 SecretsManagerClient.builder()
-                                        .httpClient(UrlConnectionHttpClient.create())
+                                        .httpClient(ApacheHttpClient.create())
                                         .build())
                         .defaultMaxAge(cacheDuration, MINUTES);
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/signing/SignerFactory.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/signing/SignerFactory.java
@@ -2,7 +2,7 @@ package uk.gov.di.ipv.core.library.signing;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.ECKey;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -24,7 +24,7 @@ public class SignerFactory {
         this.kmsClient =
                 KmsClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .httpClientBuilder(ApacheHttpClient.builder())
                         .build();
     }
 

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -7,7 +7,6 @@ plugins {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkSqs,
-			libs.awsSdkUrlConnectionClient,
 			libs.bundles.awsLambda,
 			libs.bundles.log4j,
 			libs.jacksonDatabind,


### PR DESCRIPTION
## Proposed changes
### What changed

Switch from `UrlConnectionHttpClient` (software.amazon.awssdk:url-connection-client) to `ApacheHttpClient` (software.amazon.awssdk:apache-client) as a speculative fix for the segfault issue.

I didn't reproduce a segfault in the dev environment. I believe previously, attempts at fixing the issue were made on the build environment. I don't think it's worth trying to feature flag this or anything though there is a slight risk of performance degradation. 

### Why did it change

Because Apache is the only http client that they claim to support. See known limitations at the bottom of this page: https://docs.dynatrace.com/docs/ingest-from/amazon-web-services/integrate-into-aws/aws-lambda-integration/aws-lambda-extension 

