### PR TITLE
PYIC-8421: send evidence_request to fraud CRI to skip PEPS

### DIFF
--- a/api-tests/data/cri-stub-requests/dcmaw/kenneth-brc-valid/evidence.json
+++ b/api-tests/data/cri-stub-requests/dcmaw/kenneth-brc-valid/evidence.json
@@ -1,7 +1,7 @@
 {
   "type": "IdentityCheck",
   "txn": "RB000117420948",
-  "strengthScore": 3,
+  "strengthScore": 4,
   "validityScore": 2,
   "activityHistoryScore": 1,
   "checkDetails": [

--- a/api-tests/features/account-intervention/journey-ending-interventions.feature
+++ b/api-tests/features/account-intervention/journey-ending-interventions.feature
@@ -19,7 +19,9 @@ Feature: Journey ending interventions
     When The AIS stub will return an '<second_ais_response>' result
     And TICF CRI will respond with default parameters and
       | interventionCode | <ticf_intervention_code> |
-    And I submit 'kenneth-score-2' details to the CRI stub
+    And I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get an OAuth response with error code 'session_invalidated'
 
     Examples:
@@ -61,7 +63,9 @@ Feature: Journey ending interventions
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
     When The AIS stub will return an '<second_ais_response>' result
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get an OAuth response with error code 'session_invalidated'
 
     Examples:
@@ -107,7 +111,9 @@ Feature: Journey ending interventions
       | context   | "international_user" |
     Then I get a 'fraud' CRI response
     When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get an OAuth response with error code 'session_invalidated'
 
   Scenario: Blocked intervention at end of initial F2F journey
@@ -126,5 +132,7 @@ Feature: Journey ending interventions
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
     When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
-    And I submit 'kenneth-score-2' details to the CRI stub
+    And I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get an OAuth response with error code 'session_invalidated'

--- a/api-tests/features/account-intervention/p2-reprove-identity.feature
+++ b/api-tests/features/account-intervention/p2-reprove-identity.feature
@@ -23,7 +23,9 @@ Feature: Reprove Identity Journey
         Then I get an 'address' CRI response
         When I submit 'kenneth-current' details to the CRI stub
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-score-2' details to the CRI stub
+        When I submit 'kenneth-score-2' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":1} |
         Then I get a 'page-ipv-success' page response
         When I submit a 'next' event
         Then I get an OAuth response
@@ -50,7 +52,9 @@ Feature: Reprove Identity Journey
         Then I get an 'address' CRI response
         When I submit 'kenneth-current' details to the CRI stub
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-score-2' details to the CRI stub
+        When I submit 'kenneth-score-2' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":2} |
         Then I get a 'f2f' CRI response
         When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
             | Attribute          | Values                                          |
@@ -77,7 +81,9 @@ Feature: Reprove Identity Journey
         Then I get an 'address' CRI response
         When I submit 'kenneth-current' details to the CRI stub
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-score-2' details to the CRI stub
+        When I submit 'kenneth-score-2' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":2} |
         Then I get a 'f2f' CRI response
         When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
             | Attribute          | Values                                          |
@@ -114,7 +120,9 @@ Feature: Reprove Identity Journey
         When I submit 'kenneth-current' details to the CRI stub
         Then I get a 'fraud' CRI response
         When The AIS stub will return an 'AIS_NO_INTERVENTION' result
-        And I submit 'kenneth-score-2' details to the CRI stub
+        And I submit 'kenneth-score-2' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":1} |
         Then I get a 'page-ipv-success' page response
         When I submit a 'next' event
         Then I get an OAuth response
@@ -143,7 +151,9 @@ Feature: Reprove Identity Journey
         Then I get an 'address' CRI response
         When I submit 'kenneth-current' details to the CRI stub
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-score-2' details to the CRI stub
+        When I submit 'kenneth-score-2' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":2} |
         Then I get a 'f2f' CRI response
         When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
             | Attribute          | Values                                          |
@@ -171,7 +181,9 @@ Feature: Reprove Identity Journey
         Then I get an 'address' CRI response
         When I submit 'kenneth-current' details to the CRI stub
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-score-2' details to the CRI stub
+        When I submit 'kenneth-score-2' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":2} |
         Then I get a 'f2f' CRI response
         When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
             | Attribute          | Values                                          |
@@ -208,7 +220,9 @@ Feature: Reprove Identity Journey
             Then I get an 'address' CRI response
             When I submit 'kenneth-current' details to the CRI stub
             Then I get a 'fraud' CRI response
-            When I submit 'kenneth-score-2' details to the CRI stub
+            When I submit 'kenneth-score-2' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get a 'f2f' CRI response
             When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
                 | Attribute          | Values                                          |
@@ -227,7 +241,9 @@ Feature: Reprove Identity Journey
             Then I get an 'address' CRI response
             When I submit 'lora-current' details to the CRI stub
             Then I get a 'fraud' CRI response
-            When I submit 'lora-score-2' details to the CRI stub
+            When I submit 'lora-score-2' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get a 'pyi-no-match' page response
             When I submit a 'next' event
             Then I get an OAuth response
@@ -259,7 +275,9 @@ Feature: Reprove Identity Journey
             Then I get an 'address' CRI response
             When I submit 'kenneth-current' details to the CRI stub
             Then I get a 'fraud' CRI response
-            When I submit 'kenneth-score-2' details to the CRI stub
+            When I submit 'kenneth-score-2' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get a 'f2f' CRI response
             When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
                 | Attribute          | Values                                          |
@@ -279,7 +297,9 @@ Feature: Reprove Identity Journey
             Then I get an 'address' CRI response
             When I submit 'lora-current' details to the CRI stub
             Then I get a 'fraud' CRI response
-            When I submit 'lora-score-2' details to the CRI stub
+            When I submit 'lora-score-2' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get a 'pyi-no-match' page response
             When I submit a 'next' event
             Then I get an OAuth response

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -16,7 +16,9 @@ Feature: Audit Events
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -51,7 +53,9 @@ Feature: Audit Events
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
       | Attribute          | Values                                      |
@@ -84,7 +88,9 @@ Feature: Audit Events
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
       | Attribute          | Values                                      |
@@ -139,7 +145,9 @@ Feature: Audit Events
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -169,7 +177,9 @@ Feature: Audit Events
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -223,7 +233,9 @@ Feature: Audit Events
             | Attribute | Values               |
             | context   | "international_user" |
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+    When I submit 'kenneth-changed-family-name-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response with context 'updateIdentity'
     When I submit a 'next' event
     Then I get an OAuth response
@@ -291,7 +303,9 @@ Feature: Audit Events
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -334,7 +348,9 @@ Feature: Audit Events
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response

--- a/api-tests/features/cimit/p1-alternate-doc.feature
+++ b/api-tests/features/cimit/p1-alternate-doc.feature
@@ -23,7 +23,9 @@ Feature: P1 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -60,7 +62,9 @@ Feature: P1 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -90,7 +94,9 @@ Feature: P1 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -122,7 +128,9 @@ Feature: P1 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -162,7 +170,9 @@ Feature: P1 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'end' event
       Then I get a 'page-pre-experian-kbv-transition' page response
@@ -194,7 +204,9 @@ Feature: P1 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -225,7 +237,9 @@ Feature: P1 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -294,7 +308,9 @@ Feature: P1 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'lora-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'lora-score-2' details to the CRI stub
+      When I submit 'lora-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response

--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
@@ -14,7 +14,9 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -75,7 +77,9 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -93,7 +97,9 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-f2f.feature
@@ -14,7 +14,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -108,7 +110,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I submit '<document-details>' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
         | Attribute          | Values                                      |
@@ -137,7 +141,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I call the CRI stub with attributes and get a 'temporarily_unavailable' OAuth error
         | Attribute          | Values                                      |
@@ -154,7 +160,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I get an error from the async CRI stub
       Then I get a 'page-face-to-face-handoff' page response
@@ -179,7 +187,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
         | Attribute          | Values                                      |
@@ -206,7 +216,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
         | Attribute          | Values                                      |

--- a/api-tests/features/cimit/p2-alternate-doc.feature
+++ b/api-tests/features/cimit/p2-alternate-doc.feature
@@ -25,7 +25,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -62,7 +64,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -92,7 +96,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -132,7 +138,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -180,7 +188,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'end' event
       Then I get a 'page-pre-experian-kbv-transition' page response
@@ -220,7 +230,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -251,7 +263,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -320,7 +334,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get an 'address' CRI response
       When I submit 'lora-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'lora-score-2' details to the CRI stub
+      When I submit 'lora-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
@@ -17,7 +17,9 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -78,7 +80,9 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -100,7 +104,9 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
@@ -16,7 +16,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -110,7 +112,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I submit '<document-details>' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
         | Attribute          | Values                                      |
@@ -139,7 +143,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I call the CRI stub with attributes and get a 'temporarily_unavailable' OAuth error
         | Attribute          | Values                                      |
@@ -156,7 +162,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I get an error from the async CRI stub
       Then I get a 'page-face-to-face-handoff' page response
@@ -181,7 +189,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
         | Attribute          | Values                                      |
@@ -208,7 +218,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
         | Attribute          | Values                                      |

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -35,7 +35,9 @@ Feature: Disabled CRI journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -73,7 +75,9 @@ Feature: Disabled CRI journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -183,7 +187,9 @@ Feature: Disabled CRI journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -219,9 +225,7 @@ Feature: Disabled CRI journeys
       Then I get a 'pyi-escape' page response
 
   Rule: DWP KBVs are disabled or unsuitable
-
-    Scenario: Experian KBV is offered first
-      Given I activate the 'dwpKbvDisabled' feature sets
+    Background: User starts a web journey to KBV
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
@@ -236,26 +240,19 @@ Feature: Disabled CRI journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+
+    Scenario: Experian KBV is offered first
+      Given I activate the 'dwpKbvDisabled' feature sets
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
 
     Scenario: Experian KBV is offered if DWP KBV unsuitable
       Given I activate the 'dwpKbvTest' feature set
-      When I start a new 'medium-confidence' journey
-      Then I get a 'live-in-uk' page response
-      When I submit a 'uk' event
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'appTriage' event
-      Then I get a 'dcmaw' CRI response
-      When I submit an 'access-denied' event
-      Then I get a 'page-multiple-doc-check' page response
-      When I submit a 'ukPassport' event
-      Then I get a 'ukPassport' CRI response
-      When I submit 'kenneth-passport-valid' details to the CRI stub
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit an 'end' event
       Then I get a 'page-pre-experian-kbv-transition' page response

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -108,7 +108,9 @@ Feature: Authoritative source checks with driving licence CRI
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -145,7 +147,9 @@ Feature: Authoritative source checks with driving licence CRI
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -182,7 +186,9 @@ Feature: Authoritative source checks with driving licence CRI
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -211,7 +217,9 @@ Feature: Authoritative source checks with driving licence CRI
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response

--- a/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
@@ -64,7 +64,9 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -93,7 +95,9 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -122,7 +126,9 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
       | Attribute          | Values                     |
@@ -159,7 +165,9 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
       | Attribute          | Values                                      |
@@ -240,7 +248,9 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
+      When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -269,7 +279,9 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
         | Attribute | Values               |
         | context   | "international_user" |
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-family-name-and-address-score-2' details to the CRI stub
+      When I submit 'kenneth-changed-family-name-and-address-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -353,7 +365,9 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response

--- a/api-tests/features/inherited-identity/extended-scenarios.feature
+++ b/api-tests/features/inherited-identity/extended-scenarios.feature
@@ -18,7 +18,9 @@ Feature: Inherited identity extended scenarios
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -40,7 +42,9 @@ Feature: Inherited identity extended scenarios
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
       | Attribute          | Values                                          |
@@ -89,7 +93,9 @@ Feature: Inherited identity extended scenarios
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-passport-breaching' details with attributes to the CRI stub
       | Attribute          | Values                                          |
@@ -117,7 +123,9 @@ Feature: Inherited identity extended scenarios
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I get an error from the async CRI stub
     Then I get a 'page-face-to-face-handoff' page response
@@ -153,7 +161,9 @@ Feature: Inherited identity extended scenarios
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -186,7 +196,9 @@ Feature: Inherited identity extended scenarios
             | Attribute | Values               |
             | context   | "international_user" |
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response with context 'updateIdentity'
     When I submit a 'next' event
     Then I get an OAuth response
@@ -218,7 +230,9 @@ Feature: Inherited identity extended scenarios
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response

--- a/api-tests/features/inherited-identity/inherited-identity.feature
+++ b/api-tests/features/inherited-identity/inherited-identity.feature
@@ -57,7 +57,9 @@ Feature: Inherited Identity
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -120,7 +122,9 @@ Feature: Inherited Identity
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/m1c-journeys.feature
+++ b/api-tests/features/m1c-journeys.feature
@@ -19,7 +19,9 @@ Feature: M1C Unavailable Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -33,7 +35,9 @@ Feature: M1C Unavailable Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -49,7 +53,9 @@ Feature: M1C Unavailable Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'pyi-no-match' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -70,7 +76,9 @@ Feature: M1C Unavailable Journeys
       # Repeat fraud check with no update
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit <fraudResponse> details to the CRI stub
+      When I submit <fraudResponse> details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -91,7 +99,9 @@ Feature: M1C Unavailable Journeys
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit <fraudResponse> details to the CRI stub
+      When I submit <fraudResponse> details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -108,7 +118,9 @@ Feature: M1C Unavailable Journeys
       Then I get a 'address' CRI response
       When I submit 'kenneth-changed' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit <fraudResponse> details to the CRI stub
+      When I submit <fraudResponse> details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -132,7 +144,9 @@ Feature: M1C Unavailable Journeys
       Then I get a 'address' CRI response
       When I submit 'kenneth-changed' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit <fraudResponse> details to the CRI stub
+      When I submit <fraudResponse> details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -157,7 +171,9 @@ Feature: M1C Unavailable Journeys
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+      When I submit 'kenneth-changed-family-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -185,7 +201,9 @@ Feature: M1C Unavailable Journeys
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-family-name-unavailable' details to the CRI stub
+      When I submit 'kenneth-changed-family-name-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -205,7 +223,9 @@ Feature: M1C Unavailable Journeys
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-family-name-unavailable' details to the CRI stub
+      When I submit 'kenneth-changed-family-name-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityValid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response

--- a/api-tests/features/p1-app-journey.feature
+++ b/api-tests/features/p1-app-journey.feature
@@ -19,7 +19,9 @@ Feature: P1 app journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/p1-f2f-journey.feature
+++ b/api-tests/features/p1-f2f-journey.feature
@@ -19,7 +19,9 @@ Feature: P1 F2F journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
       | Attribute          | Values                                      |
@@ -42,7 +44,9 @@ Feature: P1 F2F journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1-history-0' details to the CRI stub
+    When I submit 'kenneth-score-1-history-0' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-passport-valid' details with attributes to the CRI stub
       | Attribute          | Values                                      |
@@ -64,7 +68,9 @@ Feature: P1 F2F journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-1' details to the CRI stub
+      When I submit 'kenneth-score-1' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
 
     Scenario: P1 F2F Journey - pending

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -19,7 +19,9 @@ Feature: P1 No Photo Id Journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -52,7 +54,9 @@ Feature: P1 No Photo Id Journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -100,7 +104,9 @@ Feature: P1 No Photo Id Journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -139,7 +145,9 @@ Feature: P1 No Photo Id Journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -172,7 +180,9 @@ Feature: P1 No Photo Id Journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -211,7 +221,9 @@ Feature: P1 No Photo Id Journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'end' event
     Then I get a 'page-pre-experian-kbv-transition' page response
@@ -244,7 +256,9 @@ Feature: P1 No Photo Id Journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -292,7 +306,9 @@ Feature: P1 No Photo Id Journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1-history-0' details to the CRI stub
+    When I submit 'kenneth-score-1-history-0' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response

--- a/api-tests/features/p1-web-journey.feature
+++ b/api-tests/features/p1-web-journey.feature
@@ -16,7 +16,9 @@ Feature: P1 Web Journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -44,7 +46,9 @@ Feature: P1 Web Journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
         | Attribute          | Values                                      |
@@ -65,7 +69,9 @@ Feature: P1 Web Journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -98,7 +104,9 @@ Feature: P1 Web Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-1' details to the CRI stub
+      When I submit 'kenneth-score-1' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -118,7 +126,9 @@ Feature: P1 Web Journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -139,7 +149,9 @@ Feature: P1 Web Journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -162,7 +174,9 @@ Feature: P1 Web Journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -191,7 +205,9 @@ Feature: P1 Web Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-1' details to the CRI stub
+      When I submit 'kenneth-score-1' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -218,7 +234,9 @@ Feature: P1 Web Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-1' details to the CRI stub
+      When I submit 'kenneth-score-1' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -253,7 +271,9 @@ Feature: P1 Web Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-1' details to the CRI stub
+      When I submit 'kenneth-score-1' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -17,7 +17,9 @@ Feature: P2 App journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -25,9 +27,10 @@ Feature: P2 App journey
     Then I get a 'P2' identity
 
     Examples:
-      | doc      | details                      |
-      | passport | kenneth-passport-valid       |
-      | BRC      | kenneth-brc-valid            |
+      | doc             | details                       |
+      | passport        | kenneth-passport-valid        |
+      | BRC             | kenneth-brc-valid             |
+      | BRP             | kenneth-brp-valid             |
 
   Scenario: Successful P2 identity via DCMAW using kenneth-driving-permit-valid
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -40,7 +43,9 @@ Feature: P2 App journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -14,7 +14,9 @@ Feature: P2 F2F journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
         | Attribute          | Values                                      |
@@ -69,7 +71,9 @@ Feature: P2 F2F journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit '<details>' details with attributes to the async CRI stub
         | Attribute          | Values                                      |
@@ -107,8 +111,9 @@ Feature: P2 F2F journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
-      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       When I submit '<details>' details with attributes to the async CRI stub
         | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
@@ -140,7 +145,9 @@ Feature: P2 F2F journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
 
     Scenario: Oauth access_denied error F2F
@@ -196,7 +203,9 @@ Feature: P2 F2F journey
       Then I get a 'fraud' CRI response
 
     Scenario: requested strength score three for fraud score 2
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the CRI stub
         | Attribute          | Values                                          |
@@ -204,7 +213,9 @@ Feature: P2 F2F journey
       Then I get a 'page-face-to-face-handoff' page response
 
     Scenario: requested strength score four for fraud score 1
-      When I submit 'kenneth-score-1' details to the CRI stub
+      When I submit 'kenneth-score-1' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the CRI stub
         | Attribute          | Values                                          |
@@ -212,7 +223,9 @@ Feature: P2 F2F journey
       Then I get a 'page-face-to-face-handoff' page response
 
     Scenario: requested strength score four fraud score 1 and history 0
-      When I submit 'kenneth-score-1-history-0' details to the CRI stub
+      When I submit 'kenneth-score-1-history-0' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the CRI stub
         | Attribute          | Values                                          |
@@ -220,7 +233,9 @@ Feature: P2 F2F journey
       Then I get a 'page-face-to-face-handoff' page response
 
     Scenario: requested strength score four for fraud score 2 and history 0
-      When I submit 'kenneth-score-2-history-0' details to the CRI stub
+      When I submit 'kenneth-score-2-history-0' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the CRI stub
         | Attribute          | Values                                          |
@@ -241,7 +256,9 @@ Feature: P2 F2F journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-verification-1' details with attributes to the async CRI stub
         | Attribute          | Values                                      |

--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -49,7 +49,9 @@ Feature: P2 International Address
       | Attribute | Values               |
       | context   | "international_user" |
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-no-applicable' details to the CRI stub
+    When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -27,7 +27,9 @@ Feature: P2 no photo id journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -93,7 +95,9 @@ Feature: P2 no photo id journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -115,7 +119,9 @@ Feature: P2 no photo id journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -137,7 +143,9 @@ Feature: P2 no photo id journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -203,7 +211,9 @@ Feature: P2 no photo id journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
 
     Scenario: P2 no photo id journey - Abandon - Return to RP
@@ -261,7 +271,9 @@ Feature: P2 no photo id journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -309,7 +321,9 @@ Feature: P2 no photo id journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response

--- a/api-tests/features/p2-reuse-journey.feature
+++ b/api-tests/features/p2-reuse-journey.feature
@@ -21,7 +21,9 @@ Feature: P2 Reuse journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -19,7 +19,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -47,7 +49,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
         | Attribute          | Values                                      |
@@ -68,7 +72,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -94,7 +100,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -122,7 +130,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'end' event
     Then I get a 'page-pre-experian-kbv-transition' page response
@@ -150,7 +160,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -173,7 +185,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -200,7 +214,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -236,7 +252,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -270,7 +288,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'personal-independence-payment' page response
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
@@ -301,7 +321,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -342,7 +364,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
       | Attribute          | Values                                          |
@@ -363,7 +387,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-0-breaching' details to the CRI stub
+    When I submit 'kenneth-score-0-breaching' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'pyi-no-match' page response
 
     Examples:
@@ -378,7 +404,9 @@ Feature: P2 Web document journey
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'pyi-no-match' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -393,7 +421,9 @@ Feature: P2 Web document journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -38,7 +38,9 @@ Feature: Repeat fraud check failures
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-no-applicable' details to the CRI stub
+      When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
@@ -54,7 +56,9 @@ Feature: Repeat fraud check failures
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
@@ -92,7 +96,9 @@ Feature: Repeat fraud check failures
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
+      When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
@@ -110,7 +116,9 @@ Feature: Repeat fraud check failures
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-breaching-ci' details to the CRI stub
+      When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
@@ -124,7 +132,9 @@ Feature: Repeat fraud check failures
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'alice-score-2' details to the CRI stub
+      When I submit 'alice-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response
@@ -140,7 +150,9 @@ Feature: Repeat fraud check failures
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
+      When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'pyi-no-match' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -159,7 +171,9 @@ Feature: Repeat fraud check failures
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I call the CRI stub and get an 'access_denied' OAuth error
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
       When I submit a 'returnToRp' event
       Then I get an OAuth response

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
@@ -29,7 +29,9 @@ Feature: Repeat fraud check journeys
       # Repeat fraud check with no update
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit expired 'kenneth-score-2' details to the CRI stub
+      When I submit expired 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -46,7 +48,9 @@ Feature: Repeat fraud check journeys
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
+      When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -76,7 +80,9 @@ Feature: Repeat fraud check journeys
         | Attribute | Values               |
         | context   | "international_user" |
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -103,7 +109,9 @@ Feature: Repeat fraud check journeys
             | Attribute | Values               |
             | context   | "international_user" |
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+      When I submit 'kenneth-changed-family-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -118,12 +126,18 @@ Feature: Repeat fraud check journeys
       Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
       When I submit a 'update-name' event
       Then I get a 'dcmaw' CRI response
-      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'drivingLicence' CRI response
-      When I submit 'kenneth-changed-given-name-driving-permit-valid' details with attributes to the CRI stub
-        | Attribute | Values          |
-        | context   | "check_details" |
+      When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response with context 'coiAddress'
+      When I submit a 'next' event
+      Then I get a 'address' CRI response
+      When I submit 'kenneth-changed' details with attributes to the CRI stub
+        | Attribute | Values               |
+        | context   | "international_user" |
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response with context 'updateIdentity'
 
     Scenario: Unsupported Changes
       # Repeat fraud check with various unsupported events and back navigation
@@ -182,7 +196,9 @@ Feature: Repeat fraud check journeys
       # Repeat fraud check with no update
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-no-applicable' details to the CRI stub
+      When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -199,7 +215,9 @@ Feature: Repeat fraud check journeys
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-no-applicable' details to the CRI stub
+      When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -214,7 +232,9 @@ Feature: Repeat fraud check journeys
         | Attribute | Values               |
         | context   | "international_user" |
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-no-applicable' details to the CRI stub
+      When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -235,7 +255,9 @@ Feature: Repeat fraud check journeys
             | Attribute | Values               |
             | context   | "international_user" |
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-no-applicable' details to the CRI stub
+      When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -258,7 +280,9 @@ Feature: Repeat fraud check journeys
       # Repeat fraud check with no update
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -275,7 +299,9 @@ Feature: Repeat fraud check journeys
       Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
       When I submit a 'next' event
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -288,7 +314,9 @@ Feature: Repeat fraud check journeys
       Then I get a 'address' CRI response
       When I submit 'kenneth-changed' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response
@@ -307,7 +335,9 @@ Feature: Repeat fraud check journeys
       Then I get a 'address' CRI response
       When I submit 'kenneth-changed' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -16,7 +16,9 @@ Feature: Return exit codes
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -56,7 +58,9 @@ Feature: Return exit codes
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -114,7 +118,9 @@ Feature: Return exit codes
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2-always-required' details to the CRI stub
+    When I submit 'kenneth-score-2-always-required' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -137,7 +143,9 @@ Feature: Return exit codes
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2-non-breaching' details to the CRI stub
+    When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -168,7 +176,9 @@ Feature: Return exit codes
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-0-breaching' details to the CRI stub
+    When I submit 'kenneth-score-0-breaching' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'pyi-no-match' page response
     When I submit an 'next' event
     Then I get an OAuth response
@@ -189,7 +199,9 @@ Feature: Return exit codes
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-0-breaching' details to the CRI stub
+    When I submit 'kenneth-score-0-breaching' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'pyi-no-match' page response
     When I submit an 'next' event
     Then I get an OAuth response

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -68,7 +68,9 @@ Feature: Identity reuse update details failures
             Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
-            When I submit 'kenneth-changed-given-name-score-0' details to the CRI stub
+            When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityValid'
             When I submit a 'returnToRp' event
             Then I get an OAuth response
@@ -86,7 +88,9 @@ Feature: Identity reuse update details failures
             Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
-            When I submit 'kenneth-breaching-ci' details to the CRI stub
+            When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
             When I submit a 'returnToRp' event
             Then I get an OAuth response
@@ -102,7 +106,9 @@ Feature: Identity reuse update details failures
             Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
-            When I submit 'kenneth-changed-given-name-score-2' details to the CRI stub
+            When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":1} |
             Then I get a 'pyi-no-match' page response
             When I submit a 'next' event
             Then I get an OAuth response
@@ -117,7 +123,9 @@ Feature: Identity reuse update details failures
             Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
-            When I submit 'alice-score-2' details to the CRI stub
+            When I submit 'alice-score-2' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":1} |
             Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityValid'
             When I submit an 'returnToRp' event
             Then I get an OAuth response
@@ -135,7 +143,9 @@ Feature: Identity reuse update details failures
             Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
-            When I call the CRI stub and get an 'access_denied' OAuth error
+            When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get an 'sorry-could-not-confirm-details' page response with context 'existingIdentityValid'
             When I submit a 'returnToRp' event
             Then I get an OAuth response

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
@@ -20,7 +20,9 @@ Feature: International identity reuse update details
             | Attribute | Values               |
             | context   | "international_user" |
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-no-applicable' details to the CRI stub
+        When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":1} |
         Then I get a 'page-ipv-success' page response with context 'updateIdentity'
         When I submit a 'next' event
         Then I get an OAuth response
@@ -41,7 +43,9 @@ Feature: International identity reuse update details
             | Attribute | Values               |
             | context   | "international_user" |
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-changed-family-name-and-address-no-applicable' details to the CRI stub
+        When I submit 'kenneth-changed-family-name-and-address-no-applicable' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":1} |
         Then I get a 'page-ipv-success' page response with context 'updateIdentity'
         When I submit a 'next' event
         Then I get an OAuth response
@@ -63,7 +67,9 @@ Feature: International identity reuse update details
             | Attribute | Values               |
             | context   | "international_user" |
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-changed-given-name-and-address-no-applicable' details to the CRI stub
+        When I submit 'kenneth-changed-given-name-and-address-no-applicable' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":1} |
         Then I get a 'page-ipv-success' page response with context 'updateIdentity'
         When I submit a 'next' event
         Then I get an OAuth response

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details.feature
@@ -2,10 +2,10 @@
 Feature: Identity reuse update details
     Background:
         Given the subject already has the following credentials
-            | CRI     | scenario                     |
-            | dcmaw   | kenneth-driving-permit-valid |
-            | address | kenneth-current              |
-            | fraud   | kenneth-score-2              |
+            | CRI     | scenario               |
+            | dcmaw   | kenneth-passport-valid |
+            | address | kenneth-current        |
+            | fraud   | kenneth-score-2        |
         And I activate the 'disableStrategicApp' feature set
         When I start a new 'medium-confidence' journey
         Then I get a 'page-ipv-reuse' page response
@@ -25,7 +25,9 @@ Feature: Identity reuse update details
         Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
         When I submit a 'next' event
         Then I get a 'fraud' CRI response
-        When I submit '<fraud-details>' details to the CRI stub
+        When I submit '<fraud-details>' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":2} |
         Then I get a 'page-ipv-success' page response with context 'updateIdentity'
         When I submit a 'next' event
         Then I get an OAuth response
@@ -46,7 +48,9 @@ Feature: Identity reuse update details
             | Attribute | Values               |
             | context   | "international_user" |
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-score-2' details to the CRI stub
+        When I submit 'kenneth-score-2' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":1} |
         Then I get a 'page-ipv-success' page response with context 'updateIdentity'
         When I submit a 'next' event
         Then I get an OAuth response
@@ -71,7 +75,9 @@ Feature: Identity reuse update details
             | Attribute | Values               |
             | context   | "international_user" |
         Then I get a 'fraud' CRI response
-        When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+        When I submit 'kenneth-changed-family-name-score-2' details with attributes to the CRI stub
+            | Attribute          | Values                   |
+            | evidence_requested | {"identityFraudScore":2} |
         Then I get a 'page-ipv-success' page response with context 'updateIdentity'
         When I submit a 'next' event
         Then I get an OAuth response

--- a/api-tests/features/stored-identity/cimit-journeys.feature
+++ b/api-tests/features/stored-identity/cimit-journeys.feature
@@ -23,7 +23,9 @@ Feature: Stored Identity Service - CIMIT journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -62,7 +64,9 @@ Feature: Stored Identity Service - CIMIT journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -103,7 +107,9 @@ Feature: Stored Identity Service - CIMIT journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -142,7 +148,9 @@ Feature: Stored Identity Service - CIMIT journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -175,7 +183,9 @@ Feature: Stored Identity Service - CIMIT journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -210,7 +220,9 @@ Feature: Stored Identity Service - CIMIT journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
         | Attribute          | Values                                      |

--- a/api-tests/features/stored-identity/inherited-identities.feature
+++ b/api-tests/features/stored-identity/inherited-identities.feature
@@ -63,7 +63,9 @@ Feature: Inherited Identity journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/stored-identity/m1c-journeys.feature
+++ b/api-tests/features/stored-identity/m1c-journeys.feature
@@ -19,7 +19,9 @@ Feature: Stored Identity - M1C Outcomes
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -34,7 +36,9 @@ Feature: Stored Identity - M1C Outcomes
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -51,7 +55,9 @@ Feature: Stored Identity - M1C Outcomes
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'pyi-no-match' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -77,7 +83,9 @@ Feature: Stored Identity - M1C Outcomes
         | Attribute | Values               |
         | context   | "international_user" |
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-unavailable' details to the CRI stub
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -106,7 +114,9 @@ Feature: Stored Identity - M1C Outcomes
       Then I get a 'address' CRI response
       When I submit 'kenneth-changed' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit '<fraud-details>' details to the CRI stub
+      When I submit '<fraud-details>' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response with context 'updateIdentity'
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/stored-identity/p1-journeys.feature
+++ b/api-tests/features/stored-identity/p1-journeys.feature
@@ -18,7 +18,9 @@ Feature: Stored Identity - P1 journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -35,7 +37,9 @@ Feature: Stored Identity - P1 journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -54,7 +58,9 @@ Feature: Stored Identity - P1 journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -83,7 +89,9 @@ Feature: Stored Identity - P1 journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -108,7 +116,9 @@ Feature: Stored Identity - P1 journeys
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-1' details to the CRI stub
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'f2f' CRI response
     When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
       | Attribute          | Values                                      |

--- a/api-tests/features/stored-identity/p1-repeat-fraud-check.feature
+++ b/api-tests/features/stored-identity/p1-repeat-fraud-check.feature
@@ -15,7 +15,9 @@ Feature: Stored Identity - repeat fraud check
   Scenario: Fraud 6 Months Expiry + No Update
     When I submit a 'next' event
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response with context 'repeatFraudCheck'
     When I submit a 'next' event
     Then I get an OAuth response
@@ -40,7 +42,9 @@ Feature: Stored Identity - repeat fraud check
       | Attribute | Values               |
       | context   | "international_user" |
     Then I get a 'fraud' CRI response
-    When I submit '<fraud-details>' details to the CRI stub
+    When I submit '<fraud-details>' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response with context 'updateIdentity'
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/stored-identity/p1-reuse-existing-identity.feature
+++ b/api-tests/features/stored-identity/p1-reuse-existing-identity.feature
@@ -17,7 +17,9 @@ Feature: Stored Identity - Update Existing Identity
     Then I get a 'address' CRI response
     When I submit 'kenneth-changed' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response with context 'updateIdentity'
     When I submit a 'next' event
     Then I get an OAuth response
@@ -38,7 +40,9 @@ Feature: Stored Identity - Update Existing Identity
     Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
     When I submit a 'next' event
     Then I get a 'fraud' CRI response
-    When I submit '<fraud-details>' details to the CRI stub
+    When I submit '<fraud-details>' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response with context 'updateIdentity'
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -18,7 +18,9 @@ Feature: Stored Identity - P2 journeys
       | Attribute | Values               |
       | context   | "international_user" |
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-no-applicable' details to the CRI stub
+    When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -42,7 +44,9 @@ Feature: Stored Identity - P2 journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response
@@ -65,7 +69,9 @@ Feature: Stored Identity - P2 journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
         | Attribute          | Values                                      |
@@ -100,7 +106,9 @@ Feature: Stored Identity - P2 journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response

--- a/api-tests/features/stored-identity/reprove-identity-journeys.feature
+++ b/api-tests/features/stored-identity/reprove-identity-journeys.feature
@@ -26,7 +26,9 @@ Feature: Reprove Identity Journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -43,7 +45,9 @@ Feature: Reprove Identity Journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
         | Attribute          | Values                                      |
@@ -79,7 +83,9 @@ Feature: Reprove Identity Journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -98,7 +104,9 @@ Feature: Reprove Identity Journey
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
         | Attribute          | Values                                      |

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -21,7 +21,9 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -228,7 +230,9 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
@@ -30,7 +30,9 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/strategic-app/p1-strategic-app.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app.feature
@@ -27,7 +27,9 @@ Feature: M2B Strategic App Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -54,7 +56,9 @@ Feature: M2B Strategic App Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -23,7 +23,9 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-pre-experian-kbv-transition' page response
     When I submit a 'next' event
     Then I get a 'kbv' CRI response
@@ -230,7 +232,9 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
@@ -33,7 +33,9 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -180,7 +182,9 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
         | Attribute | Values               |
         | context   | "international_user" |
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-no-applicable' details to the CRI stub
+      When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'pyi-no-match' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -29,7 +29,9 @@ Feature: M2B Strategic App Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -74,7 +76,9 @@ Feature: M2B Strategic App Journeys
         | Attribute | Values               |
         | context   | "international_user" |
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -177,7 +181,9 @@ Feature: M2B Strategic App Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -200,7 +206,9 @@ Feature: M2B Strategic App Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -288,7 +296,9 @@ Feature: M2B Strategic App Journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/strategic-app/strategic-app-dl-auth-source-check-reuse-update-details.feature
+++ b/api-tests/features/strategic-app/strategic-app-dl-auth-source-check-reuse-update-details.feature
@@ -38,7 +38,9 @@ Feature: Identity reuse update details with Strategic App
             Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
             When I submit a 'next' event
             Then I get a 'fraud' CRI response
-            When I submit '<fraud-details>' details to the CRI stub
+            When I submit '<fraud-details>' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get a 'page-ipv-success' page response with context 'updateIdentity'
             When I submit a 'next' event
             Then I get an OAuth response
@@ -79,7 +81,9 @@ Feature: Identity reuse update details with Strategic App
             Then I get a 'address' CRI response
             When I submit 'kenneth-changed' details to the CRI stub
             Then I get a 'fraud' CRI response
-            When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+            When I submit 'kenneth-changed-family-name-score-2' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get a 'page-ipv-success' page response with context 'updateIdentity'
             When I submit a 'next' event
             Then I get an OAuth response
@@ -115,7 +119,9 @@ Feature: Identity reuse update details with Strategic App
             Then I get a 'address' CRI response
             When I submit 'kenneth-changed' details to the CRI stub
             Then I get a 'fraud' CRI response
-            When I submit 'kenneth-changed-family-name-score-2' details to the CRI stub
+            When I submit 'kenneth-changed-family-name-score-2' details with attributes to the CRI stub
+                | Attribute          | Values                   |
+                | evidence_requested | {"identityFraudScore":2} |
             Then I get a 'page-ipv-success' page response with context 'updateIdentity'
             When I submit a 'next' event
             Then I get an OAuth response

--- a/api-tests/features/ticf/failed-ticf-responses.feature
+++ b/api-tests/features/ticf/failed-ticf-responses.feature
@@ -22,7 +22,9 @@ Feature: Failed TICF responses
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -53,7 +55,9 @@ Feature: Failed TICF responses
     Then I get an 'address' CRI response
     When I submit 'kenneth-current' details to the CRI stub
     Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details to the CRI stub
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -19,7 +19,9 @@ Feature: TICF failed/error journeys
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'kbv' CRI response

--- a/api-tests/features/ticf/ticf-successful-responses.feature
+++ b/api-tests/features/ticf/ticf-successful-responses.feature
@@ -23,7 +23,9 @@ Feature: TICF successful responses
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'pyi-no-match' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -48,7 +50,9 @@ Feature: TICF successful responses
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'pyi-no-match' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -98,7 +102,9 @@ Feature: TICF successful responses
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -126,7 +132,9 @@ Feature: TICF successful responses
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get an OAuth response with error code 'session_invalidated'
 
   Rule: TICF response delay less than 2s
@@ -150,7 +158,9 @@ Feature: TICF successful responses
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response
@@ -182,7 +192,9 @@ Feature: TICF successful responses
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details to the CRI stub
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -37,6 +37,7 @@ import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45ProfileEvaluator;
+import uk.gov.di.ipv.core.library.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
@@ -59,13 +60,16 @@ import java.net.URISyntaxException;
 import java.security.InvalidParameterException;
 import java.text.ParseException;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.DWP_KBV;
+import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_FRAUD;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_CONSTRUCT_REDIRECT_URI;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_EVIDENCE_REQUESTED;
@@ -362,7 +366,10 @@ public class BuildCriOauthRequestHandler
             evidenceRequest =
                     getEvidenceRequestForKbvCri(
                             VotHelper.getThresholdVot(ipvSessionItem, clientOAuthSessionItem));
+        } else if (cri.equals(EXPERIAN_FRAUD)) {
+            evidenceRequest = getEvidenceRequestForExperianFraudCri(vcs);
         }
+
         SignedJWT signedJWT =
                 AuthorizationRequestHelper.createSignedJWT(
                         sharedClaims,
@@ -416,7 +423,8 @@ public class BuildCriOauthRequestHandler
             return null;
         }
 
-        return new EvidenceRequest(SCORING_POLICY_GPG45, minViableStrengthOpt.getAsInt(), null);
+        return new EvidenceRequest(
+                SCORING_POLICY_GPG45, minViableStrengthOpt.getAsInt(), null, null);
     }
 
     private EvidenceRequest getEvidenceRequestForKbvCri(Vot targetVot) {
@@ -430,7 +438,38 @@ public class BuildCriOauthRequestHandler
                                             + targetVot);
                 };
 
-        return new EvidenceRequest(SCORING_POLICY_GPG45, null, verificationScoreRequired);
+        return new EvidenceRequest(SCORING_POLICY_GPG45, null, verificationScoreRequired, null);
+    }
+
+    private EvidenceRequest getEvidenceRequestForExperianFraudCri(
+            List<VerifiableCredential> sessionCredentials) {
+        var appVcs =
+                sessionCredentials.stream()
+                        .filter(vc -> vc.getCri().equals(DCMAW) || vc.getCri().equals(DCMAW_ASYNC))
+                        .toList();
+
+        int identityFraudScore = 2;
+        if (!appVcs.isEmpty()) {
+            var gpg45Score = gpg45ProfileEvaluator.buildScore(appVcs);
+
+            var maxStrength =
+                    gpg45Score.getEvidences().stream()
+                            .max(Comparator.comparing(Gpg45Scores.Evidence::getStrength))
+                            .map(Gpg45Scores.Evidence::getStrength)
+                            .orElse(0);
+
+            var maxValidity =
+                    gpg45Score.getEvidences().stream()
+                            .max(Comparator.comparing(Gpg45Scores.Evidence::getValidity))
+                            .map(Gpg45Scores.Evidence::getValidity)
+                            .orElse(0);
+
+            if (maxStrength >= 4 && maxValidity >= 2 && gpg45Score.getVerification() >= 3) {
+                identityFraudScore = 1;
+            }
+        }
+
+        return new EvidenceRequest(null, null, null, identityFraudScore);
     }
 
     private List<String> getAllowedSharedClaimAttrs(Cri cri) {

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -13,6 +13,7 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.net.URIBuilder;
 import org.junit.jupiter.api.AfterEach;
@@ -93,6 +94,7 @@ import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.Cri.CLAIMED_IDENTITY;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.Cri.DWP_KBV;
+import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_FRAUD;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.Cri.PASSPORT;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.CREDENTIAL_ATTRIBUTES_1;
@@ -102,6 +104,10 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JW
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PRIVATE_KEY;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.TEST_EC_PUBLIC_JWK;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawAsyncDrivingPermitDva;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawAsyncPassport;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawDrivingPermitDvaM1b;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawPassport;
 import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.generateVerifiableCredential;
 import static uk.gov.di.ipv.core.library.helpers.VerifiableCredentialGenerator.vcClaimFailedWithCis;
 
@@ -128,7 +134,7 @@ class BuildCriOauthRequestHandlerTest {
     private static final String EVIDENCE_REQUEST = "evidenceRequest";
     private static final String EVIDENCE_REQUESTED = "evidence_requested";
     private static final EvidenceRequest TEST_EVIDENCE_REQUESTED =
-            new EvidenceRequest("gpg45", 2, null);
+            new EvidenceRequest("gpg45", 2, null, null);
     private static String CRI_WITH_EVIDENCE_REQUEST;
     private static String CRI_WITH_CONTEXT_AND_EVIDENCE_REQUEST;
 
@@ -156,6 +162,7 @@ class BuildCriOauthRequestHandlerTest {
     private OauthCriConfig oauthCriConfig;
     private OauthCriConfig dcmawOauthCriConfig;
     private OauthCriConfig f2FOauthCriConfig;
+    private OauthCriConfig experianFraudCriConfig;
     private OauthCriConfig claimedIdentityOauthCriConfig;
     private ClientOAuthSessionItem clientOAuthSessionItem;
     private final IpvSessionItem ipvSessionItem = new IpvSessionItem();
@@ -223,6 +230,20 @@ class BuildCriOauthRequestHandlerTest {
                         .build();
 
         claimedIdentityOauthCriConfig =
+                OauthCriConfig.builder()
+                        .tokenUrl(new URI(CRI_TOKEN_URL))
+                        .credentialUrl(new URI(CRI_CREDENTIAL_URL))
+                        .authorizeUrl(new URI(CRI_AUTHORIZE_URL))
+                        .clientId(IPV_CLIENT_ID)
+                        .signingKey("{}")
+                        .encryptionKey(RSA_ENCRYPTION_PUBLIC_JWK)
+                        .componentId("http://www.example.com/audience")
+                        .clientCallbackUrl(URI.create("http://www.example.com/callback/criId"))
+                        .requiresApiKey(true)
+                        .requiresAdditionalEvidence(false)
+                        .build();
+
+        experianFraudCriConfig =
                 OauthCriConfig.builder()
                         .tokenUrl(new URI(CRI_TOKEN_URL))
                         .credentialUrl(new URI(CRI_CREDENTIAL_URL))
@@ -900,6 +921,84 @@ class BuildCriOauthRequestHandlerTest {
 
         JsonNode evidenceRequested = claimsSet.get(EVIDENCE_REQUESTED);
         assertEquals(2, evidenceRequested.get("strengthScore").asInt());
+        verify(mockIpvSessionService, times(1)).updateIpvSession(any());
+    }
+
+    private static Stream<Arguments> provideAppVcsForExperianFraudRequest() {
+        return Stream.of(
+                Arguments.of(List.of(vcDcmawPassport()), 1),
+                Arguments.of(List.of(vcDcmawAsyncPassport()), 1),
+                Arguments.of(List.of(vcDcmawDrivingPermitDvaM1b()), 2),
+                Arguments.of(List.of(vcDcmawAsyncDrivingPermitDva()), 2),
+                Arguments.of(List.of(), 2));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideAppVcsForExperianFraudRequest")
+    void shouldSetEvidenceRequestForFraudWithIdentityFraudScoreSetTo1IfGivenChippedDocumentVc(
+            List<VerifiableCredential> appVcs, int expectedIdentityFraudScore) throws Exception {
+        // Arrange
+        when(mockOauthKeyService.getEncryptionKey(f2FOauthCriConfig))
+                .thenReturn(RSAKey.parse(RSA_ENCRYPTION_PUBLIC_JWK));
+        when(configService.getActiveConnection(EXPERIAN_FRAUD)).thenReturn(MAIN_CONNECTION);
+        when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, EXPERIAN_FRAUD))
+                .thenReturn(experianFraudCriConfig);
+        when(configService.getLongParameter(JWT_TTL_SECONDS)).thenReturn(900L);
+        when(configService.getParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
+        when(configService.getParameter(
+                        CREDENTIAL_ISSUER_SHARED_ATTRIBUTES, EXPERIAN_FRAUD.getId()))
+                .thenReturn(null);
+        when(mockIpvSessionService.getIpvSession(SESSION_ID)).thenReturn(ipvSessionItem);
+        mockVcHelper.when(() -> VcHelper.isSuccessfulVc(any())).thenReturn(true, true);
+        when(mockSessionCredentialService.getCredentials(SESSION_ID, TEST_USER_ID))
+                .thenReturn(
+                        ListUtils.union(
+                                List.of(
+                                        generateVerifiableCredential(
+                                                TEST_USER_ID,
+                                                ADDRESS,
+                                                vcClaimFailedWithCis(CREDENTIAL_ATTRIBUTES_1),
+                                                IPV_ISSUER)),
+                                appVcs));
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        clientOAuthSessionItem.setVtr(List.of("P1"));
+        if (!appVcs.isEmpty()) {
+            when(mockGpg45ProfileEvaluator.buildScore(any())).thenCallRealMethod();
+        }
+        when(mockSignerFactory.getSigner())
+                .thenReturn(new LocalECDSASigner(getSigningPrivateKey()));
+
+        CriJourneyRequest input =
+                CriJourneyRequest.builder()
+                        .ipvSessionId(SESSION_ID)
+                        .ipAddress(TEST_IP_ADDRESS)
+                        .language(TEST_LANGUAGE)
+                        .journey(String.format(JOURNEY_BASE_URL, EXPERIAN_FRAUD.getId()))
+                        .build();
+
+        // Act
+        var responseJson = handleRequest(input, context);
+
+        // Assert
+        CriResponse response = OBJECT_MAPPER.readValue(responseJson, CriResponse.class);
+
+        URIBuilder redirectUri = new URIBuilder(response.getCri().getRedirectUrl());
+        List<NameValuePair> queryParams = redirectUri.getQueryParams();
+
+        Optional<NameValuePair> request =
+                queryParams.stream().filter(param -> param.getName().equals("request")).findFirst();
+
+        assertTrue(request.isPresent());
+        JWEObject jweObject = JWEObject.parse(request.get().getValue());
+        jweObject.decrypt(new RSADecrypter(getEncryptionPrivateKey()));
+
+        SignedJWT signedJWT = SignedJWT.parse(jweObject.getPayload().toString());
+        JsonNode claimsSet = OBJECT_MAPPER.readTree(signedJWT.getJWTClaimsSet().toString());
+
+        JsonNode evidenceRequested = claimsSet.get(EVIDENCE_REQUESTED);
+        assertEquals(
+                expectedIdentityFraudScore, evidenceRequested.get("identityFraudScore").asInt());
         verify(mockIpvSessionService, times(1)).updateIpvSession(any());
     }
 

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandlerTest.java
@@ -160,10 +160,6 @@ class BuildCriOauthRequestHandlerTest {
     @InjectMocks private BuildCriOauthRequestHandler buildCriOauthRequestHandler;
 
     private OauthCriConfig oauthCriConfig;
-    private OauthCriConfig dcmawOauthCriConfig;
-    private OauthCriConfig f2FOauthCriConfig;
-    private OauthCriConfig experianFraudCriConfig;
-    private OauthCriConfig claimedIdentityOauthCriConfig;
     private ClientOAuthSessionItem clientOAuthSessionItem;
     private final IpvSessionItem ipvSessionItem = new IpvSessionItem();
 
@@ -188,62 +184,6 @@ class BuildCriOauthRequestHandlerTest {
     @BeforeEach
     void setUp() throws URISyntaxException {
         oauthCriConfig =
-                OauthCriConfig.builder()
-                        .tokenUrl(new URI(CRI_TOKEN_URL))
-                        .credentialUrl(new URI(CRI_CREDENTIAL_URL))
-                        .authorizeUrl(new URI(CRI_AUTHORIZE_URL))
-                        .clientId(IPV_CLIENT_ID)
-                        .signingKey("{}")
-                        .encryptionKey(RSA_ENCRYPTION_PUBLIC_JWK)
-                        .componentId("http://www.example.com/audience")
-                        .clientCallbackUrl(URI.create("http://www.example.com/callback/criId"))
-                        .requiresApiKey(true)
-                        .requiresAdditionalEvidence(false)
-                        .build();
-
-        dcmawOauthCriConfig =
-                OauthCriConfig.builder()
-                        .tokenUrl(new URI(CRI_TOKEN_URL))
-                        .credentialUrl(new URI(CRI_CREDENTIAL_URL))
-                        .authorizeUrl(new URI(CRI_AUTHORIZE_URL))
-                        .clientId(IPV_CLIENT_ID)
-                        .signingKey("{}")
-                        .encryptionKey(RSA_ENCRYPTION_PUBLIC_JWK)
-                        .componentId("http://www.example.com/audience")
-                        .clientCallbackUrl(URI.create("http://www.example.com/callback/criId"))
-                        .requiresApiKey(true)
-                        .requiresAdditionalEvidence(false)
-                        .build();
-
-        f2FOauthCriConfig =
-                OauthCriConfig.builder()
-                        .tokenUrl(new URI(CRI_TOKEN_URL))
-                        .credentialUrl(new URI(CRI_CREDENTIAL_URL))
-                        .authorizeUrl(new URI(CRI_AUTHORIZE_URL))
-                        .clientId(IPV_CLIENT_ID)
-                        .signingKey("{}")
-                        .encryptionKey(RSA_ENCRYPTION_PUBLIC_JWK)
-                        .componentId("http://www.example.com/audience")
-                        .clientCallbackUrl(URI.create("http://www.example.com/callback/criId"))
-                        .requiresApiKey(true)
-                        .requiresAdditionalEvidence(false)
-                        .build();
-
-        claimedIdentityOauthCriConfig =
-                OauthCriConfig.builder()
-                        .tokenUrl(new URI(CRI_TOKEN_URL))
-                        .credentialUrl(new URI(CRI_CREDENTIAL_URL))
-                        .authorizeUrl(new URI(CRI_AUTHORIZE_URL))
-                        .clientId(IPV_CLIENT_ID)
-                        .signingKey("{}")
-                        .encryptionKey(RSA_ENCRYPTION_PUBLIC_JWK)
-                        .componentId("http://www.example.com/audience")
-                        .clientCallbackUrl(URI.create("http://www.example.com/callback/criId"))
-                        .requiresApiKey(true)
-                        .requiresAdditionalEvidence(false)
-                        .build();
-
-        experianFraudCriConfig =
                 OauthCriConfig.builder()
                         .tokenUrl(new URI(CRI_TOKEN_URL))
                         .credentialUrl(new URI(CRI_CREDENTIAL_URL))
@@ -677,11 +617,11 @@ class BuildCriOauthRequestHandlerTest {
     void shouldReceive200ResponseCodeAndReturnCredentialIssuerResponseWithResponseTypeParam()
             throws Exception {
         // Arrange
-        when(mockOauthKeyService.getEncryptionKey(dcmawOauthCriConfig))
+        when(mockOauthKeyService.getEncryptionKey(oauthCriConfig))
                 .thenReturn(RSAKey.parse(RSA_ENCRYPTION_PUBLIC_JWK));
         when(configService.getActiveConnection(DCMAW)).thenReturn(MAIN_CONNECTION);
         when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, DCMAW))
-                .thenReturn(dcmawOauthCriConfig);
+                .thenReturn(oauthCriConfig);
         when(configService.getParameter(CREDENTIAL_ISSUER_SHARED_ATTRIBUTES, DCMAW.getId()))
                 .thenReturn(null);
         when(configService.getLongParameter(JWT_TTL_SECONDS)).thenReturn(900L);
@@ -763,11 +703,11 @@ class BuildCriOauthRequestHandlerTest {
     void shouldReceive200ResponseCodeAndReturnCredentialIssuerResponseWithLanguageParamForDwpKbv()
             throws Exception {
         // Arrange
-        when(mockOauthKeyService.getEncryptionKey(dcmawOauthCriConfig))
+        when(mockOauthKeyService.getEncryptionKey(oauthCriConfig))
                 .thenReturn(RSAKey.parse(RSA_ENCRYPTION_PUBLIC_JWK));
         when(configService.getActiveConnection(DWP_KBV)).thenReturn(MAIN_CONNECTION);
         when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, DWP_KBV))
-                .thenReturn(dcmawOauthCriConfig);
+                .thenReturn(oauthCriConfig);
         when(configService.getParameter(CREDENTIAL_ISSUER_SHARED_ATTRIBUTES, DWP_KBV.getId()))
                 .thenReturn(null);
         when(configService.getLongParameter(JWT_TTL_SECONDS)).thenReturn(900L);
@@ -853,11 +793,11 @@ class BuildCriOauthRequestHandlerTest {
     @Test
     void shouldSetEvidenceRequestForF2FWithMinStrengthScoreForP1() throws Exception {
         // Arrange
-        when(mockOauthKeyService.getEncryptionKey(f2FOauthCriConfig))
+        when(mockOauthKeyService.getEncryptionKey(oauthCriConfig))
                 .thenReturn(RSAKey.parse(RSA_ENCRYPTION_PUBLIC_JWK));
         when(configService.getActiveConnection(F2F)).thenReturn(MAIN_CONNECTION);
         when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, F2F))
-                .thenReturn(f2FOauthCriConfig);
+                .thenReturn(oauthCriConfig);
         when(configService.getLongParameter(JWT_TTL_SECONDS)).thenReturn(900L);
         when(configService.getParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getParameter(CREDENTIAL_ISSUER_SHARED_ATTRIBUTES, F2F.getId()))
@@ -938,11 +878,11 @@ class BuildCriOauthRequestHandlerTest {
     void shouldSetEvidenceRequestForFraudWithIdentityFraudScoreSetTo1IfGivenChippedDocumentVc(
             List<VerifiableCredential> appVcs, int expectedIdentityFraudScore) throws Exception {
         // Arrange
-        when(mockOauthKeyService.getEncryptionKey(f2FOauthCriConfig))
+        when(mockOauthKeyService.getEncryptionKey(oauthCriConfig))
                 .thenReturn(RSAKey.parse(RSA_ENCRYPTION_PUBLIC_JWK));
         when(configService.getActiveConnection(EXPERIAN_FRAUD)).thenReturn(MAIN_CONNECTION);
         when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, EXPERIAN_FRAUD))
-                .thenReturn(experianFraudCriConfig);
+                .thenReturn(oauthCriConfig);
         when(configService.getLongParameter(JWT_TTL_SECONDS)).thenReturn(900L);
         when(configService.getParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getParameter(
@@ -1007,11 +947,11 @@ class BuildCriOauthRequestHandlerTest {
     void shouldIncludeGivenParametersIntoCriResponseIfInJourneyUri(
             String journeyUri, Map<String, Object> expectedClaims) throws Exception {
         // Arrange
-        when(mockOauthKeyService.getEncryptionKey(claimedIdentityOauthCriConfig))
+        when(mockOauthKeyService.getEncryptionKey(oauthCriConfig))
                 .thenReturn(RSAKey.parse(RSA_ENCRYPTION_PUBLIC_JWK));
         when(configService.getActiveConnection(CLAIMED_IDENTITY)).thenReturn(MAIN_CONNECTION);
         when(configService.getOauthCriConfigForConnection(MAIN_CONNECTION, CLAIMED_IDENTITY))
-                .thenReturn(claimedIdentityOauthCriConfig);
+                .thenReturn(oauthCriConfig);
         when(configService.getParameter(COMPONENT_ID)).thenReturn(IPV_ISSUER);
         when(configService.getParameter(
                         CREDENTIAL_ISSUER_SHARED_ATTRIBUTES, CLAIMED_IDENTITY.getId()))

--- a/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
+++ b/lambdas/build-cri-oauth-request/src/test/java/uk/gov/di/ipv/core/buildcrioauthrequest/helpers/AuthorizationRequestHelperTest.java
@@ -70,7 +70,7 @@ class AuthorizationRequestHelperTest {
     private static final String AUDIENCE = "Audience";
     private static final String TEST_CONTEXT = "test_context";
     private static final EvidenceRequest TEST_EVIDENCE_REQUEST =
-            new EvidenceRequest("gpg45", 2, null);
+            new EvidenceRequest("gpg45", 2, null, null);
     private static final Long IPV_TOKEN_TTL = 900L;
     private static final String MOCK_CORE_FRONT_CALLBACK_URL = "callbackUri";
     private static final String TEST_REDIRECT_URI = "http:example.com/callback/criId";
@@ -213,7 +213,7 @@ class AuthorizationRequestHelperTest {
                         OAUTH_STATE,
                         TEST_USER_ID,
                         TEST_JOURNEY_ID,
-                        new EvidenceRequest("gpg45", 2, null),
+                        new EvidenceRequest("gpg45", 2, null, null),
                         null);
 
         var evidenceRequested = result.getJWTClaimsSet().getClaim("evidence_requested");
@@ -238,7 +238,7 @@ class AuthorizationRequestHelperTest {
                         OAUTH_STATE,
                         TEST_USER_ID,
                         TEST_JOURNEY_ID,
-                        new EvidenceRequest(null, 2, null),
+                        new EvidenceRequest(null, 2, null, null),
                         null);
 
         var evidenceRequested = result.getJWTClaimsSet().getClaim("evidence_requested");

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/stepresponses/CriStepResponseTest.java
@@ -37,12 +37,12 @@ class CriStepResponseTest {
                 Arguments.of(
                         "aCriId",
                         null,
-                        new EvidenceRequest("gpg45", 2, null),
+                        new EvidenceRequest("gpg45", 2, null, null),
                         "/journey/cri/build-oauth-request/aCriId?evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D"),
                 Arguments.of(
                         "aCriId",
                         "test_context",
-                        new EvidenceRequest("gpg45", 2, null),
+                        new EvidenceRequest("gpg45", 2, null, null),
                         "/journey/cri/build-oauth-request/aCriId?context=test_context&evidenceRequest=eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ%3D%3D"));
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/EvidenceRequest.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/EvidenceRequest.java
@@ -25,6 +25,7 @@ public class EvidenceRequest extends BaseClaim {
     private final String scoringPolicy;
     private final Integer strengthScore;
     private final Integer verificationScore;
+    private final Integer identityFraudScore;
 
     public String toBase64() throws JsonProcessingException {
         var jsonString = objectMapper.writeValueAsString(this);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/EvidenceRequestTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/domain/EvidenceRequestTest.java
@@ -13,27 +13,34 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class EvidenceRequestTest {
     @SuppressWarnings("java:S125") // Commented out code
     // {"scoringPolicy":"gpg45","strengthScore":2}
-    private static final String BASE64_ENCODED_GPG45_STRENGTH_2_VERIFICATION_NULL =
+    private static final String BASE64_ENCODED_GPG45_STRENGTH_2 =
             // pragma: allowlist nextline secret
             "eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyfQ==";
 
     @SuppressWarnings("java:S125") // Commented out code
     // {"scoringPolicy":"gpg45","verificationScore":1}
-    private static final String BASE64_ENCODED_GPG45_STRENGTH_NULL_VERIFICATION_1 =
+    private static final String BASE64_ENCODED_GPG45_VERIFICATION_1 =
             // pragma: allowlist nextline secret
             "eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJ2ZXJpZmljYXRpb25TY29yZSI6MX0=";
 
     @SuppressWarnings("java:S125") // Commented out code
-    // {"scoringPolicy":"gpg45","strengthScore":2,"verificationScore":1}
+    // {"scoringPolicy":"gpg45","identityFraudScore":1}
+    private static final String BASE64_ENCODED_GPG45_IDENTITY_FRAUD_SCORE_1 =
+            // pragma: allowlist nextline secret
+            "eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJpZGVudGl0eUZyYXVkU2NvcmUiOjF9";
+
+    @SuppressWarnings("java:S125") // Commented out code
+    // {"scoringPolicy":"gpg45","strengthScore":2,"verificationScore":1,"identityFraudScore":1}
     private static final String BASE64_ENCODED_GPG45_STRENGTH_2_VERIFICATION_1 =
             // pragma: allowlist nextline secret
-            "eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyLCJ2ZXJpZmljYXRpb25TY29yZSI6MX0=";
+            "eyJzY29yaW5nUG9saWN5IjoiZ3BnNDUiLCJzdHJlbmd0aFNjb3JlIjoyLCJ2ZXJpZmljYXRpb25TY29yZSI6MSwiaWRlbnRpdHlGcmF1ZFNjb3JlIjoxfQ==";
 
     private static Stream<Arguments> base64EncodingsAndValues() {
         return Stream.of(
-                Arguments.of(BASE64_ENCODED_GPG45_STRENGTH_2_VERIFICATION_NULL, "gpg45", 2, null),
-                Arguments.of(BASE64_ENCODED_GPG45_STRENGTH_NULL_VERIFICATION_1, "gpg45", null, 1),
-                Arguments.of(BASE64_ENCODED_GPG45_STRENGTH_2_VERIFICATION_1, "gpg45", 2, 1));
+                Arguments.of(BASE64_ENCODED_GPG45_STRENGTH_2, "gpg45", 2, null, null),
+                Arguments.of(BASE64_ENCODED_GPG45_VERIFICATION_1, "gpg45", null, 1, null),
+                Arguments.of(BASE64_ENCODED_GPG45_IDENTITY_FRAUD_SCORE_1, "gpg45", null, null, 1),
+                Arguments.of(BASE64_ENCODED_GPG45_STRENGTH_2_VERIFICATION_1, "gpg45", 2, 1, 1));
     }
 
     @ParameterizedTest
@@ -42,10 +49,13 @@ class EvidenceRequestTest {
             String expectedResult,
             String scoringPolicy,
             Integer strengthScore,
-            Integer verificationScore)
+            Integer verificationScore,
+            Integer identityFraudScore)
             throws JsonProcessingException {
         // Arrange
-        var underTest = new EvidenceRequest(scoringPolicy, strengthScore, verificationScore);
+        var underTest =
+                new EvidenceRequest(
+                        scoringPolicy, strengthScore, verificationScore, identityFraudScore);
 
         // Act
         var result = underTest.toBase64();
@@ -71,7 +81,7 @@ class EvidenceRequestTest {
     @Test
     void toMapWithNoNulls_whenCalledWithAllNullValues_ReturnsEmptyMap() {
         // Arrange
-        var underTest = new EvidenceRequest(null, null, null);
+        var underTest = new EvidenceRequest(null, null, null, null);
 
         // Act
         var result = underTest.toMapWithNoNulls();
@@ -83,7 +93,7 @@ class EvidenceRequestTest {
     @Test
     void toMapWithNoNulls_whenCalledWithNoNullValues_ReturnsFullMap() {
         // Arrange
-        var underTest = new EvidenceRequest("policy", 1, 2);
+        var underTest = new EvidenceRequest("policy", 1, 2, 1);
 
         // Act
         var result = underTest.toMapWithNoNulls();
@@ -92,5 +102,6 @@ class EvidenceRequestTest {
         assertEquals("policy", result.get("scoringPolicy"));
         assertEquals(1, result.get("strengthScore"));
         assertEquals(2, result.get("verificationScore"));
+        assertEquals(1, result.get("identityFraudScore"));
     }
 }


### PR DESCRIPTION
## Proposed changes
### What changed

- added `identityFraudScore` to `EvidenceRequest`
- send evidence_request with identityFraudScore to Fraud CRI
  - this is set to 1 if the user has undergone a liveness/likeness check (ie via the app) and they use a chipped doc (ie strength>=4,validity>=2,verification>=3)

### Why did it change

- We want to skip the PEPS check used by Fraud CRI for stronger documents to manage the volume of users completing this check as it cannot support more than 1 transaction per second

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8421](https://govukverify.atlassian.net/browse/PYIC-8421)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated


[PYIC-8421]: https://govukverify.atlassian.net/browse/PYIC-8421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ