### PR TITLE
BAU: Fix callbackFromStrategicApp to use returned client session id

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -304,7 +304,7 @@ Feature: Audit Events
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session
-    Then I get an error response with message 'Missing ipv session id header' and status code '400'
+    Then I get an OAuth response with error code 'access_denied'
     # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
     # has managed to log back in to the site.
     When I poll for async DCMAW credential receipt

--- a/api-tests/features/strategic-app/p1-strategic-app.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app.feature
@@ -44,7 +44,7 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
-      Then I get an error response with message 'Missing ipv session id header' and status code '400'
+      Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
       When I poll for async DCMAW credential receipt

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -62,7 +62,7 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
-      Then I get an error response with message 'Missing ipv session id header' and status code '400'
+      Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
       When I poll for async DCMAW credential receipt

--- a/api-tests/src/clients/core-back-internal-client.ts
+++ b/api-tests/src/clients/core-back-internal-client.ts
@@ -93,7 +93,12 @@ export const callbackFromStrategicApp = async (
 
   const body = await response.json();
 
-  return await sendJourneyEvent(body?.journey, ipvSessionId, featureSet);
+  return await sendJourneyEvent(
+    body?.journey,
+    ipvSessionId,
+    featureSet,
+    body?.clientOAuthSessionId,
+  );
 };
 
 // Returns the response if there is a VC, or undefined if no VC is found (404). Any other response will trigger an error.

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -19,7 +19,6 @@ import { getRandomString } from "../utils/random-string-generator.js";
 import {
   isClientResponse,
   isCriResponse,
-  isErrorResponse,
   isJourneyResponse,
   isPageResponse,
   JourneyEngineResponse,
@@ -208,22 +207,6 @@ Then(
       assert.equal(this.error.statusCode, expectedStatusCode);
       assert.equal(this.error.origin, origin);
     }
-  },
-);
-
-Then(
-  /I get an error response with message '([\w,: ]+)' and status code '(\d{3})'/,
-  function (this: World, expectedMessage: string, expectedStatusCode: number) {
-    if (!this.lastJourneyEngineResponse) {
-      throw new Error("No last journey engine response found.");
-    }
-
-    assert.ok(
-      isErrorResponse(this.lastJourneyEngineResponse),
-      `got a ${describeResponse(this.lastJourneyEngineResponse)}`,
-    );
-    assert.equal(this.lastJourneyEngineResponse.statusCode, expectedStatusCode);
-    assert.equal(this.lastJourneyEngineResponse.errorMessage, expectedMessage);
   },
 );
 


### PR DESCRIPTION
## Proposed changes
### What changed

- Fix callbackFromStrategicApp to use returned client session id

### Why did it change

- API tests weren't passing clientOAuthSessionId through to the process journey event request, nor testing the result was an oauth request with access_denied message.

## Checklists

- [x] READMEs and documentation up-to-date
https://govukverify.atlassian.net/wiki/spaces/DID/pages/5448237347/How+to+go+through+a+v2+App+MAM+Journey+in+a+dev+environment

- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
