### PR TITLE
PYIC-8454: Set received this session for DCMAW Async VC

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -480,7 +480,7 @@ public class CheckExistingIdentityHandler
                 previousIpvSessionItem.getIpvSessionId());
 
         sessionCredentialsService.persistCredentials(
-                credentialBundle.credentials, auditEventUser.getSessionId(), false);
+                credentialBundle.credentials, auditEventUser.getSessionId(), true);
 
         return switch (lowestGpg45ConfidenceRequested) {
             case P1 -> JOURNEY_DCMAW_ASYNC_VC_RECEIVED_LOW;

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -686,7 +686,7 @@ class CheckExistingIdentityHandlerTest {
         // Assert
         assertEquals(expectedJourney, journeyResponse);
         verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
-        verify(mockSessionCredentialService).persistCredentials(vcs, TEST_SESSION_ID, false);
+        verify(mockSessionCredentialService).persistCredentials(vcs, TEST_SESSION_ID, true);
         verify(auditService).sendAuditEvent(auditEventArgumentCaptor.capture());
         assertEquals(
                 AuditEventTypes.IPV_APP_SESSION_RECOVERED,

--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -229,7 +229,7 @@ public class CheckMobileAppVcReceiptHandler
         }
 
         sessionCredentialsService.persistCredentials(
-                List.of(dcmawAsyncVc.get()), ipvSessionItem.getIpvSessionId(), false);
+                List.of(dcmawAsyncVc.get()), ipvSessionItem.getIpvSessionId(), true);
 
         return criCheckingService.checkVcResponse(
                 List.of(dcmawAsyncVc.get()),

--- a/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/test/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandlerTest.java
@@ -174,7 +174,7 @@ class CheckMobileAppVcReceiptHandlerTest {
         assertEquals(HttpStatusCode.OK, response.getStatusCode());
         assertEquals(new JourneyResponse(JOURNEY_NEXT_PATH), journeyResponse);
         verify(sessionCredentialsService)
-                .persistCredentials(List.of(vc), TEST_IPV_SESSION_ID, false);
+                .persistCredentials(List.of(vc), TEST_IPV_SESSION_ID, true);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes
### What changed

- Set received this session for DCMAW Async VC

### Why did it change

- So DCMAW Async VCs are sent to Fraud

### Issue tracking

- [PYIC-8454](https://govukverify.atlassian.net/browse/PYIC-8454)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8454]: https://govukverify.atlassian.net/browse/PYIC-8454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ