### PR TITLE
PYIC-8080: Clean internationalAddressEnabled feature flag.

### DIFF
--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
@@ -9,7 +9,6 @@ Feature: International identity reuse update details
         And I activate the 'disableStrategicApp' feature set
         When I start a new 'medium-confidence' journey
         Then I get a 'page-ipv-reuse' page response
-        When I activate the 'internationalAddress' feature sets
         And I submit a 'update-details' event
         Then I get a 'update-details' page response
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -54,10 +54,7 @@ states:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD_UPDATE_ADDRESS
-        checkFeatureFlag:
-          internationalAddressEnabled:
-            targetState: ADDRESS_AND_FRAUD_UPDATE_ADDRESS
-            targetEntryEvent: internationalUser
+        targetEntryEvent: internationalUser
 
   ADDRESS_AND_FRAUD_UPDATE_ADDRESS:
     nestedJourney: ADDRESS_AND_FRAUD

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -295,10 +295,7 @@ states:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD
-        checkFeatureFlag:
-          internationalAddressEnabled:
-            targetState: ADDRESS_AND_FRAUD
-            targetEntryEvent: internationalUser
+        targetEntryEvent: internationalUser
 
   ADDRESS_AND_FRAUD:
     nestedJourney: ADDRESS_AND_FRAUD

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -358,7 +358,6 @@ core:
     resetIdentity: false
     pendingF2FResetEnabled: false
     strategicAppEnabled: true
-    internationalAddressEnabled: true
     inheritedIdentity: true
     repeatFraudCheckEnabled: true
     mfaResetEnabled: true
@@ -377,9 +376,6 @@ core:
     storedIdentityService:
       featureFlags:
         storedIdentityServiceEnabled: true
-    internationalAddress:
-      featureFlags:
-        internationalAddressEnabled: true
     mfaReset:
       featureFlags:
         mfaResetEnabled: true


### PR DESCRIPTION
## Proposed changes
### What changed

- Removed 'internationalAddressEnabled' feature flag

### Why did it change

- As it is enabled across all environments for a while, we can safely remove it.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8080](https://govukverify.atlassian.net/browse/PYIC-8080)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8080]: https://govukverify.atlassian.net/browse/PYIC-8080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ