### PR TITLE
PYIC-8427: use evcs /identity endpoint

### DIFF
--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -60,28 +60,25 @@ public class StoreIdentityService {
 
         var hasStoredSiObject = false;
         var isPendingIdentity = identityType.equals(CandidateIdentityType.PENDING);
-        if (configService.enabled(STORED_IDENTITY_SERVICE)) {
+        LOGGER.info(LogHelper.buildLogMessage("Storing user VCs with POST"));
+        evcsService.storeCompletedOrPendingIdentityWithPost(
+                userId, sessionCredentials, evcsVcs, isPendingIdentity);
+
+        if (configService.enabled(STORED_IDENTITY_SERVICE) && !isPendingIdentity) {
             try {
-                LOGGER.info(LogHelper.buildLogMessage("Attempting to store user VCs with PUT"));
-                if (isPendingIdentity) {
-                    evcsService.storePendingIdentityWithPut(userId, sessionCredentials);
-                } else {
-                    var httpResponse =
-                            evcsService.storeCompletedIdentityWithPut(
-                                    userId, sessionCredentials, strongestMatchedVot, achievedVot);
-                    hasStoredSiObject = httpResponse.statusCode() == HttpStatusCode.ACCEPTED;
-                }
-            } catch (FailedToCreateStoredIdentityForEvcsException | EvcsServiceException e) {
+                var httpResponse =
+                        evcsService.storeStoredIdentityRecord(
+                                userId, sessionCredentials, strongestMatchedVot, achievedVot);
+                hasStoredSiObject = httpResponse.statusCode() == HttpStatusCode.ACCEPTED;
+            } catch (FailedToCreateStoredIdentityForEvcsException e) {
                 LOGGER.warn(
                         LogHelper.buildLogMessage(
-                                "Failed to store user VCs with PUT, falling back to POST method"));
-                evcsService.storeCompletedOrPendingIdentityWithPost(
-                        userId, sessionCredentials, evcsVcs, isPendingIdentity);
+                                "Failed to create stored identity record. Stored identity record was not saved to EVCS."));
+            } catch (EvcsServiceException e) {
+                LOGGER.warn(
+                        LogHelper.buildLogMessage(
+                                "Failed to store stored identity record to EVCS. Continuing user journey."));
             }
-        } else {
-            LOGGER.info(LogHelper.buildLogMessage("Storing user VCs with POST"));
-            evcsService.storeCompletedOrPendingIdentityWithPost(
-                    userId, sessionCredentials, evcsVcs, isPendingIdentity);
         }
 
         LOGGER.info(LogHelper.buildLogMessage("Identity successfully stored"));

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -61,7 +61,7 @@ public class StoreIdentityService {
         var hasStoredSiObject = false;
         var isPendingIdentity = identityType.equals(CandidateIdentityType.PENDING);
         LOGGER.info(LogHelper.buildLogMessage("Storing user VCs with POST"));
-        evcsService.storeCompletedOrPendingIdentityWithPost(
+        evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                 userId, sessionCredentials, evcsVcs, isPendingIdentity);
 
         if (configService.enabled(STORED_IDENTITY_SERVICE) && !isPendingIdentity) {

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
@@ -125,7 +125,7 @@ class StoreIdentityServiceTest {
 
             // Assert
             verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPost(USER_ID, VCS, List.of(), false);
+                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
         }
 
         @Test
@@ -167,7 +167,7 @@ class StoreIdentityServiceTest {
             assertEquals(COMPONENT_ID, auditEvent.getComponentId());
             assertEquals(testAuditEventUser, auditEvent.getUser());
             verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPost(any(), any(), any(), anyBoolean());
+                    .storeCompletedOrPendingIdentityWithPostVcs(any(), any(), any(), anyBoolean());
         }
 
         @Test
@@ -197,7 +197,7 @@ class StoreIdentityServiceTest {
             assertEquals(COMPONENT_ID, auditEvent.getComponentId());
             assertEquals(testAuditEventUser, auditEvent.getUser());
             verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPost(any(), any(), any(), anyBoolean());
+                    .storeCompletedOrPendingIdentityWithPostVcs(any(), any(), any(), anyBoolean());
         }
 
         @Test
@@ -225,7 +225,7 @@ class StoreIdentityServiceTest {
             assertEquals(testAuditEventUser, auditEvent.getUser());
 
             verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPost(USER_ID, VCS, List.of(), true);
+                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), true);
         }
 
         @Test
@@ -255,7 +255,7 @@ class StoreIdentityServiceTest {
             assertEquals(COMPONENT_ID, auditEvent.getComponentId());
             assertEquals(testAuditEventUser, auditEvent.getUser());
             verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPost(any(), any(), any(), anyBoolean());
+                    .storeCompletedOrPendingIdentityWithPostVcs(any(), any(), any(), anyBoolean());
         }
     }
 
@@ -266,7 +266,7 @@ class StoreIdentityServiceTest {
                         new EvcsServiceException(
                                 HTTPResponse.SC_SERVER_ERROR, FAILED_AT_EVCS_HTTP_REQUEST_SEND))
                 .when(evcsService)
-                .storeCompletedOrPendingIdentityWithPost(USER_ID, VCS, List.of(), true);
+                .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), true);
 
         // Assert
         assertThrows(
@@ -308,7 +308,7 @@ class StoreIdentityServiceTest {
 
             // Assert
             verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPost(USER_ID, VCS, List.of(), false);
+                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
             verify(evcsService, times(1))
                     .storeStoredIdentityRecord(USER_ID, VCS, STRONGEST_MATCHED_VOT, P2);
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
@@ -334,7 +334,7 @@ class StoreIdentityServiceTest {
 
             // Assert
             verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPost(USER_ID, VCS, List.of(), true);
+                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), true);
             verify(evcsService, times(0)).storeStoredIdentityRecord(any(), any(), any(), any());
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
 
@@ -375,7 +375,7 @@ class StoreIdentityServiceTest {
 
             // Assert
             verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPost(USER_ID, VCS, List.of(), false);
+                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
 
             var auditEvent = auditEventCaptor.getValue();
@@ -406,7 +406,7 @@ class StoreIdentityServiceTest {
 
             // Assert
             verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPost(USER_ID, VCS, List.of(), false);
+                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
             verify(evcsService, times(1))
                     .storeStoredIdentityRecord(USER_ID, VCS, STRONGEST_MATCHED_VOT, P2);
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
@@ -424,7 +424,7 @@ class StoreIdentityServiceTest {
         // Arrange
         doThrow(EvcsServiceException.class)
                 .when(evcsService)
-                .storeCompletedOrPendingIdentityWithPost(USER_ID, VCS, List.of(), false);
+                .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
 
         // Act/Assert
         assertThrows(

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
@@ -15,7 +15,6 @@ import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsCreateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsPostIdentityDto;
-import uk.gov.di.ipv.core.library.evcs.dto.EvcsPutUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
@@ -110,40 +109,12 @@ public class EvcsClient {
         }
     }
 
-    public HttpResponse<String> storeUserVCs(EvcsPutUserVCsDto userVCsForEvcs)
-            throws EvcsServiceException {
-        LOGGER.info(
-                LogHelper.buildLogMessage(
-                        "Preparing to store %d user VCs using PUT method"
-                                .formatted(userVCsForEvcs.vcs().size())));
-
-        try {
-            HttpRequest.Builder httpRequestBuilder =
-                    HttpRequest.newBuilder()
-                            .uri(getVcsUriWithNoParams())
-                            .PUT(
-                                    HttpRequest.BodyPublishers.ofString(
-                                            OBJECT_MAPPER.writeValueAsString(userVCsForEvcs)))
-                            .header(
-                                    X_API_KEY_HEADER,
-                                    configService.getSecret(ConfigurationVariable.EVCS_API_KEY))
-                            .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
-
-            return sendHttpRequest(httpRequestBuilder.build());
-        } catch (URISyntaxException e) {
-            throw new EvcsServiceException(
-                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_CONSTRUCT_EVCS_URI);
-        } catch (JsonProcessingException e) {
-            throw new EvcsServiceException(
-                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_PARSE_EVCS_REQUEST_BODY);
-        }
-    }
-
     public HttpResponse<String> storeUserVCs(
             String userId, List<EvcsCreateUserVCsDto> userVCsForEvcs) throws EvcsServiceException {
         LOGGER.info(
                 LogHelper.buildLogMessage(
-                        "Preparing to store %d user VCs".formatted(userVCsForEvcs.size())));
+                        "Preparing to store %d user VCs using POST /vcs endpoint"
+                                .formatted(userVCsForEvcs.size())));
         try {
             HttpRequest.Builder httpRequestBuilder =
                     HttpRequest.newBuilder()
@@ -217,10 +188,6 @@ public class EvcsClient {
             throw new EvcsServiceException(
                     HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_PARSE_EVCS_REQUEST_BODY);
         }
-    }
-
-    private URI getVcsUriWithNoParams() throws URISyntaxException {
-        return getUri(VCS_SUB_PATH, null, null);
     }
 
     private URI getIdentityUri() throws URISyntaxException {

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPostIdentityDto.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPostIdentityDto.java
@@ -1,0 +1,3 @@
+package uk.gov.di.ipv.core.library.evcs.dto;
+
+public record EvcsPostIdentityDto(String userId, EvcsStoredIdentityDto si) {}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPostIdentityDto.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPostIdentityDto.java
@@ -1,3 +1,9 @@
 package uk.gov.di.ipv.core.library.evcs.dto;
 
-public record EvcsPostIdentityDto(String userId, EvcsStoredIdentityDto si) {}
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record EvcsPostIdentityDto(
+        String userId, List<EvcsCreateUserVCsDto> vcs, EvcsStoredIdentityDto si) {}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPutUserVCsDto.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPutUserVCsDto.java
@@ -1,9 +1,0 @@
-package uk.gov.di.ipv.core.library.evcs.dto;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-import java.util.List;
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
-public record EvcsPutUserVCsDto(
-        String userId, List<EvcsCreateUserVCsDto> vcs, EvcsStoredIdentityDto si) {}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -10,7 +10,6 @@ import uk.gov.di.ipv.core.library.evcs.client.EvcsClient;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsCreateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsPostIdentityDto;
-import uk.gov.di.ipv.core.library.evcs.dto.EvcsPutUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
@@ -190,25 +189,25 @@ public class EvcsService {
         return evcsClient.getUserVcs(userId, evcsAccessToken, List.of(states)).vcs();
     }
 
-    public void storePendingIdentityWithPut(String userId, List<VerifiableCredential> credentials)
-            throws EvcsServiceException {
-        var putUserVcsDto = createPendingPutUserVcsDto(userId, credentials);
-        evcsClient.storeUserVCs(putUserVcsDto);
+    public void storePendingIdentityWithPostIdentity(
+            String userId, List<VerifiableCredential> credentials) throws EvcsServiceException {
+        var postIdentityDto = createPendingPostIdentityDto(userId, credentials);
+        evcsClient.storeUserIdentity(postIdentityDto);
     }
 
-    public HttpResponse<String> storeCompletedIdentityWithPut(
+    public HttpResponse<String> storeCompletedIdentityWithPostIdentity(
             String userId,
             List<VerifiableCredential> credentials,
             VotMatchingResult.VotAndProfile strongestAchievedVot,
             Vot achievedVot)
             throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
-        var putUserVcsDto =
-                createCompletedPutUserVcsDto(
+        var postIdentityDto =
+                createCompletedPostIdentityDto(
                         userId, credentials, strongestAchievedVot, achievedVot);
-        return evcsClient.storeUserVCs(putUserVcsDto);
+        return evcsClient.storeUserIdentity(postIdentityDto);
     }
 
-    private EvcsPutUserVCsDto createCompletedPutUserVcsDto(
+    private EvcsPostIdentityDto createCompletedPostIdentityDto(
             String userId,
             List<VerifiableCredential> credentials,
             VotMatchingResult.VotAndProfile strongestAchievedVot,
@@ -218,7 +217,7 @@ public class EvcsService {
                 storedIdentityService.getStoredIdentityForEvcs(
                         userId, credentials, strongestAchievedVot, achievedVot);
 
-        return new EvcsPutUserVCsDto(
+        return new EvcsPostIdentityDto(
                 userId,
                 credentials.stream()
                         .map(
@@ -229,9 +228,9 @@ public class EvcsService {
                 storedIdentityJwt);
     }
 
-    private EvcsPutUserVCsDto createPendingPutUserVcsDto(
+    private EvcsPostIdentityDto createPendingPostIdentityDto(
             String userId, List<VerifiableCredential> credentials) {
-        return new EvcsPutUserVCsDto(
+        return new EvcsPostIdentityDto(
                 userId,
                 credentials.stream()
                         .map(
@@ -242,7 +241,7 @@ public class EvcsService {
                 null);
     }
 
-    public void storeCompletedOrPendingIdentityWithPost(
+    public void storeCompletedOrPendingIdentityWithPostVcs(
             String userId,
             List<VerifiableCredential> credentials,
             List<EvcsGetUserVCDto> existingEvcsUserVCs,
@@ -282,7 +281,7 @@ public class EvcsService {
                 storedIdentityService.getStoredIdentityForEvcs(
                         userId, credentials, strongestAchievedVot, achievedVot);
 
-        var evcsStoreIdentityDto = new EvcsPostIdentityDto(userId, storedIdentityJwt);
+        var evcsStoreIdentityDto = new EvcsPostIdentityDto(userId, null, storedIdentityJwt);
 
         return evcsClient.storeUserIdentity(evcsStoreIdentityDto);
     }

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -9,6 +9,7 @@ import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.evcs.client.EvcsClient;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsCreateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
+import uk.gov.di.ipv.core.library.evcs.dto.EvcsPostIdentityDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsPutUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
@@ -269,6 +270,21 @@ public class EvcsService {
         if (!CollectionUtils.isEmpty(existingEvcsUserVCs))
             updateExistingUserVCs(userId, credentials, existingEvcsUserVCs, isPendingIdentity);
         if (!userVCsToStore.isEmpty()) evcsClient.storeUserVCs(userId, userVCsToStore);
+    }
+
+    public HttpResponse<String> storeStoredIdentityRecord(
+            String userId,
+            List<VerifiableCredential> credentials,
+            VotMatchingResult.VotAndProfile strongestAchievedVot,
+            Vot achievedVot)
+            throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
+        var storedIdentityJwt =
+                storedIdentityService.getStoredIdentityForEvcs(
+                        userId, credentials, strongestAchievedVot, achievedVot);
+
+        var evcsStoreIdentityDto = new EvcsPostIdentityDto(userId, storedIdentityJwt);
+
+        return evcsClient.storeUserIdentity(evcsStoreIdentityDto);
     }
 
     private void updateExistingUserVCs(

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -19,7 +19,6 @@ import uk.gov.di.ipv.core.library.evcs.dto.EvcsCreateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsPostIdentityDto;
-import uk.gov.di.ipv.core.library.evcs.dto.EvcsPutUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsStoredIdentityDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
@@ -119,7 +118,6 @@ class EvcsServiceTest {
 
     @Captor ArgumentCaptor<List<EvcsCreateUserVCsDto>> evcsCreateUserVCsDtosCaptor;
     @Captor ArgumentCaptor<List<EvcsUpdateUserVCsDto>> evcsUpdateUserVCsDtosCaptor;
-    @Captor ArgumentCaptor<EvcsPutUserVCsDto> evcsPutUserVCsDtoCaptor;
     @Captor ArgumentCaptor<EvcsPostIdentityDto> evcsPostIdentityDtoCaptor;
     @Captor ArgumentCaptor<String> stringArgumentCaptor;
 
@@ -138,7 +136,7 @@ class EvcsServiceTest {
         @Test
         void testStoreIdentity_whenNoExistingEvcsUserVCs() throws Exception {
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPost(
+            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                     TEST_USER_ID, VERIFIABLE_CREDENTIALS, List.of(), false);
 
             // Assert
@@ -162,7 +160,7 @@ class EvcsServiceTest {
         @Test
         void testStorePendingIdentity_onSuccessfulJourney_for_incompleteF2F() throws Exception {
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPost(
+            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                     TEST_USER_ID, VERIFIABLE_CREDENTIALS_ONE_EXIST_IN_EVCS, List.of(), true);
 
             // Assert
@@ -182,7 +180,7 @@ class EvcsServiceTest {
         @Test
         void testStoreIdentity_for_6MFCJourney() throws Exception {
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPost(
+            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                     TEST_USER_ID,
                     VERIFIABLE_CREDENTIALS_ONE_EXIST_IN_EVCS,
                     EVCS_GET_USER_VC_DTO,
@@ -229,7 +227,7 @@ class EvcsServiceTest {
                                     EvcsVCState.CURRENT,
                                     Map.of("reason", "testing")));
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPost(
+            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                     TEST_USER_ID,
                     VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS,
                     evcsGetUserVcsWithCurrentStateAllExistingDto,
@@ -260,7 +258,7 @@ class EvcsServiceTest {
                                     EvcsVCState.PENDING_RETURN,
                                     Map.of("reason", "testing")));
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPost(
+            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                     TEST_USER_ID,
                     VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS,
                     evcsGetUserVcsWithPendingAllExistingDto,
@@ -299,7 +297,7 @@ class EvcsServiceTest {
                                     EvcsVCState.PENDING_RETURN,
                                     Map.of("reason", "testing")));
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPost(
+            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                     TEST_USER_ID, List.of(), evcsGetUserVcsWithPendingAllExistingDto, false);
 
             // Assert
@@ -325,7 +323,7 @@ class EvcsServiceTest {
                                     EvcsVCState.CURRENT,
                                     Map.of("inheritedIdentity", Cri.HMRC_MIGRATION.getId())));
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPost(
+            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                     TEST_USER_ID, VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS, vcsInEvcs, false);
 
             // Assert
@@ -337,33 +335,33 @@ class EvcsServiceTest {
     }
 
     @Nested
-    class StoreIdentityWithPutMethod {
+    class StoreIdentityWithPostIdentityMethod {
         @Test
-        void shouldStorePendingIdentityWithPutMethod() throws Exception {
+        void shouldStorePendingIdentityWithPostIdentityMethod() throws Exception {
             // Arrange
             var testVcs = List.of(VC_ADDRESS_TEST);
 
             // Act
-            evcsService.storePendingIdentityWithPut(TEST_USER_ID, testVcs);
+            evcsService.storePendingIdentityWithPostIdentity(TEST_USER_ID, testVcs);
 
             // Assert
-            verify(mockEvcsClient).storeUserVCs(evcsPutUserVCsDtoCaptor.capture());
+            verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
 
             assertEquals(
                     clientOAuthSessionItem.getUserId(),
-                    evcsPutUserVCsDtoCaptor.getValue().userId());
+                    evcsPostIdentityDtoCaptor.getValue().userId());
             assertEquals(
                     VC_ADDRESS_TEST.getVcString(),
-                    evcsPutUserVCsDtoCaptor.getValue().vcs().get(0).vc());
-            assertEquals(PENDING_RETURN, evcsPutUserVCsDtoCaptor.getValue().vcs().get(0).state());
-            assertEquals(ONLINE, evcsPutUserVCsDtoCaptor.getValue().vcs().get(0).provenance());
+                    evcsPostIdentityDtoCaptor.getValue().vcs().get(0).vc());
+            assertEquals(PENDING_RETURN, evcsPostIdentityDtoCaptor.getValue().vcs().get(0).state());
+            assertEquals(ONLINE, evcsPostIdentityDtoCaptor.getValue().vcs().get(0).provenance());
 
             verify(mockEvcsClient, never()).updateUserVCs(any(), any());
             verify(mockEvcsClient, never()).storeUserVCs(any(), any());
         }
 
         @Test
-        void shouldStoreCompletedIdentityWithPutMethod() throws Exception {
+        void shouldStoreCompletedIdentityWithPostIdentityMethod() throws Exception {
             // Arrange
             var testVcs = List.of(VC_ADDRESS_TEST);
             var testSiJwt = "test.si.jwt";
@@ -372,22 +370,22 @@ class EvcsServiceTest {
                     .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
 
             // Act
-            evcsService.storeCompletedIdentityWithPut(
+            evcsService.storeCompletedIdentityWithPostIdentity(
                     TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT);
 
             // Assert
-            verify(mockEvcsClient).storeUserVCs(evcsPutUserVCsDtoCaptor.capture());
+            verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
 
             assertEquals(
                     clientOAuthSessionItem.getUserId(),
-                    evcsPutUserVCsDtoCaptor.getValue().userId());
+                    evcsPostIdentityDtoCaptor.getValue().userId());
             assertEquals(
                     VC_ADDRESS_TEST.getVcString(),
-                    evcsPutUserVCsDtoCaptor.getValue().vcs().get(0).vc());
-            assertEquals(CURRENT, evcsPutUserVCsDtoCaptor.getValue().vcs().get(0).state());
-            assertEquals(ONLINE, evcsPutUserVCsDtoCaptor.getValue().vcs().get(0).provenance());
-            assertEquals(testSiJwt, evcsPutUserVCsDtoCaptor.getValue().si().jwt());
-            assertEquals(P1, evcsPutUserVCsDtoCaptor.getValue().si().vot());
+                    evcsPostIdentityDtoCaptor.getValue().vcs().get(0).vc());
+            assertEquals(CURRENT, evcsPostIdentityDtoCaptor.getValue().vcs().get(0).state());
+            assertEquals(ONLINE, evcsPostIdentityDtoCaptor.getValue().vcs().get(0).provenance());
+            assertEquals(testSiJwt, evcsPostIdentityDtoCaptor.getValue().si().jwt());
+            assertEquals(P1, evcsPostIdentityDtoCaptor.getValue().si().vot());
 
             verify(mockEvcsClient, never()).updateUserVCs(any(), any());
             verify(mockEvcsClient, never()).storeUserVCs(any(), any());


### PR DESCRIPTION
## Proposed changes
### What changed

- use EVCS /identity POST endpoint to store stored identity record
  - fails open when failing to create SI object, EVCS returns non-202 response or fails to send/process http request
- removes use of PUT `/vcs` request to store VCs + SI
  - removes references to this endpoint but keeps some of the logic so we don't have to put the same logic back in in phase 2

### Why did it change
Trust & Reuse team have re-estimated the size of their work to instead now implement a POST /identity endpoint. As part of phase 1, we only need to use this endpoint to store the SI record. In phase 2, the endpoint will be updated to store the VCs as well.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8427](https://govukverify.atlassian.net/browse/PYIC-8427)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code


[PYIC-8427]: https://govukverify.atlassian.net/browse/PYIC-8427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ