### PR TITLE
PYIC-8430: Reduce calls to Parameter store

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/NoCriForIssuerException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/NoCriForIssuerException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.ipv.core.library.exceptions;
-
-public class NoCriForIssuerException extends Exception {
-    public NoCriForIssuerException(String message) {
-        super(message);
-    }
-}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -21,17 +21,17 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigParseException;
 import uk.gov.di.ipv.core.library.exceptions.NoConfigForConnectionException;
-import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public abstract class ConfigService {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -198,43 +198,38 @@ public abstract class ConfigService {
         }
     }
 
-    public Map<String, Cri> getAllCrisByIssuer() {
-        Map<String, Cri> issuerMap = new HashMap<>();
-        for (var cri : Cri.values()) {
-            for (var componentId : getCriComponentIds(cri)) {
-                issuerMap.put(componentId, cri);
+    public Map<String, Cri> getIssuerCris() {
+        var allCriParameters = getParametersByPrefix("credentialIssuers");
+        var issuerToCriMap = new HashMap<String, Cri>();
+
+        for (Map.Entry<String, String> entry : allCriParameters.entrySet()) {
+            var fullPath = entry.getKey();
+            var value = entry.getValue();
+
+            var cri = findCriFromPath(fullPath);
+            if (cri == null) continue;
+
+            try {
+                var criConfig = OBJECT_MAPPER.readValue(value, CriConfig.class);
+                var issuer = criConfig.getComponentId();
+                issuerToCriMap.put(issuer, cri);
+            } catch (JsonProcessingException e) {
+                throw new ConfigParseException(
+                        String.format(
+                                "Failed to parse credential issuer configuration at path '%s': %s",
+                                fullPath, e));
             }
         }
-        return issuerMap;
+        return issuerToCriMap;
     }
 
-    public Cri getCriByIssuer(String issuer) throws NoCriForIssuerException {
-        for (var cri : Cri.values()) {
-            if (getCriComponentIds(cri).contains(issuer)) {
-                return cri;
-            }
-        }
-        throw new NoCriForIssuerException(String.format("No cri found for issuer: '%s'", issuer));
-    }
+    private Cri findCriFromPath(String parameterPath) {
+        Pattern pattern = Pattern.compile("([^/]+)/connections");
+        Matcher matcher = pattern.matcher(parameterPath);
 
-    private List<String> getCriComponentIds(Cri cri) {
-        final String pathTemplate =
-                ConfigurationVariable.CREDENTIAL_ISSUER_CONNECTION_PREFIX.getPath();
-        var criId = cri.getId();
-        var result = new ArrayList<String>();
-        try {
-            var parameters = getParametersByPrefix(formatPath(pathTemplate, criId));
-            for (var parameter : parameters.values()) {
-                var criConfig = OBJECT_MAPPER.readValue(parameter, CriConfig.class);
-
-                result.add(criConfig.getComponentId());
-            }
-            return result;
-        } catch (JsonProcessingException e) {
-            throw new ConfigParseException(
-                    String.format(
-                            "Failed to parse credential issuer configuration at parameter path '%s' because: '%s'",
-                            pathTemplate, e));
+        if (matcher.find()) {
+            return Cri.fromId(matcher.group(1));
         }
+        return null;
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -27,7 +27,6 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigParseException;
 import uk.gov.di.ipv.core.library.exceptions.NoConfigForConnectionException;
-import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
@@ -88,13 +87,7 @@ class AppConfigServiceTest {
               activeConnection: test
               connections:
                 test: '{
-                  "componentId":"alternate-issuer"
-                }'
-            criWithMalformedConfig:
-              activeConnection: test
-              connections:
-                test: '{
-                  componentId: alternate-issuer
+                  "componentId":"dcmaw-issuer"
                 }'
           featureFlags:
             testFeatureFlag: false
@@ -114,6 +107,21 @@ class AppConfigServiceTest {
           clients:
             testClient:
               validRedirectUrls: a,list,of,strings
+    """;
+    private static final String TEST_RAW_PARAMETERS_MALFORMED_CRI_CONFIG =
+            """
+        core:
+          self:
+            componentId: "test-component-id"
+            bearerTokenTtl: 1800
+            someStringList: "a,list,of,strings"
+          credentialIssuers:
+            dcmawAsync:
+              activeConnection: test
+              connections:
+                test: '{
+                  componentId: dcmaw-async-issuer
+                }'
     """;
     @Mock Cri criMock;
     @Mock AppConfigProvider appConfigProvider;
@@ -331,15 +339,6 @@ class AppConfigServiceTest {
         assertTrue(configMap.isEmpty());
     }
 
-    @Test
-    void getCriByIssuerReturnsCri() throws NoCriForIssuerException {
-        // Act
-        var cri = configService.getCriByIssuer("main-issuer");
-
-        // Assert
-        assertEquals(ADDRESS, cri);
-    }
-
     // CIMIT config
 
     @Test
@@ -375,30 +374,11 @@ class AppConfigServiceTest {
     // Get CRI by issuer
 
     @Test
-    void shouldReturnCriForValidIssuers() throws NoCriForIssuerException {
+    void shouldReturnIssuerCris() {
         // Act & Assert
-        assertEquals(ADDRESS, configService.getCriByIssuer("main-issuer"));
-        assertEquals(ADDRESS, configService.getCriByIssuer("stub-issuer"));
-        assertEquals(DCMAW, configService.getCriByIssuer("alternate-issuer"));
-    }
-
-    @Test
-    void shouldErrorForInvalidIssuer() {
-        // Act & Assert
-        assertThrows(
-                NoCriForIssuerException.class,
-                () -> configService.getCriByIssuer("non-existent-issuer"));
-    }
-
-    @Test
-    void getAllCrisByIssuerShouldReturnMapOfAllIssuersAndCri() {
-        // Act
-        var actual = configService.getAllCrisByIssuer();
-
-        // Assert
         assertEquals(
-                Map.of("stub-issuer", ADDRESS, "main-issuer", ADDRESS, "alternate-issuer", DCMAW),
-                actual);
+                Map.of("stub-issuer", ADDRESS, "main-issuer", ADDRESS, "dcmaw-issuer", DCMAW),
+                configService.getIssuerCris());
     }
 
     // OAuth CRI config
@@ -464,7 +444,8 @@ class AppConfigServiceTest {
         @Test
         void getOauthCriConfigForConnectionShouldThrowIfCriConfigMalformed() {
             // Arrange
-            when(criMock.getId()).thenReturn("criWithMalformedConfig");
+            when(appConfigProvider.get(any())).thenReturn(TEST_RAW_PARAMETERS_MALFORMED_CRI_CONFIG);
+            when(criMock.getId()).thenReturn("dcmawAsync");
 
             // Act & Assert
             assertThrows(

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/YamlConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/YamlConfigServiceTest.java
@@ -7,6 +7,7 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -70,12 +71,12 @@ class YamlConfigServiceTest {
     }
 
     @Test
-    void getCriByIssuerReturnsCri() throws Exception {
+    void shouldReturnIssuerCris() throws Exception {
         var configService = getConfigService();
 
-        var cri = configService.getCriByIssuer("test-issuer");
-
-        assertEquals(Cri.ADDRESS, cri);
+        assertEquals(
+                Map.of("test-issuer", Cri.ADDRESS, "alternate-issuer", Cri.DCMAW),
+                configService.getIssuerCris());
     }
 
     @Test

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -16,7 +16,6 @@ import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
 import uk.gov.di.ipv.core.library.evcs.metadata.InheritedIdentityMetadata;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
-import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
 
@@ -133,33 +132,41 @@ public class EvcsService {
             getParsedVerifiableCredentialsFromEvcsResponse(
                     String userId, List<EvcsGetUserVCDto> evcsUserVcs)
                     throws CredentialParseException {
-        Map<EvcsVCState, List<VerifiableCredential>> credentials = new EnumMap<>(EvcsVCState.class);
-        for (var vc : evcsUserVcs) {
-            try {
+        var credentials = new EnumMap<EvcsVCState, List<VerifiableCredential>>(EvcsVCState.class);
+
+        try {
+            var issuerCris = configService.getIssuerCris();
+            var cimitComponentId =
+                    configService.getParameter(ConfigurationVariable.CIMIT_COMPONENT_ID);
+
+            for (var vc : evcsUserVcs) {
                 var jwt = SignedJWT.parse(vc.vc());
+                var issuer = jwt.getJWTClaimsSet().getIssuer();
 
                 // With SIS, we now store the CIMIT VC. We don't want to add this to the
                 // credential bundle so we skip the VC if it's from CIMIT.
-                if (configService
-                        .getParameter(ConfigurationVariable.CIMIT_COMPONENT_ID)
-                        .equals(jwt.getJWTClaimsSet().getIssuer())) {
+                if (cimitComponentId.equals(issuer)) {
                     continue;
                 }
 
-                var cri = configService.getCriByIssuer(jwt.getJWTClaimsSet().getIssuer());
+                var cri = issuerCris.get(issuer);
+                if (cri == null) {
+                    throw new CredentialParseException(
+                            String.format(
+                                    "Failed to find credential issuer for vc issuer: %s", issuer));
+                }
+
                 var credential = VerifiableCredential.fromValidJwt(userId, cri, jwt);
                 if (!credentials.containsKey(vc.state())) {
                     credentials.put(vc.state(), new ArrayList<>());
                 }
                 credentials.get(vc.state()).add(credential);
-            } catch (NoCriForIssuerException e) {
-                throw new CredentialParseException("Failed to find credential issuer for vc", e);
-            } catch (ParseException e) {
-                throw new CredentialParseException(
-                        "Encountered a parsing error while attempting to parse evcs credentials",
-                        e);
             }
+        } catch (ParseException e) {
+            throw new CredentialParseException(
+                    "Encountered a parsing error while attempting to parse evcs credentials", e);
         }
+
         return credentials;
     }
 

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -24,7 +24,6 @@ import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
-import uk.gov.di.ipv.core.library.exceptions.NoCriForIssuerException;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
@@ -458,13 +457,15 @@ class EvcsServiceTest {
     }
 
     @Test
-    void testGetVerifiableCredentials()
-            throws CredentialParseException, NoCriForIssuerException, EvcsServiceException {
+    void testGetVerifiableCredentials() throws CredentialParseException, EvcsServiceException {
         // Arrange
-        when(mockConfigService.getCriByIssuer(vcAddressM1a().getClaimsSet().getIssuer()))
-                .thenReturn(Cri.ADDRESS);
-        when(mockConfigService.getCriByIssuer(vcWebPassportSuccessful().getClaimsSet().getIssuer()))
-                .thenReturn(Cri.DCMAW);
+        when(mockConfigService.getIssuerCris())
+                .thenReturn(
+                        Map.of(
+                                vcAddressM1a().getClaimsSet().getIssuer(),
+                                Cri.ADDRESS,
+                                vcWebPassportSuccessful().getClaimsSet().getIssuer(),
+                                Cri.DCMAW));
         when(mockConfigService.getParameter(ConfigurationVariable.CIMIT_COMPONENT_ID))
                 .thenReturn("https://cimit.stubs.account.gov.uk");
 
@@ -496,11 +497,9 @@ class EvcsServiceTest {
     }
 
     @Test
-    void testGetVerifiableCredentialsShouldErrorWhenCriNotFound()
-            throws NoCriForIssuerException, EvcsServiceException {
+    void testGetVerifiableCredentialsShouldErrorWhenCriNotFound() throws EvcsServiceException {
         // Arrange
-        when(mockConfigService.getCriByIssuer(any()))
-                .thenThrow(new NoCriForIssuerException("not found"));
+        when(mockConfigService.getIssuerCris()).thenReturn(Map.of());
 
         when(mockEvcsClient.getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, List.of(CURRENT)))
                 .thenReturn(
@@ -534,10 +533,13 @@ class EvcsServiceTest {
                         new EvcsGetUserVCDto(
                                 vcWebPassportSuccessful().getVcString(), CURRENT, null));
 
-        when(mockConfigService.getCriByIssuer(vcAddressM1a().getClaimsSet().getIssuer()))
-                .thenReturn(Cri.ADDRESS);
-        when(mockConfigService.getCriByIssuer(vcWebPassportSuccessful().getClaimsSet().getIssuer()))
-                .thenReturn(Cri.DCMAW);
+        when(mockConfigService.getIssuerCris())
+                .thenReturn(
+                        Map.of(
+                                vcAddressM1a().getClaimsSet().getIssuer(),
+                                Cri.ADDRESS,
+                                vcWebPassportSuccessful().getClaimsSet().getIssuer(),
+                                Cri.DCMAW));
         when(mockConfigService.getParameter(ConfigurationVariable.CIMIT_COMPONENT_ID))
                 .thenReturn("https://cimit.stubs.account.gov.uk");
 
@@ -563,10 +565,13 @@ class EvcsServiceTest {
                         new EvcsGetUserVCDto(
                                 vcWebPassportSuccessful().getVcString(), PENDING_RETURN, null));
 
-        when(mockConfigService.getCriByIssuer(vcAddressM1a().getClaimsSet().getIssuer()))
-                .thenReturn(Cri.ADDRESS);
-        when(mockConfigService.getCriByIssuer(vcWebPassportSuccessful().getClaimsSet().getIssuer()))
-                .thenReturn(Cri.DCMAW);
+        when(mockConfigService.getIssuerCris())
+                .thenReturn(
+                        Map.of(
+                                vcAddressM1a().getClaimsSet().getIssuer(),
+                                Cri.ADDRESS,
+                                vcWebPassportSuccessful().getClaimsSet().getIssuer(),
+                                Cri.DCMAW));
         when(mockConfigService.getParameter(ConfigurationVariable.CIMIT_COMPONENT_ID))
                 .thenReturn("https://cimit.stubs.account.gov.uk");
 
@@ -595,10 +600,13 @@ class EvcsServiceTest {
                                 vcWebPassportSuccessful().getVcString(), CURRENT, null),
                         new EvcsGetUserVCDto(vcSecurityCheckNoCis().getVcString(), CURRENT, null));
 
-        when(mockConfigService.getCriByIssuer(vcAddressM1a().getClaimsSet().getIssuer()))
-                .thenReturn(Cri.ADDRESS);
-        when(mockConfigService.getCriByIssuer(vcWebPassportSuccessful().getClaimsSet().getIssuer()))
-                .thenReturn(Cri.DCMAW);
+        when(mockConfigService.getIssuerCris())
+                .thenReturn(
+                        Map.of(
+                                vcAddressM1a().getClaimsSet().getIssuer(),
+                                Cri.ADDRESS,
+                                vcWebPassportSuccessful().getClaimsSet().getIssuer(),
+                                Cri.DCMAW));
         when(mockConfigService.getParameter(ConfigurationVariable.CIMIT_COMPONENT_ID))
                 .thenReturn("https://cimit.stubs.account.gov.uk");
 


### PR DESCRIPTION
## Proposed changes
### What changed

- Reduce calls to Parameter store for GetParametersByPath & remove repeated GetParameters for cimit component id.

### Why did it change

- Calling `GetParametersByPath` 15x per fetch from EVCS
- Rate limits hit & it's inefficient

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- https://govukverify.atlassian.net/browse/PYIC-8430?focusedCommentId=233618
- [PYIC-8430](https://govukverify.atlassian.net/browse/PYIC-8430)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8430]: https://govukverify.atlassian.net/browse/PYIC-8430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ