### PR TITLE
BAU: Add checks to ensure VCs aren't written on account interention

### DIFF
--- a/api-tests/features/account-intervention/journey-ending-interventions.feature
+++ b/api-tests/features/account-intervention/journey-ending-interventions.feature
@@ -23,6 +23,7 @@ Feature: Journey ending interventions
       | Attribute          | Values                   |
       | evidence_requested | {"identityFraudScore":1} |
     Then I get an OAuth response with error code 'session_invalidated'
+    And I don't have a stored identity in EVCS
 
     Examples:
       | intervention                        | when  | first_ais_response             | second_ais_response                                | ticf_intervention_code |
@@ -67,6 +68,7 @@ Feature: Journey ending interventions
       | Attribute          | Values                   |
       | evidence_requested | {"identityFraudScore":1} |
     Then I get an OAuth response with error code 'session_invalidated'
+    And I don't have a stored identity in EVCS
 
     Examples:
       | intervention                        | when  | first_ais_response                                 | second_ais_response                                |
@@ -136,3 +138,4 @@ Feature: Journey ending interventions
       | Attribute          | Values                   |
       | evidence_requested | {"identityFraudScore":2} |
     Then I get an OAuth response with error code 'session_invalidated'
+    And I don't have a stored identity in EVCS


### PR DESCRIPTION
## Proposed changes
### What changed

Added checks to ensure identities aren't saved when there's an account intervention

### Why did it change

Should really have been there all along

NOTE: Ideally we'd also have checks on the AIS tests that have a pre-existing identity to make sure that identity hasn't changed, but that's more difficult and this should catch regressions