### PR TITLE
Pyic 8306 Create policy for manualF2fReset lambda

### DIFF
--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-international.feature
@@ -9,7 +9,6 @@ Feature: International identity reuse update details
         And I activate the 'disableStrategicApp' feature set
         When I start a new 'medium-confidence' journey
         Then I get a 'page-ipv-reuse' page response
-        When I activate the 'internationalAddress' feature sets
         And I submit a 'update-details' event
         Then I get a 'update-details' page response
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -777,6 +777,24 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref ManualF2fPendingResetFunctionLogGroup
 
+  ManualF2fPendingResetFunctionManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    DependsOn:
+      - "ManualF2fPendingResetFunction"
+    Properties:
+      ManagedPolicyName: manual-f2f-pending-reset-function-managed-policy
+      Description: Allows invoking the ManualF2f Lambda
+      Path: /control-tower/lambdas/
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+              - lambda:GetFunction
+            Resource:
+              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:manual-f2f-pending-reset-${Environment}:live
+
   IssueClientAccessTokenFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -4329,3 +4347,7 @@ Outputs:
     Value: !GetAtt LoggingKmsKey.Arn
     Export:
       Name: !Sub "CoreBackLoggingKmsKeyArn-${Environment}"
+  ManualF2fInvokePolicyArn:
+    Value: !Ref ManualF2fPendingResetFunctionManagedPolicy
+    Export:
+      Name: !Sub "ManualF2fPendingResetFunctionManagedPolicyArn-${Environment}"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -4347,7 +4347,3 @@ Outputs:
     Value: !GetAtt LoggingKmsKey.Arn
     Export:
       Name: !Sub "CoreBackLoggingKmsKeyArn-${Environment}"
-  ManualF2fInvokePolicyArn:
-    Value: !Ref ManualF2fPendingResetFunctionManagedPolicy
-    Export:
-      Name: !Sub "ManualF2fPendingResetFunctionManagedPolicyArn-${Environment}"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -132,6 +132,10 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsBuildStagingProd: !Or
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -779,6 +783,7 @@ Resources:
 
   ManualF2fPendingResetFunctionManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
+    Condition: IsBuildStagingProd
     DependsOn:
       - "ManualF2fPendingResetFunction"
     Properties:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -54,10 +54,7 @@ states:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD_UPDATE_ADDRESS
-        checkFeatureFlag:
-          internationalAddressEnabled:
-            targetState: ADDRESS_AND_FRAUD_UPDATE_ADDRESS
-            targetEntryEvent: internationalUser
+        targetEntryEvent: internationalUser
 
   ADDRESS_AND_FRAUD_UPDATE_ADDRESS:
     nestedJourney: ADDRESS_AND_FRAUD

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -295,10 +295,7 @@ states:
     events:
       next:
         targetState: ADDRESS_AND_FRAUD
-        checkFeatureFlag:
-          internationalAddressEnabled:
-            targetState: ADDRESS_AND_FRAUD
-            targetEntryEvent: internationalUser
+        targetEntryEvent: internationalUser
 
   ADDRESS_AND_FRAUD:
     nestedJourney: ADDRESS_AND_FRAUD

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -358,7 +358,6 @@ core:
     resetIdentity: false
     pendingF2FResetEnabled: false
     strategicAppEnabled: true
-    internationalAddressEnabled: true
     inheritedIdentity: true
     repeatFraudCheckEnabled: true
     mfaResetEnabled: true
@@ -377,9 +376,6 @@ core:
     storedIdentityService:
       featureFlags:
         storedIdentityServiceEnabled: true
-    internationalAddress:
-      featureFlags:
-        internationalAddressEnabled: true
     mfaReset:
       featureFlags:
         mfaResetEnabled: true


### PR DESCRIPTION
## Proposed changes
### What changed

- Added Managed Policy for manualF2fReset lambda that allows to read that specific lambda and invoke it

### Why did it change

- As we created manualF2fReset lambda we need to allow TSD to execute it and nothing more.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8306](https://govukverify.atlassian.net/browse/PYIC-8306)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8306]: https://govukverify.atlassian.net/browse/PYIC-8306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ