### PR TITLE
PYIC-8306: Add ManagedPolicy and AssumedPolicy to manualF2fReset lambda.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -132,6 +132,10 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsBuildStagingProd: !Or
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -776,6 +780,45 @@ Resources:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Ref ManualF2fPendingResetFunctionLogGroup
+
+  ManualF2fPendingResetFunctionManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: IsBuildStagingProd
+    Properties:
+      ManagedPolicyName: ManualF2fPendingResetManagedPolicy
+      Description: Allows invoking the ManualF2f Lambda
+      Path: /runbooks/runbook-f2f-reset/
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+              - lambda:GetFunction
+            Resource:
+              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:manual-f2f-pending-reset-${Environment}
+
+  ManualF2fPendingResetFunctionInvokeRole:
+    Type: AWS::IAM::Role
+    Condition: IsBuildStagingProd
+    Properties:
+      RoleName: RunbookF2fResetRole
+      Description: "This role allows approved support team to perform pending F2F reset"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: "sts:AssumeRole"
+            Condition:
+              ArnLike:
+                aws:PrincipalARN:
+                  !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedServiceSupport*
+      ManagedPolicyArns:
+        - !Ref ManualF2fPendingResetFunctionManagedPolicy
+      MaxSessionDuration: 43200
+      Path: /runbooks/runbook-f2f-reset/
 
   IssueClientAccessTokenFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## Proposed changes
### What changed

- Added Managed Policy for manualF2fReset lambda that allows to read that specific lambda and invoke it
- Added IAM Role with assumed policy for ApprovedServiceSupport

### Why did it change

- As we created manualF2fReset lambda we need to allow TSD to execute it and nothing more.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8306](https://govukverify.atlassian.net/browse/PYIC-8306)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8306]: https://govukverify.atlassian.net/browse/PYIC-8306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ