### PR TITLE
PYIC-8443: update nested test class to remove put reference

### DIFF
--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
@@ -283,7 +283,7 @@ class StoreIdentityServiceTest {
     }
 
     @Nested
-    class StoreIdentityWithPut {
+    class PostIdentityEndpoint {
         @BeforeEach
         void setUp() {
             when(configService.enabled(STORED_IDENTITY_SERVICE)).thenReturn(true);


### PR DESCRIPTION
## Proposed changes
### What changed

- removing missed `put` endpoint reference

### Why did it change

- we no longer use the evcs put endpoint

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8443](https://govukverify.atlassian.net/browse/PYIC-8443)



[PYIC-8443]: https://govukverify.atlassian.net/browse/PYIC-8443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ