### PR TITLE
PYIC-8467: Log async CRI response access denied at INFO level

### DIFF
--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -168,6 +168,7 @@ public class ProcessAsyncCriCredentialHandler
                     Cri cri = Cri.fromId(responseItem.getCredentialIssuer());
                     String errorCode = errorAsyncCriResponse.getError();
                     EmbeddedMetricHelper.asyncCriErrorResponse(cri.getId(), errorCode);
+
                     if (CriResponseService.ERROR_ACCESS_DENIED.equals(errorCode)) {
                         responseItem.setStatus(CriResponseService.STATUS_ABANDON);
                     } else {
@@ -176,7 +177,7 @@ public class ProcessAsyncCriCredentialHandler
                     criResponseService.updateCriResponseItem(responseItem);
                 });
 
-        LOGGER.error(
+        StringMapMessage logMessage =
                 new StringMapMessage()
                         .with(
                                 LOG_MESSAGE_DESCRIPTION.getFieldName(),
@@ -184,7 +185,13 @@ public class ProcessAsyncCriCredentialHandler
                         .with(
                                 LOG_ERROR_DESCRIPTION.getFieldName(),
                                 errorAsyncCriResponse.getErrorDescription())
-                        .with(LOG_ERROR_CODE.getFieldName(), errorAsyncCriResponse.getError()));
+                        .with(LOG_ERROR_CODE.getFieldName(), errorAsyncCriResponse.getError());
+
+        if (CriResponseService.ERROR_ACCESS_DENIED.equals(errorAsyncCriResponse.getError())) {
+            LOGGER.info(logMessage);
+        } else {
+            LOGGER.error(logMessage);
+        }
 
         criResponseItem.ifPresent(
                 responseItem ->


### PR DESCRIPTION
## Proposed changes
### What changed

- Downgrade the logging to INFO level. Other error responses such as server_error must still be logged at ERROR level

### Why did it change

- In process-async-cri-credential we’re logging access_denied error responses at ERROR level which is causing a lot of noise - these aren’t strictly errors, they just represent the user abandoning the v2 app (dcmawAsync) or their PO visit (F2F)

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8467](https://govukverify.atlassian.net/browse/PYIC-8467)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8467]: https://govukverify.atlassian.net/browse/PYIC-8467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ