### PR TITLE
PYIC-8466: log sqs message id and journey id in process-async-cri-cre…

### DIFF
--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/BaseAsyncCriResponse.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/BaseAsyncCriResponse.java
@@ -1,7 +1,5 @@
 package uk.gov.di.ipv.core.processasynccricredential.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,11 +8,8 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @ExcludeFromGeneratedCoverageReport
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class BaseAsyncCriResponse {
     private final String userId;
     private final String oauthState;
-
-    @JsonProperty("govuk_signin_journey_id")
     private final String journeyId;
 }

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/BaseAsyncCriResponse.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/BaseAsyncCriResponse.java
@@ -1,5 +1,7 @@
 package uk.gov.di.ipv.core.processasynccricredential.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,7 +10,11 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @ExcludeFromGeneratedCoverageReport
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class BaseAsyncCriResponse {
     private final String userId;
     private final String oauthState;
+
+    @JsonProperty("govuk_signin_journey_id")
+    private final String journeyId;
 }

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/ErrorAsyncCriResponse.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/ErrorAsyncCriResponse.java
@@ -12,8 +12,12 @@ public class ErrorAsyncCriResponse extends BaseAsyncCriResponse {
 
     @Builder
     private ErrorAsyncCriResponse(
-            String userId, String oauthState, String error, String errorDescription) {
-        super(userId, oauthState);
+            String userId,
+            String oauthState,
+            String error,
+            String errorDescription,
+            String journeyId) {
+        super(userId, oauthState, journeyId);
         this.error = error;
         this.errorDescription = errorDescription;
     }

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/SuccessAsyncCriResponse.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/domain/SuccessAsyncCriResponse.java
@@ -13,8 +13,11 @@ public class SuccessAsyncCriResponse extends BaseAsyncCriResponse {
 
     @Builder
     private SuccessAsyncCriResponse(
-            String userId, String oauthState, List<String> verifiableCredentialJWTs) {
-        super(userId, oauthState);
+            String userId,
+            String oauthState,
+            List<String> verifiableCredentialJWTs,
+            String journeyId) {
+        super(userId, oauthState, journeyId);
         this.verifiableCredentialJWTs = verifiableCredentialJWTs;
     }
 }

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/dto/CriResponseMessageDto.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/dto/CriResponseMessageDto.java
@@ -22,6 +22,9 @@ public class CriResponseMessageDto {
     @JsonProperty("state")
     private String oauthState;
 
+    @JsonProperty("govuk_signin_journey_id")
+    private String journeyId;
+
     @JsonProperty("https://vocab.account.gov.uk/v1/credentialJWT")
     private List<String> verifiableCredentialJWTs;
 

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/helpers/AsyncCriResponseHelper.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/helpers/AsyncCriResponseHelper.java
@@ -22,6 +22,7 @@ public class AsyncCriResponseHelper {
                     .userId(criResponseMessageDto.getUserId())
                     .oauthState(criResponseMessageDto.getOauthState())
                     .verifiableCredentialJWTs(criResponseMessageDto.getVerifiableCredentialJWTs())
+                    .journeyId(criResponseMessageDto.getJourneyId())
                     .build();
         } else {
             return ErrorAsyncCriResponse.builder()
@@ -29,6 +30,7 @@ public class AsyncCriResponseHelper {
                     .oauthState(criResponseMessageDto.getOauthState())
                     .error(criResponseMessageDto.getError())
                     .errorDescription(criResponseMessageDto.getErrorDescription())
+                    .journeyId(criResponseMessageDto.getJourneyId())
                     .build();
         }
     }

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -63,6 +63,7 @@ class ProcessAsyncCriCredentialHandlerTest {
     private static final String TEST_MESSAGE_ID = UUID.randomUUID().toString();
     private static final String TEST_CREDENTIAL_ISSUER_ID = F2F.getId();
     private static final String TEST_USER_ID = "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6";
+    private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final Cri TEST_CRI = Cri.F2F;
     private static final String TEST_COMPONENT_ID = TEST_CRI.getId();
     private static final String TEST_OAUTH_STATE = UUID.randomUUID().toString();
@@ -314,6 +315,7 @@ class ProcessAsyncCriCredentialHandlerTest {
                 new CriResponseMessageDto(
                         TEST_USER_ID,
                         TEST_OAUTH_STATE,
+                        TEST_JOURNEY_ID,
                         null,
                         errorType,
                         TEST_ASYNC_ERROR_DESCRIPTION);
@@ -328,7 +330,12 @@ class ProcessAsyncCriCredentialHandlerTest {
         final SQSEvent sqsEvent = new SQSEvent();
         final CriResponseMessageDto criResponseMessageDto =
                 new CriResponseMessageDto(
-                        TEST_USER_ID, testOauthState, List.of(F2F_VC.getVcString()), null, null);
+                        TEST_USER_ID,
+                        testOauthState,
+                        TEST_JOURNEY_ID,
+                        List.of(F2F_VC.getVcString()),
+                        null,
+                        null);
         final SQSEvent.SQSMessage message = new SQSEvent.SQSMessage();
         message.setMessageId(TEST_MESSAGE_ID);
         message.setBody(OBJECT_MAPPER.writeValueAsString(criResponseMessageDto));

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/LogHelper.java
@@ -72,6 +72,7 @@ public class LogHelper {
         LOG_PAYLOAD("payload"),
         LOG_PROFILE("profile"),
         LOG_QUEUE_NAME("queueName"),
+        LOG_SQS_MESSAGE_ID("sqsMessageId"),
         LOG_REDIRECT_URI("redirectUri"),
         LOG_RESET_TYPE("resetType"),
         LOG_RESPONSE_CONTENT_TYPE("responseContentType"),
@@ -159,6 +160,11 @@ public class LogHelper {
         } else {
             LogHelper.attachFieldToLogs(LOG_QUEUE_NAME, queueName);
         }
+    }
+
+    public static void attachSqsMessageIdToLogs(String sqsMessageId) {
+        var idValue = StringUtils.isBlank(sqsMessageId) ? "unknown" : sqsMessageId;
+        attachFieldToLogs(LogField.LOG_SQS_MESSAGE_ID, idValue);
     }
 
     private static void attachFieldToLogs(LogField field, String value) {


### PR DESCRIPTION
…dential logs

## Proposed changes
### What changed

- log `sqsMessageId` and `govuk_signin_journey_id` (if available) from process-async-cri-credential lambda

Stubs PR updates here: https://github.com/govuk-one-login/ipv-stubs/pull/1557

| description | screenshot |
|-|-|
| f2f log with missing govuk_signin_journey_id (logging sqs message id) | <img width="625" alt="f2f_sqs_message_id" src="https://github.com/user-attachments/assets/e7760df9-75ca-4c57-b9ea-f05d2699dc2c" /> |
| f2f log with stub journey id and sqs message id | <img width="737" alt="Screenshot 2025-07-01 at 15 14 04" src="https://github.com/user-attachments/assets/bec4ad78-d38a-4439-a046-8682731abf16" /> |
| v2 app log with journey id and sqs message id | <img width="655" alt="v2_sqsMessageId_journeyId" src="https://github.com/user-attachments/assets/117672bd-7334-4a8c-a89c-5df4a42f1e8d" /> |

### Why did it change

- improve observability for async credentials

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8466](https://govukverify.atlassian.net/browse/PYIC-8466)



[PYIC-8466]: https://govukverify.atlassian.net/browse/PYIC-8466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ