### PR TITLE
Revert "Revert "PYIC-8306: Add ManagedPolicy and AssumedPolicy to manualF2fReset lambda.""

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -820,6 +820,7 @@ Resources:
                   !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedServiceSupport*
       ManagedPolicyArns:
         - !Ref ManualF2fPendingResetFunctionManagedPolicy
+      PermissionsBoundary: !Sub "${PermissionsBoundary}"
       MaxSessionDuration: 43200
       Path: /runbooks/
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -799,8 +799,29 @@ Resources:
   ManualF2fPendingResetFunctionInvokeRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${AWS::StackName}-RunbookF2fResetRole
+      RoleName: !Sub ${AWS::StackName}-RunbookF2fResetModification
       Description: "This role allows approved support team to perform pending F2F reset"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: "sts:AssumeRole"
+            Condition:
+              ArnLike:
+                aws:PrincipalARN:
+                  !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedServiceSupport*
+      ManagedPolicyArns:
+        - !Ref ManualF2fPendingResetFunctionManagedPolicy
+      MaxSessionDuration: 43200
+      Path: /runbooks/
+
+  IAMRoleCreationTest:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${AWS::StackName}-Create
+      Description: "Test role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -132,6 +132,10 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsBuildStagingProd: !Or
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -782,6 +786,7 @@ Resources:
 
   ManualF2fPendingResetFunctionManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
+    Condition: IsBuildStagingProd
     Properties:
       ManagedPolicyName: ManualF2fPendingResetManagedPolicy
       Description: Allows invoking the ManualF2f Lambda
@@ -798,6 +803,7 @@ Resources:
 
   ManualF2fPendingResetFunctionInvokeRole:
     Type: AWS::IAM::Role
+    Condition: IsBuildStagingProd
     Properties:
       RoleName: !Sub ${AWS::StackName}-RunbookF2fResetRole
       Description: "This role allows approved support team to perform pending F2F reset"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -799,29 +799,8 @@ Resources:
   ManualF2fPendingResetFunctionInvokeRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${AWS::StackName}-RunbookF2fResetModification
+      RoleName: !Sub ${AWS::StackName}-RunbookF2fResetRole
       Description: "This role allows approved support team to perform pending F2F reset"
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
-            Action: "sts:AssumeRole"
-            Condition:
-              ArnLike:
-                aws:PrincipalARN:
-                  !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedServiceSupport*
-      ManagedPolicyArns:
-        - !Ref ManualF2fPendingResetFunctionManagedPolicy
-      MaxSessionDuration: 43200
-      Path: /runbooks/
-
-  IAMRoleCreationTest:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: !Sub ${AWS::StackName}-Create
-      Description: "Test role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -799,7 +799,7 @@ Resources:
   ManualF2fPendingResetFunctionInvokeRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: RunbookF2fResetRole
+      RoleName: /runbooks/RunbookF2fResetRole
       Description: "This role allows approved support team to perform pending F2F reset"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -820,7 +820,10 @@ Resources:
                   !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedServiceSupport*
       ManagedPolicyArns:
         - !Ref ManualF2fPendingResetFunctionManagedPolicy
-      PermissionsBoundary: !Sub "${PermissionsBoundary}"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
       MaxSessionDuration: 43200
       Path: /runbooks/
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -799,7 +799,7 @@ Resources:
   ManualF2fPendingResetFunctionInvokeRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: RunbookF2fResetRole
+      RoleName: !Sub ${AWS::StackName}-RunbookF2fResetRole
       Description: "This role allows approved support team to perform pending F2F reset"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -756,12 +756,15 @@ Resources:
                 StringEquals:
                   "lambda:VpcIds":
                     - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+            - Sid: AllowGetDeleteCriResponseDynamoDbTable
+              Effect: Allow
+              Action:
+                - 'dynamodb:GetItem'
+                - 'dynamodb:DeleteItem'
+              Resource:
+                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/cri-response
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
-        - DynamoDBReadPolicy:
-            TableName: !Ref CRIResponseTable
-        - DynamoDBCrudPolicy:
-            TableName: !Ref CRIResponseTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*
       AutoPublishAlias: live

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -799,7 +799,7 @@ Resources:
   ManualF2fPendingResetFunctionInvokeRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: /runbooks/RunbookF2fResetRole
+      RoleName: RunbookF2fResetRole
       Description: "This role allows approved support team to perform pending F2F reset"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -132,6 +132,10 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsBuildStagingProd: !Or
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -776,6 +780,45 @@ Resources:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Ref ManualF2fPendingResetFunctionLogGroup
+
+  ManualF2fPendingResetFunctionManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: IsBuildStagingProd
+    Properties:
+      ManagedPolicyName: ManualF2fPendingResetManagedPolicy
+      Description: Allows invoking the ManualF2f Lambda
+      Path: /runbooks/runbook-f2f-reset/
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+              - lambda:GetFunction
+            Resource:
+              - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:manual-f2f-pending-reset-${Environment}
+
+  ManualF2fPendingResetFunctionInvokeRole:
+    Type: AWS::IAM::Role
+    Condition: IsBuildStagingProd
+    Properties:
+      RoleName: RunbookF2fResetRole
+      Description: "This role allows approved support team to perform pending F2F reset"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: "sts:AssumeRole"
+            Condition:
+              ArnLike:
+                aws:PrincipalARN:
+                  !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedServiceSupport*
+      ManagedPolicyArns:
+        - !Ref ManualF2fPendingResetFunctionManagedPolicy
+      MaxSessionDuration: 43200
+      Path: /runbooks/runbook-f2f-reset/
 
   IssueClientAccessTokenFunction:
     Type: AWS::Serverless::Function

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -132,10 +132,6 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
-  IsBuildStagingProd: !Or
-    - !Equals [ !Ref Environment, build ]
-    - !Equals [ !Ref Environment, staging ]
-    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -786,7 +782,6 @@ Resources:
 
   ManualF2fPendingResetFunctionManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
-    Condition: IsBuildStagingProd
     Properties:
       ManagedPolicyName: ManualF2fPendingResetManagedPolicy
       Description: Allows invoking the ManualF2f Lambda
@@ -803,7 +798,6 @@ Resources:
 
   ManualF2fPendingResetFunctionInvokeRole:
     Type: AWS::IAM::Role
-    Condition: IsBuildStagingProd
     Properties:
       RoleName: RunbookF2fResetRole
       Description: "This role allows approved support team to perform pending F2F reset"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -785,7 +785,7 @@ Resources:
     Properties:
       ManagedPolicyName: ManualF2fPendingResetManagedPolicy
       Description: Allows invoking the ManualF2f Lambda
-      Path: /runbooks/runbook-f2f-reset/
+      Path: /runbooks/
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -815,7 +815,7 @@ Resources:
       ManagedPolicyArns:
         - !Ref ManualF2fPendingResetFunctionManagedPolicy
       MaxSessionDuration: 43200
-      Path: /runbooks/runbook-f2f-reset/
+      Path: /runbooks/
 
   IssueClientAccessTokenFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-back#3261

Original PR
https://github.com/govuk-one-login/ipv-core-back/pull/3255

## Proposed changes
### What changed

- Added Managed Policy for manualF2fReset lambda that allows to read that specific lambda and invoke it
- Added IAM Role with assumed policy for ApprovedServiceSupport

### Why did it change

- As we created manualF2fReset lambda we need to allow TSD to execute it and nothing more.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8306](https://govukverify.atlassian.net/browse/PYIC-8306)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8306]: https://govukverify.atlassian.net/browse/PYIC-8306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ