### PR TITLE
PYIC-8461: add log for number of session credentials retrieved

### DIFF
--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -63,6 +63,11 @@ public class SessionCredentialsService {
                         VerifiableCredential.fromSessionCredentialItem(credential, userId));
             }
 
+            LOGGER.info(
+                    LogHelper.buildLogMessage(
+                                    "Successfully retrieved and parsed session credential items")
+                            .with("numberOfCredentialsRetrieved", credentials.size()));
+
             return verifiableCredentialList;
         } catch (CredentialParseException e) {
             LOGGER.error(LogHelper.buildErrorMessage("Error parsing session credential item", e));


### PR DESCRIPTION
## Proposed changes
### What changed

- Adding log for number of session credential items retrieved when we read from the session credentials table

### Why did it change

- There was a bug [here](https://govukverify.atlassian.net/browse/SPT-1545?focusedCommentId=233730) where SPOT received a user's TICF + CIMIT VCs but not their identity VCs. Adding this log so it can help debug this issue further if it were to happen again

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8461](https://govukverify.atlassian.net/browse/PYIC-8461)

## Checklists
- [x] No risk of exposure: PII, credentials, etc through logs/ code


[PYIC-8461]: https://govukverify.atlassian.net/browse/PYIC-8461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ