### PR TITLE
BAU Log request timeouts at WARN level

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClient.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/tracing/TracingHttpClient.java
@@ -54,8 +54,8 @@ public class TracingHttpClient extends HttpClient {
         try {
             return baseClient.send(request, responseBodyHandler);
         } catch (IOException e) {
-            LOGGER.error(LogHelper.buildErrorMessage("HTTP request failed with IOException", e));
             if (e instanceof HttpTimeoutException) {
+                LOGGER.warn(LogHelper.buildErrorMessage("HTTP request timed out", e));
                 throw e;
             }
             // We occasionally see HTTP/2 GOAWAY messages and in build we occasionally see
@@ -74,6 +74,7 @@ public class TracingHttpClient extends HttpClient {
                     throw new UncheckedIOException(ex);
                 }
             }
+            LOGGER.error(LogHelper.buildErrorMessage("HTTP request failed with IOException", e));
             // Rethrow any other IOException as unchecked exception
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
## Proposed changes
### What changed

Log request timeouts at WARN rather than ERROR level in the base HTTP client

### Why did it change

Request timeouts are expected, particularly now TICF CRI has exited dark mode (for which we've currently configured a 1 second timeout in prod) and logging at ERROR level generates a distracting amount of noise in the logs. We're throwing the exception for the caller to handle anyway
