### PR TITLE
Pyic 8358 Fix Manual f2f lambda SQS configuration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -723,6 +723,7 @@ Resources:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub manual-f2f-pending-reset-${Environment}
           CRI_RESPONSE_TABLE_NAME: !Ref CRIResponseTable
+          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
           AWS_LAMBDA_EXEC_WRAPPER: !If
             - UseDynatrace
             - /opt/dynatrace
@@ -772,6 +773,16 @@ Resources:
             TableName: !Ref CRIResponseTable
         - SSMParameterReadPolicy:
             ParameterName: !Sub ${Environment}/core/*
+        - SQSSendMessagePolicy:
+            QueueName: !ImportValue AuditEventQueueName
+        - Statement:
+            - Sid: kmsAuditEventQueueEncryptionKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:Decrypt'
+                - 'kms:GenerateDataKey'
+              Resource:
+                - !ImportValue AuditEventQueueEncryptionKeyArn
       AutoPublishAlias: live
 
   ManualF2fPendingResetFunctionLogGroup:

--- a/lambdas/manual-f2f-pending-reset/src/main/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandler.java
+++ b/lambdas/manual-f2f-pending-reset/src/main/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandler.java
@@ -90,6 +90,8 @@ public class ManualF2fPendingResetHandler implements RequestHandler<String, Map<
             LOGGER.error(LogHelper.buildErrorMessage("Failed to delete record", e));
             response.put(RESULT_KEY, RESULT_ERROR);
             response.put(MESSAGE_KEY, "Failed to delete record due to internal error.");
+        } finally {
+            auditService.awaitAuditEvents();
         }
 
         return response;

--- a/lambdas/manual-f2f-pending-reset/src/test/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandlerTest.java
+++ b/lambdas/manual-f2f-pending-reset/src/test/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandlerTest.java
@@ -134,6 +134,7 @@ class ManualF2fPendingResetHandlerTest {
 
         assertEquals(IPV_F2F_SUPPORT_CANCEL, auditEvent.getEventName());
         assertEquals(TEST_USER_ID, auditEvent.getUser().getUserId());
+        verify(auditService, times(1)).awaitAuditEvents();
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes
### What changed

- Added required configuration to send audit event for queue in manual f2f reset lambda.

### Why did it change

- Without this configuration, event can not be lunched to the queue.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8358](https://govukverify.atlassian.net/browse/PYIC-8358)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8358]: https://govukverify.atlassian.net/browse/PYIC-8358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ