### PR TITLE
PYIC-8104: update jose in /api-tests

### DIFF
--- a/api-tests/package-lock.json
+++ b/api-tests/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "17.0.1",
         "eslint": "8.57.0",
         "eslint-config-prettier": "10.1.1",
-        "jose": "5.10.0",
+        "jose": "6.0.6",
         "jsonschema": "1.5.0",
         "prettier": "3.6.0",
         "start-server-and-test": "2.0.4",
@@ -2272,11 +2272,10 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.6.tgz",
+      "integrity": "sha512-FFF9x3KcdRJgQo74X8e6I4D1h3Wtd27fEo0suijveKFc+HFz6M5gonqxFPnDos9ulJFRqMNqWI6NexiHQPSnfQ==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/api-tests/package.json
+++ b/api-tests/package.json
@@ -21,7 +21,7 @@
     "dotenv": "17.0.1",
     "eslint": "8.57.0",
     "eslint-config-prettier": "10.1.1",
-    "jose": "5.10.0",
+    "jose": "6.0.6",
     "jsonschema": "1.5.0",
     "prettier": "3.6.0",
     "start-server-and-test": "2.0.4",

--- a/local-running/core.local.secrets.template.yaml
+++ b/local-running/core.local.secrets.template.yaml
@@ -10,7 +10,8 @@ core:
       "crv": "P-256",
       "d": "OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU",
       "x": "E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM",
-      "y": "KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"
+      "y": "KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04",
+      "alg": "ES256"
     }'
     # This test encryption key is only used locally
     # pragma: allowlist nextline secret


### PR DESCRIPTION
## Proposed changes
### What changed

- update jose to 6.0.6
- update local config to have an "alg" property

### Why did it change

- "alg" property missing from one of our enc keys was causing the jwks api test to fail

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8104](https://govukverify.atlassian.net/browse/PYIC-8104)


[PYIC-8104]: https://govukverify.atlassian.net/browse/PYIC-8104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ