### PR TITLE
Pyic 8457

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -206,7 +206,7 @@ Mappings:
       asyncCriLambdaTimeout: 30
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
-      opentelemetryLayerArn: arn:aws:lambda:eu-west-2:901920570463:layer:aws-otel-java-wrapper-arm64-ver-1-32-0:6
+      opentelemetryLayerArn: arn:aws:lambda:eu-west-2:457601271792:layer:aws-otel-java-wrapper-arm64-ver-1-32-0-6:1
       dynatraceOtlpSecretArn: arn:aws:secretsmanager:eu-west-2:457601271792:secret:dynatrace_api_token_otlp # pragma: allowlist secret
     "335257547869": # Staging
       environment: staging

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2921,12 +2921,22 @@ Resources:
             - !Ref AWS::NoValue
           AWS_LAMBDA_EXEC_WRAPPER: !If
             - UseDynatrace
-            - /opt/dynatrace
+            - !If
+              - IsBuild
+              - /opt/otel-handler
+              - /opt/dynatrace
             - !Ref AWS::NoValue
       Layers:
         - !If
           - UseDynatrace
-          - !FindInMap [
+          - !If
+            - IsBuild
+            - !FindInMap [
+              EnvironmentConfiguration,
+              !Ref 'AWS::AccountId',
+              opentelemetryLayerArn
+            ]
+            - !FindInMap [
               EnvironmentConfiguration,
               !Ref 'AWS::AccountId',
               dynatraceLayerArn,


### PR DESCRIPTION
## Proposed changes
### What changed

We couldn't use the layer directly from the 3rd party because it needs to be signed so I've manually downloaded it, signed it and published it in our build environment.

Switch out the layer arn for that one while we wait to hear back from the Observability team about them doing it properly, the way they do for Dynatrace.

