### PR TITLE
PYIC-8254: Add POST /identity & /identity/invalidate contract tests

### DIFF
--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
@@ -192,7 +192,8 @@ public class EvcsClient {
         }
     }
 
-    public void invalidateStoredIdentityRecord(String userId) throws EvcsServiceException {
+    public HttpResponse<String> invalidateStoredIdentityRecord(String userId)
+            throws EvcsServiceException {
         LOGGER.info(
                 LogHelper.buildLogMessage("Preparing to invalidate user's stored identity record"));
         try {
@@ -208,7 +209,7 @@ public class EvcsClient {
                                     configService.getSecret(ConfigurationVariable.EVCS_API_KEY))
                             .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
 
-            sendHttpRequest(httpRequestBuilder.build());
+            return sendHttpRequest(httpRequestBuilder.build());
         } catch (URISyntaxException e) {
             throw new EvcsServiceException(
                     HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_CONSTRUCT_EVCS_URI);

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
@@ -521,7 +521,7 @@ class ContractTest {
     public RequestResponsePact nullBodyPostIdentityReturns400(PactDslWithProvider builder) {
         return builder.given("EVCS client exist")
                 .given("test-evcs-api-key is a valid API key")
-                .uponReceiving("A request to create a stored identity in EVCS, with null user id")
+                .uponReceiving("A request to create a stored identity in EVCS, with null body")
                 .path("/identity")
                 .method("POST")
                 .headers(

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
@@ -103,7 +103,6 @@ class ContractTest {
                 .thenReturn(EVCS_API_KEY);
     }
 
-    // GET /vcs/{userId}
     @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
     public RequestResponsePact validRetrieveVcRequestReturnsUsersVcWith200(
             PactDslWithProvider builder) {
@@ -261,7 +260,6 @@ class ContractTest {
                 });
     }
 
-    // POST /vcs/{userId}
     @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
     public RequestResponsePact validCreateUserVcReturnsMessageIdWith202(
             PactDslWithProvider builder) {
@@ -389,7 +387,6 @@ class ContractTest {
                 });
     }
 
-    // PATCH /vcs/{userId}
     @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
     public RequestResponsePact validUpdateUserVcReturnsMessageIdWith204(
             PactDslWithProvider builder) {
@@ -475,7 +472,6 @@ class ContractTest {
                 });
     }
 
-    // POST /identity
     @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
     public RequestResponsePact postIdentityReturns202(PactDslWithProvider builder) {
         return builder.given("EVCS client exist")
@@ -803,7 +799,6 @@ class ContractTest {
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getResponseCode());
     }
 
-    // POST /identity/invalidate
     @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
     public RequestResponsePact postIdentityInvalidateReturns204(PactDslWithProvider builder) {
         return builder.given("EVCS client exist")


### PR DESCRIPTION
## Proposed changes
### What changed

- Add POST /identity & /identity/invalidate contract tests.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8254](https://govukverify.atlassian.net/browse/PYIC-8254)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8254]: https://govukverify.atlassian.net/browse/PYIC-8254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ