### PR TITLE
PYIC-8413: Enable rebrand for local running

### DIFF
--- a/local-running/compose.yaml
+++ b/local-running/compose.yaml
@@ -49,6 +49,7 @@ services:
       PORT: 4501
       LANGUAGE_TOGGLE: true
       USE_DEVICE_INTELLIGENCE: true
+      MAY_2025_REBRAND_ENABLED: true
       CDN_DOMAIN:
       ENABLE_PREVIEW: "development"
       NPM_CONFIG_NODE_OPTIONS: "--inspect=0.0.0.0"


### PR DESCRIPTION
## Proposed changes
### What changed

Turn on new branding for local running

### Why did it change

So that local snapshot tests work and the team can see the new branding

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8413](https://govukverify.atlassian.net/browse/PYIC-8413)


[PYIC-8413]: https://govukverify.atlassian.net/browse/PYIC-8413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ