### PR TITLE
PYIC-8502: Remove v2 app from reverification journey

### DIFF
--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -7,7 +7,6 @@ Feature: MFA reset journey
         | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
-      And I activate the 'disableStrategicApp' feature set
 
       # Start MFA reset journey
       When I start a new 'reverification' journey
@@ -137,133 +136,32 @@ Feature: MFA reset journey
       When I submit a 'next' event
       Then I get a 'dcmaw' CRI response
 
-  Rule: User has an existing identity and uses the strategic app
-    Background:
+  Rule: User has an existing identity and strategic app is enabled
+    Background: There is an existing user and they start an MFA reset journey
       Given the subject already has the following credentials
         | CRI     | scenario                     |
         | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
-      And I activate the 'strategicApp,drivingLicenceAuthCheck' feature set
+      # Even when the v2 app is enabled the reverification journey should use the v1 app as the user won't be
+      # able to log in to the v2 app to use it.
+      And I activate the 'strategicApp' feature set
 
       # Start MFA reset journey
       When I start a new 'reverification' journey
       Then I get a 'you-can-change-security-code-method' page response
+
+    Scenario: Successful MFA reset journey still using v1 app
       When I submit a 'next' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
-      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-
-    @InitialisesDCMAWSessionState
-    Scenario: MAM, abandon
-      When I submit an 'anotherWay' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my MFA reset result
-      Then I get an unsuccessful MFA reset result with failure code 'identity_check_incomplete'
-
-    @InitialisesDCMAWSessionState
-    Scenario: MAM, successful
-      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
-      # And the user returns from the app to core-front
-      And I pass on the DCMAW callback
-      Then I get a 'check-mobile-app-result' page response
-      When I poll for async DCMAW credential receipt
-      Then the poll returns a '201'
-      When I submit the returned journey event
-      Then I get a 'drivingLicence' CRI response
-      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
-        | Attribute | Values          |
-        | context   | "check_details" |
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
       Then I get a 'we-matched-you-to-your-one-login' page response
       When I submit a 'next' event
       Then I get an OAuth response
       When I use the OAuth response to get my MFA reset result
       Then I get a successful MFA reset result
-
-    @InitialisesDCMAWSessionState
-    Scenario: MAM, incomplete DL auth check
-      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
-      # And the user returns from the app to core-front
-      And I pass on the DCMAW callback
-      Then I get a 'check-mobile-app-result' page response
-      When I poll for async DCMAW credential receipt
-      Then the poll returns a '201'
-      When I submit the returned journey event
-      Then I get a 'drivingLicence' CRI response
-      When I call the CRI stub and get an 'access_denied' OAuth error
-      Then I get a 'uk-driving-licence-details-not-correct' page response with context 'strategicApp'
-      When I submit an 'end' event
-      Then I get a 'prove-identity-another-way' page response with context 'noF2f'
-
-      # User gives up
-      When I submit a 'returnToRp' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my MFA reset result
-      Then I get an unsuccessful MFA reset result with failure code 'identity_check_incomplete'
-
-    @InitialisesDCMAWSessionState
-    Scenario: MAM, retry from incomplete DL auth check
-      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
-      # And the user returns from the app to core-front
-      And I pass on the DCMAW callback
-      Then I get a 'check-mobile-app-result' page response
-      When I poll for async DCMAW credential receipt
-      Then the poll returns a '201'
-      When I submit the returned journey event
-      Then I get a 'drivingLicence' CRI response
-      When I call the CRI stub and get an 'access_denied' OAuth error
-      Then I get a 'uk-driving-licence-details-not-correct' page response with context 'strategicApp'
-      When I submit an 'end' event
-      Then I get a 'prove-identity-another-way' page response with context 'noF2f'
-
-      # User trys again
-      When I submit an 'anotherTypePhotoId' event
-      Then I get a 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
-      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
-      # And the user returns from the app to core-front
-      And I pass on the DCMAW callback
-      Then I get a 'check-mobile-app-result' page response
-      When I poll for async DCMAW credential receipt
-      Then the poll returns a '201'
-      When I submit the returned journey event
-      Then I get a 'drivingLicence' CRI response
-      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
-        | Attribute | Values          |
-        | context   | "check_details" |
-      Then I get a 'we-matched-you-to-your-one-login' page response
-      When I submit a 'next' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my MFA reset result
-      Then I get a successful MFA reset result
-
-    @InitialisesDCMAWSessionState
-    Scenario: MAM, alternate doc failure
-      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
-      # And the user returns from the app to core-front
-      And I pass on the DCMAW callback
-      Then I get a 'check-mobile-app-result' page response
-      When I poll for async DCMAW credential receipt
-      Then the poll returns a '201'
-      When I submit the returned journey event
-      Then I get a 'drivingLicence' CRI response
-      When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
-        | Attribute | Values          |
-        | context   | "check_details" |
-      Then I get an OAuth response
-      When I use the OAuth response to get my MFA reset result
-      Then I get an unsuccessful MFA reset result with failure code 'identity_check_failed'
 
   Rule: The user has no existing identity
     Scenario: Attempted MFA reset journey

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -85,9 +85,6 @@ states:
       appTriage:
         targetState: APP_DOC_CHECK
         targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
         checkIfDisabled:
           dcmaw:
             targetJourney: TECHNICAL_ERROR
@@ -95,34 +92,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
-
-  STRATEGIC_APP_TRIAGE:
-    nestedJourney: STRATEGIC_APP_TRIAGE
-    exitEvents:
-      next:
-        targetState: PROCESS_REVERIFICATION_IDENTITY
-      anotherWay:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE_SKIP_MESSAGE
-      returnToRp:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
-      incompleteDlAuthCheckInvalidDl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_STRATEGIC_APP
-      failedDlAuthCheckInvalidDl:
-        targetJourney: FAILED
-        targetState: FAILED_SKIP_MESSAGE
-
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_STRATEGIC_APP:
-    response:
-      type: page
-      pageId: prove-identity-another-way
-      context: noF2f
-    events:
-      anotherTypePhotoId:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
-      returnToRp:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   APP_DOC_CHECK:
     nestedJourney: APP_DOC_CHECK
@@ -173,24 +142,6 @@ states:
       coi-check-failed:
         targetJourney: FAILED
         targetState: FAILED_SKIP_MESSAGE
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-
-  PROCESS_INCOMPLETE_IDENTITY:
-    response:
-      type: process
-      lambda: process-candidate-identity
-      lambdaInput:
-        identityType: INCOMPLETE
-    events:
-      next:
-        targetState: RETURN_TO_RP
-      account-intervention:
-        targetJourney: FAILED
-        targetState: FAILED_ACCOUNT_INTERVENTION
-      fail-with-ci:
-        targetState: RETURN_TO_RP
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR


### PR DESCRIPTION
## Proposed changes
### What changed

Reverification journey now always uses the v1 app

### Why did it change

Using the v2 app breaks the journey

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8502](https://govukverify.atlassian.net/browse/PYIC-8502)


[PYIC-8502]: https://govukverify.atlassian.net/browse/PYIC-8502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ