### PR TITLE
PYIC-4934: cleanup old kbv cri

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -39,18 +39,6 @@ nestedJourneyStates:
         exitEventToEmit: next
       fail-with-ci:
         exitEventToEmit: fail-with-ci
-  CRI_EXPERIAN_KBV:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
-      fail-with-no-ci:
-        exitEventToEmit: fail-with-no-ci
-      next:
-        exitEventToEmit: next
-      fail-with-ci:
-        exitEventToEmit: fail-with-ci
   PRE_EXPERIAN_PAGE:
     response:
       type: page

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
@@ -17,7 +17,6 @@ public enum Cri {
     DRIVING_LICENCE("drivingLicence"),
     DWP_KBV("dwpKbv"),
     EXPERIAN_FRAUD("fraud"),
-    KBV("kbv"),
     EXPERIAN_KBV("experianKbv"),
     F2F("f2f"),
     HMRC_MIGRATION("hmrcMigration", true),
@@ -27,7 +26,7 @@ public enum Cri {
 
     private final String id;
     private final boolean isOperationalCri;
-    private static final Set<Cri> KBV_CRIS = Set.of(DWP_KBV, KBV, EXPERIAN_KBV);
+    private static final Set<Cri> KBV_CRIS = Set.of(DWP_KBV, EXPERIAN_KBV);
     private static final String EXPERIAN_KBV_REDIRECT_ID = "kbv";
 
     Cri(String id) {

--- a/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45IdentityCheckValidator.java
+++ b/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45IdentityCheckValidator.java
@@ -23,7 +23,7 @@ public class Gpg45IdentityCheckValidator {
         return switch (cri) {
             case BAV, DRIVING_LICENCE, PASSPORT -> isEvidenceSuccessful(identityCheck);
             case EXPERIAN_FRAUD -> isFraudCheckSuccessful(identityCheck);
-            case DWP_KBV, KBV, EXPERIAN_KBV -> isVerificationSuccessful(identityCheck);
+            case DWP_KBV, EXPERIAN_KBV -> isVerificationSuccessful(identityCheck);
             case DCMAW, DCMAW_ASYNC, F2F, HMRC_MIGRATION ->
                     isEvidenceSuccessful(identityCheck) && isVerificationSuccessful(identityCheck);
             case NINO -> isNinoSuccessful(identityCheck);


### PR DESCRIPTION
## Proposed changes
### What changed

- removed old KBV CRI state
- removed old KBV id from CRI enum

### Why did it change

- we want to update `kbv` criId to `experianKbv`. This is one of the cleanup PRs.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-4934](https://govukverify.atlassian.net/browse/PYIC-4934)

## Checklists

- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-4934]: https://govukverify.atlassian.net/browse/PYIC-4934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ