### PR TITLE
PYIC-8506: Modify intervention-handling to use exceptions

### DIFF
--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -529,7 +529,6 @@ public class ProcessCandidateIdentityHandler
                             auditEventParameters);
 
             if (journey != null) {
-                LOGGER.error(String.format("MIKE2! %s %s", journey, processIdentityType));
                 // We still store a pending identity - it might be mitigating an existing CI
                 if (PENDING.equals(processIdentityType)) {
                     LOGGER.info(LogHelper.buildLogMessage("Storing identity"));

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/exception/AccountInterventionException.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/exception/AccountInterventionException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.ipv.core.library.ais.exception;
+
+public class AccountInterventionException extends Exception {
+    public AccountInterventionException() {
+        super("Account intervention.");
+    }
+}

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/exception/AccountInterventionException.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/exception/AccountInterventionException.java
@@ -1,5 +1,8 @@
 package uk.gov.di.ipv.core.library.ais.exception;
 
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
 public class AccountInterventionException extends Exception {
     public AccountInterventionException() {
         super("Account intervention.");

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/exception/AccountInterventionException.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/exception/AccountInterventionException.java
@@ -5,6 +5,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 @ExcludeFromGeneratedCoverageReport
 public class AccountInterventionException extends Exception {
     public AccountInterventionException() {
-        super("Account intervention.");
+        super(
+                "Account intervention. This is thrown when an intervention has been discovered in ProcessCandidateIdentity.");
     }
 }


### PR DESCRIPTION
## Proposed changes
### What changed

- Break from ProcessCandidateIdentityHandler when account intervention detected.

### Why did it change

- So TICF intervention skips following code, like for AIS in ProcessCandidateIdentityHandler

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8506](https://govukverify.atlassian.net/browse/PYIC-8506)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8506]: https://govukverify.atlassian.net/browse/PYIC-8506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ