### PR TITLE
BAU: Fix null reference exception by not calling AIS when we don't have a user ID

### DIFF
--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -267,10 +267,11 @@ public class ProcessCandidateIdentityHandler
 
             String userId = clientOAuthSessionItem.getUserId();
 
-            // We skip AIS checks for reverification journeys
+            // We skip AIS checks for reverification journeys or if we don't have a user ID to check
+            // against (in some error cases)
             if (configService.enabled(AIS_ENABLED)
                     && !SKIP_AIS_TYPES.contains(processIdentityType)
-                    && userId != null) {
+                    && !StringUtils.isBlank(userId)) {
                 var interventionState = aisService.fetchAccountState(userId);
                 if (midJourneyInterventionDetected(
                         ipvSessionItem.getInitialAccountInterventionState(), interventionState)) {

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -269,7 +269,8 @@ public class ProcessCandidateIdentityHandler
 
             // We skip AIS checks for reverification journeys
             if (configService.enabled(AIS_ENABLED)
-                    && !SKIP_AIS_TYPES.contains(processIdentityType)) {
+                    && !SKIP_AIS_TYPES.contains(processIdentityType)
+                    && userId != null) {
                 var interventionState = aisService.fetchAccountState(userId);
                 if (midJourneyInterventionDetected(
                         ipvSessionItem.getInitialAccountInterventionState(), interventionState)) {


### PR DESCRIPTION

## Proposed changes
### What changed

Don't call AIS when we don't have a user ID

### Why did it change

It doesn't make sense and was causing a null reference exception

