### PR TITLE
PYIC-4934: add support for experianKbv criId without updating journey…

### DIFF
--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_KBV;
+import static uk.gov.di.ipv.core.library.domain.Cri.KBV;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 
@@ -116,9 +116,7 @@ class CredentialTests {
         // Act
         var verifiableCredentialResponse =
                 underTest.fetchVerifiableCredential(
-                        new BearerAccessToken("dummyAccessToken"),
-                        EXPERIAN_KBV,
-                        getCriOAuthSessionItem());
+                        new BearerAccessToken("dummyAccessToken"), KBV, getCriOAuthSessionItem());
 
         // Assert
         var verifiableCredentialJwtValidator = getVerifiableCredentialValidator();
@@ -130,7 +128,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                EXPERIAN_KBV,
+                                                KBV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -247,9 +245,7 @@ class CredentialTests {
         // Act
         var verifiableCredentialResponse =
                 underTest.fetchVerifiableCredential(
-                        new BearerAccessToken("dummyAccessToken"),
-                        EXPERIAN_KBV,
-                        getCriOAuthSessionItem());
+                        new BearerAccessToken("dummyAccessToken"), KBV, getCriOAuthSessionItem());
 
         // Assert
         var verifiableCredentialJwtValidator = getVerifiableCredentialValidator();
@@ -261,7 +257,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                EXPERIAN_KBV,
+                                                KBV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -354,7 +350,7 @@ class CredentialTests {
                         () ->
                                 underTest.fetchVerifiableCredential(
                                         new BearerAccessToken("dummyInvalidAccessToken"),
-                                        EXPERIAN_KBV,
+                                        KBV,
                                         getCriOAuthSessionItem()));
 
         // Assert
@@ -423,9 +419,7 @@ class CredentialTests {
         // Act
         var verifiableCredentialResponse =
                 underTest.fetchVerifiableCredential(
-                        new BearerAccessToken("dummyAccessToken"),
-                        EXPERIAN_KBV,
-                        getCriOAuthSessionItem());
+                        new BearerAccessToken("dummyAccessToken"), KBV, getCriOAuthSessionItem());
 
         // Assert
         var verifiableCredentialJwtValidator = getVerifiableCredentialValidator();
@@ -437,7 +431,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                EXPERIAN_KBV,
+                                                KBV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -545,11 +539,7 @@ class CredentialTests {
     @NotNull
     private static CriOAuthSessionItem getCriOAuthSessionItem() {
         return new CriOAuthSessionItem(
-                "dummySessionId",
-                "dummyOAuthSessionId",
-                EXPERIAN_KBV.getId(),
-                "dummyConnection",
-                900);
+                "dummySessionId", "dummyOAuthSessionId", KBV.getId(), "dummyConnection", 900);
     }
 
     @NotNull

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/TokenTests.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_KBV;
+import static uk.gov.di.ipv.core.library.domain.Cri.KBV;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EXAMPLE_GENERATED_SECURE_TOKEN;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
@@ -201,18 +201,14 @@ class TokenTests {
     @NotNull
     private static CriOAuthSessionItem getCriOAuthSessionItem() {
         return new CriOAuthSessionItem(
-                "dummySessionId",
-                "dummyOAuthSessionId",
-                EXPERIAN_KBV.getId(),
-                "dummyConnection",
-                900);
+                "dummySessionId", "dummyOAuthSessionId", KBV.getId(), "dummyConnection", 900);
     }
 
     @NotNull
     private static CriCallbackRequest getCallbackRequest(String authCode) {
         return new CriCallbackRequest(
                 authCode,
-                EXPERIAN_KBV.getId(),
+                KBV.getId(),
                 "dummySessionId",
                 "https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv",
                 "dummyState",

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
@@ -17,7 +17,8 @@ public enum Cri {
     DRIVING_LICENCE("drivingLicence"),
     DWP_KBV("dwpKbv"),
     EXPERIAN_FRAUD("fraud"),
-    EXPERIAN_KBV("kbv"),
+    KBV("kbv"),
+    EXPERIAN_KBV("experianKbv"),
     F2F("f2f"),
     HMRC_MIGRATION("hmrcMigration", true),
     NINO("nino"),
@@ -26,7 +27,7 @@ public enum Cri {
 
     private final String id;
     private final boolean isOperationalCri;
-    private static final Set<Cri> KBV_CRIS = Set.of(DWP_KBV, EXPERIAN_KBV);
+    private static final Set<Cri> KBV_CRIS = Set.of(DWP_KBV, KBV, EXPERIAN_KBV);
 
     Cri(String id) {
         this(id, false);

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -1249,7 +1249,7 @@ public interface VcFixtures {
     static VerifiableCredential vcExperianKbvM1a() {
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                Cri.EXPERIAN_KBV,
+                Cri.KBV,
                 vcClaimExperianKbv(),
                 EXPERIAN_KBV_ISSUER_INTEGRATION,
                 Instant.ofEpochSecond(1653403140));

--- a/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45IdentityCheckValidator.java
+++ b/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45IdentityCheckValidator.java
@@ -23,7 +23,7 @@ public class Gpg45IdentityCheckValidator {
         return switch (cri) {
             case BAV, DRIVING_LICENCE, PASSPORT -> isEvidenceSuccessful(identityCheck);
             case EXPERIAN_FRAUD -> isFraudCheckSuccessful(identityCheck);
-            case DWP_KBV, EXPERIAN_KBV -> isVerificationSuccessful(identityCheck);
+            case DWP_KBV, KBV, EXPERIAN_KBV -> isVerificationSuccessful(identityCheck);
             case DCMAW, DCMAW_ASYNC, F2F, HMRC_MIGRATION ->
                     isEvidenceSuccessful(identityCheck) && isVerificationSuccessful(identityCheck);
             case NINO -> isNinoSuccessful(identityCheck);


### PR DESCRIPTION
… map

## Proposed changes
### What changed

- add support for experianKbv criId without updating journey map

### Why did it change

- updating the journey map at the same time was causing errors during canary deployment as a mixture of new and old versions of externally called lambdas which meant some supported the new criId whilst old ones didn't

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-4934](https://govukverify.atlassian.net/browse/PYIC-4934)



[PYIC-4934]: https://govukverify.atlassian.net/browse/PYIC-4934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ