### PR TITLE
PYIC-8464: update new identity journey map descriptions

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -1,7 +1,7 @@
 name: New P1 Identity
 description: >-
-  The routes a user can take to prove their identity to a low
-  confidence level (P1).
+  The routes a user can take to prove their identity to at least
+  a low confidence level (P1).
 
 states:
   # Entry points

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1,7 +1,7 @@
 name: New P2 Identity
 description: >-
-  The routes a user can take to prove their identity to a medium
-  confidence level (P2).
+  The routes a user can take to prove their identity to at least
+  a medium confidence level (P2).
 
 states:
   # Entry points


### PR DESCRIPTION
## Proposed changes
### What changed

- Update new identity low/medium confidence journey maps to make it clearer that a higher LoC can be reached with those journeys

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8464](https://govukverify.atlassian.net/browse/PYIC-8464)



[PYIC-8464]: https://govukverify.atlassian.net/browse/PYIC-8464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ