### PR TITLE
PYIC-4934: remove old KBV from CRI enum and remove unused CRI_EXPERIA…

### DIFF
--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.domain.Cri.KBV;
+import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_KBV;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
 
@@ -116,7 +116,9 @@ class CredentialTests {
         // Act
         var verifiableCredentialResponse =
                 underTest.fetchVerifiableCredential(
-                        new BearerAccessToken("dummyAccessToken"), KBV, getCriOAuthSessionItem());
+                        new BearerAccessToken("dummyAccessToken"),
+                        EXPERIAN_KBV,
+                        getCriOAuthSessionItem());
 
         // Assert
         var verifiableCredentialJwtValidator = getVerifiableCredentialValidator();
@@ -128,7 +130,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                KBV,
+                                                EXPERIAN_KBV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -245,7 +247,9 @@ class CredentialTests {
         // Act
         var verifiableCredentialResponse =
                 underTest.fetchVerifiableCredential(
-                        new BearerAccessToken("dummyAccessToken"), KBV, getCriOAuthSessionItem());
+                        new BearerAccessToken("dummyAccessToken"),
+                        EXPERIAN_KBV,
+                        getCriOAuthSessionItem());
 
         // Assert
         var verifiableCredentialJwtValidator = getVerifiableCredentialValidator();
@@ -257,7 +261,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                KBV,
+                                                EXPERIAN_KBV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -350,7 +354,7 @@ class CredentialTests {
                         () ->
                                 underTest.fetchVerifiableCredential(
                                         new BearerAccessToken("dummyInvalidAccessToken"),
-                                        KBV,
+                                        EXPERIAN_KBV,
                                         getCriOAuthSessionItem()));
 
         // Assert
@@ -419,7 +423,9 @@ class CredentialTests {
         // Act
         var verifiableCredentialResponse =
                 underTest.fetchVerifiableCredential(
-                        new BearerAccessToken("dummyAccessToken"), KBV, getCriOAuthSessionItem());
+                        new BearerAccessToken("dummyAccessToken"),
+                        EXPERIAN_KBV,
+                        getCriOAuthSessionItem());
 
         // Assert
         var verifiableCredentialJwtValidator = getVerifiableCredentialValidator();
@@ -431,7 +437,7 @@ class CredentialTests {
                                 var vc =
                                         verifiableCredentialJwtValidator.parseAndValidate(
                                                 TEST_USER,
-                                                KBV,
+                                                EXPERIAN_KBV,
                                                 credential,
                                                 EC_PRIVATE_KEY_JWK,
                                                 TEST_ISSUER,
@@ -539,7 +545,11 @@ class CredentialTests {
     @NotNull
     private static CriOAuthSessionItem getCriOAuthSessionItem() {
         return new CriOAuthSessionItem(
-                "dummySessionId", "dummyOAuthSessionId", KBV.getId(), "dummyConnection", 900);
+                "dummySessionId",
+                "dummyOAuthSessionId",
+                EXPERIAN_KBV.getId(),
+                "dummyConnection",
+                900);
     }
 
     @NotNull

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/TokenTests.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.domain.Cri.KBV;
+import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_KBV;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EXAMPLE_GENERATED_SECURE_TOKEN;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
@@ -201,14 +201,18 @@ class TokenTests {
     @NotNull
     private static CriOAuthSessionItem getCriOAuthSessionItem() {
         return new CriOAuthSessionItem(
-                "dummySessionId", "dummyOAuthSessionId", KBV.getId(), "dummyConnection", 900);
+                "dummySessionId",
+                "dummyOAuthSessionId",
+                EXPERIAN_KBV.getId(),
+                "dummyConnection",
+                900);
     }
 
     @NotNull
     private static CriCallbackRequest getCallbackRequest(String authCode) {
         return new CriCallbackRequest(
                 authCode,
-                KBV.getId(),
+                EXPERIAN_KBV.getId(),
                 "dummySessionId",
                 "https://identity.staging.account.gov.uk/credential-issuer/callback?id=kbv",
                 "dummyState",

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -39,18 +39,6 @@ nestedJourneyStates:
         exitEventToEmit: next
       fail-with-ci:
         exitEventToEmit: fail-with-ci
-  CRI_EXPERIAN_KBV:
-    response:
-      type: cri
-      criId: kbv
-    parent: CRI_STATE
-    events:
-      fail-with-no-ci:
-        exitEventToEmit: fail-with-no-ci
-      next:
-        exitEventToEmit: next
-      fail-with-ci:
-        exitEventToEmit: fail-with-ci
   PRE_EXPERIAN_PAGE:
     response:
       type: page

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
@@ -17,7 +17,6 @@ public enum Cri {
     DRIVING_LICENCE("drivingLicence"),
     DWP_KBV("dwpKbv"),
     EXPERIAN_FRAUD("fraud"),
-    KBV("kbv"),
     EXPERIAN_KBV("experianKbv"),
     F2F("f2f"),
     HMRC_MIGRATION("hmrcMigration", true),
@@ -27,7 +26,7 @@ public enum Cri {
 
     private final String id;
     private final boolean isOperationalCri;
-    private static final Set<Cri> KBV_CRIS = Set.of(DWP_KBV, KBV, EXPERIAN_KBV);
+    private static final Set<Cri> KBV_CRIS = Set.of(DWP_KBV, EXPERIAN_KBV);
     private static final String EXPERIAN_KBV_REDIRECT_ID = "kbv";
 
     Cri(String id) {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -1249,7 +1249,7 @@ public interface VcFixtures {
     static VerifiableCredential vcExperianKbvM1a() {
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
-                Cri.KBV,
+                Cri.EXPERIAN_KBV,
                 vcClaimExperianKbv(),
                 EXPERIAN_KBV_ISSUER_INTEGRATION,
                 Instant.ofEpochSecond(1653403140));

--- a/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45IdentityCheckValidator.java
+++ b/libs/gpg45-evaluator/src/main/java/uk/gov/di/ipv/core/library/gpg45/validators/Gpg45IdentityCheckValidator.java
@@ -23,7 +23,7 @@ public class Gpg45IdentityCheckValidator {
         return switch (cri) {
             case BAV, DRIVING_LICENCE, PASSPORT -> isEvidenceSuccessful(identityCheck);
             case EXPERIAN_FRAUD -> isFraudCheckSuccessful(identityCheck);
-            case DWP_KBV, KBV, EXPERIAN_KBV -> isVerificationSuccessful(identityCheck);
+            case DWP_KBV, EXPERIAN_KBV -> isVerificationSuccessful(identityCheck);
             case DCMAW, DCMAW_ASYNC, F2F, HMRC_MIGRATION ->
                     isEvidenceSuccessful(identityCheck) && isVerificationSuccessful(identityCheck);
             case NINO -> isNinoSuccessful(identityCheck);


### PR DESCRIPTION
…N_KBV state

## Proposed changes
### What changed

- removed old KBV CRI state
- removed old KBV id from CRI enum
### Why did it change

- we want to update kbv criId to experianKbv. This is one of the cleanup PRs.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-4934](https://govukverify.atlassian.net/browse/PYIC-4934)




[PYIC-4934]: https://govukverify.atlassian.net/browse/PYIC-4934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ