### PR TITLE
PYIC-8418 remove unused lastChoice context

### DIFF
--- a/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-cri-dropout.feature
@@ -119,7 +119,7 @@ Feature: Dropping out of authoritative source checks with DL CRI (e.g. due to in
     When I submit an 'end' event
     Then I get a 'prove-identity-another-way' page response
     When I submit a 'postOffice' event
-    Then I get a 'page-ipv-identity-postoffice-start' page response with context 'lastChoice'
+    Then I get a 'page-ipv-identity-postoffice-start' page response
     When I submit a 'next' event
     Then I get a 'claimedIdentity' CRI response
     When I submit 'kenneth-current' details to the CRI stub

--- a/api-tests/features/p1-f2f-journey.feature
+++ b/api-tests/features/p1-f2f-journey.feature
@@ -61,7 +61,7 @@ Feature: P1 F2F journey
       When I submit an 'end' event
       Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
       When I submit an 'end' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response with context 'lastChoice'
+      Then I get a 'page-ipv-identity-postoffice-start' page response
       When I submit a 'next' event
       Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details to the CRI stub

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -284,7 +284,7 @@ Feature: P1 No Photo Id Journey
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit an 'end' event
-    Then I get a 'page-ipv-identity-postoffice-start' page response with context 'lastChoice'
+    Then I get a 'page-ipv-identity-postoffice-start' page response
     When I submit a 'end' event
     Then I get a 'pyi-escape' page response
 

--- a/api-tests/features/stored-identity/p1-journeys.feature
+++ b/api-tests/features/stored-identity/p1-journeys.feature
@@ -130,7 +130,7 @@ Feature: Stored Identity - P1 journeys
     When I submit an 'end' event
     Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
     When I submit an 'end' event
-    Then I get a 'page-ipv-identity-postoffice-start' page response with context 'lastChoice'
+    Then I get a 'page-ipv-identity-postoffice-start' page response
     When I submit a 'next' event
     Then I get a 'claimedIdentity' CRI response
     When I submit 'kenneth-current' details to the CRI stub

--- a/api-tests/features/stored-identity/reprove-identity-journeys.feature
+++ b/api-tests/features/stored-identity/reprove-identity-journeys.feature
@@ -100,7 +100,7 @@ Feature: Reprove Identity Journey
       When I submit an 'end' event
       Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
       When I submit an 'end' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response with context 'lastChoice'
+      Then I get a 'page-ipv-identity-postoffice-start' page response
       When I submit a 'next' event
       Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details to the CRI stub

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -178,7 +178,6 @@ states:
   F2F_START_PAGE:
     response:
       type: page
-      context: lastChoice
       pageId: page-ipv-identity-postoffice-start
     events:
       next:


### PR DESCRIPTION
Remove the context `lastChoice` as it is now unused

- 

### Why did it change
frontend pages no longer use that context, so it can be removed.
- 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8418](https://govukverify.atlassian.net/browse/PYIC-8418)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8418]: https://govukverify.atlassian.net/browse/PYIC-8418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ