### PR TITLE
PYIC-8485: Update driving-licence CRI stub URL

### DIFF
--- a/api-tests/data/audit-events/alternate-doc-mitigation-journey.json
+++ b/api-tests/data/audit-events/alternate-doc-mitigation-journey.json
@@ -49,7 +49,7 @@
     "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "iss": "https://driving-license-cri.stubs.account.gov.uk",
+      "iss": "https://driving-licence-cri.stubs.account.gov.uk",
       "evidence": [
         {
           "activityHistoryScore": 0,

--- a/api-tests/data/audit-events/dwp-kbv-dropout-user-abandons-cri.json
+++ b/api-tests/data/audit-events/dwp-kbv-dropout-user-abandons-cri.json
@@ -50,7 +50,7 @@
     "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "iss": "https://driving-license-cri.stubs.account.gov.uk",
+      "iss": "https://driving-licence-cri.stubs.account.gov.uk",
       "evidence": [
         {
           "activityHistoryScore": 1,

--- a/api-tests/data/audit-events/dwp-kbv-dropout-via-thin-file.json
+++ b/api-tests/data/audit-events/dwp-kbv-dropout-via-thin-file.json
@@ -49,7 +49,7 @@
     "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "iss": "https://driving-license-cri.stubs.account.gov.uk",
+      "iss": "https://driving-licence-cri.stubs.account.gov.uk",
       "evidence": [
         {
           "activityHistoryScore": 1,

--- a/api-tests/data/audit-events/dwp-kbv-successful-journey.json
+++ b/api-tests/data/audit-events/dwp-kbv-successful-journey.json
@@ -50,7 +50,7 @@
     "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "iss": "https://driving-license-cri.stubs.account.gov.uk",
+      "iss": "https://driving-licence-cri.stubs.account.gov.uk",
       "evidence": [
         {
           "activityHistoryScore": 1,

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -261,7 +261,7 @@
     "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {
-      "iss": "https://driving-license-cri.stubs.account.gov.uk",
+      "iss": "https://driving-licence-cri.stubs.account.gov.uk",
       "evidence": [
         {
           "activityHistoryScore": 1,

--- a/api-tests/src/clients/cri-stub-client.ts
+++ b/api-tests/src/clients/cri-stub-client.ts
@@ -12,7 +12,7 @@ const STUB_CREDENTIAL_ISSUER_SUBDOMAINS: Record<string, string> = {
   address: "address-cri",
   fraud: "fraud-cri",
   ukPassport: "passport-cri",
-  drivingLicence: "driving-license-cri",
+  drivingLicence: "driving-licence-cri",
   claimedIdentity: "claimed-identity-cri",
   f2f: "f2f-cri",
   nino: "nino-cri",

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -212,17 +212,17 @@ core:
       activeConnection: "stub"
       connections:
         stub: '{
-          "authorizeUrl":"https://driving-license-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://driving-license-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://driving-license-cri.stubs.account.gov.uk/credentials/issue",
+          "authorizeUrl":"https://driving-licence-cri.stubs.account.gov.uk/authorize",
+          "tokenUrl":"https://driving-licence-cri.stubs.account.gov.uk/token",
+          "credentialUrl":"https://driving-licence-cri.stubs.account.gov.uk/credentials/issue",
           "clientId":"ipv-core-local",
           "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
           "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://driving-license-cri.stubs.account.gov.uk",
+          "componentId":"https://driving-licence-cri.stubs.account.gov.uk",
           "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/drivingLicence",
           "requiresApiKey":"false",
           "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://driving-license-cri.stubs.account.gov.uk/.well-known/jwks.json"
+          "jwksUrl":"https://driving-licence-cri.stubs.account.gov.uk/.well-known/jwks.json"
         }'
     claimedIdentity:
       id: claimedIdentity


### PR DESCRIPTION

## Proposed changes
### What changed

- Update driving-licence CRI stub URL, licen(s)e -> licen(c)e

### Why did it change

- We are using the incorrect spelling of licence. We want to be consistent with the naming

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8485](https://govukverify.atlassian.net/browse/PYIC-8485)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8485]: https://govukverify.atlassian.net/browse/PYIC-8485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ