### PR TITLE
Revert "BAU: Bump sigstore/cosign-installer from 3.9.1 to 3.9.2"

### DIFF
--- a/.github/workflows/secure-pipeline-api-tests-image.yml
+++ b/.github/workflows/secure-pipeline-api-tests-image.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
         with:
           cosign-release: 'v1.9.0'
 


### PR DESCRIPTION
This reverts commit 44ecfe9bd87e38b5c0c532e6e5cdd870c89dc0fe.

## Proposed changes
### What changed

Reverted update of cosign-installer

### Why did it change

New version won't install the version of cosign we use
