### PR TITLE
Pyic 7877 Add config support for pure yaml and json format

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -137,6 +137,23 @@ public abstract class ConfigService {
 
     private <T> T getCriConfigForType(String connection, Cri cri, Class<T> configType) {
         String criId = cri.getId();
+        var prefix =
+                String.format(
+                        ConfigurationVariable.CREDENTIAL_ISSUER_CONFIG.getPath(),
+                        criId,
+                        connection);
+        var parameters =
+                getParametersByPrefix(prefix).entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        entry -> entry.getKey().substring(prefix.length() + 1),
+                                        Map.Entry::getValue));
+
+        if (parameters.size() > 1) {
+            var returnObject = OBJECT_MAPPER.convertValue(parameters, configType);
+            return returnObject;
+        }
+
         try {
             String parameter =
                     getParameter(ConfigurationVariable.CREDENTIAL_ISSUER_CONFIG, criId, connection);
@@ -200,7 +217,14 @@ public abstract class ConfigService {
     }
 
     public Map<String, Cri> getIssuerCris() {
-        var allCriParameters = getParametersByPrefix("credentialIssuers");
+        var prefix = "credentialIssuers";
+        var allCriParameters =
+                getParametersByPrefix("credentialIssuers").entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        e -> e.getKey().substring(prefix.length()),
+                                        Map.Entry::getValue));
+
         var issuerToCriMap = new HashMap<String, Cri>();
 
         for (Map.Entry<String, String> entry : allCriParameters.entrySet()) {
@@ -212,6 +236,11 @@ public abstract class ConfigService {
                 continue;
             }
 
+            // REFACTORING REQUIRED!!!!
+            // REFACTORING REQUIRED!!!!
+            // REFACTORING REQUIRED!!!!
+            // REFACTORING REQUIRED!!!!
+            // REFACTORING REQUIRED!!!!
             var regex = String.format("/%s/connections/([^/]+)/[^/]+", cri.getId());
             var pattern = Pattern.compile(regex);
             var matcher = pattern.matcher(fullPath);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public abstract class ConfigService {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -207,19 +208,47 @@ public abstract class ConfigService {
             var value = entry.getValue();
 
             var cri = findCriFromPath(fullPath);
-            if (cri == null) continue;
+            if (cri == null) {
+                continue;
+            }
 
-            try {
-                var criConfig = OBJECT_MAPPER.readValue(value, CriConfig.class);
-                var issuer = criConfig.getComponentId();
-                issuerToCriMap.put(issuer, cri);
-            } catch (JsonProcessingException e) {
-                throw new ConfigParseException(
-                        String.format(
-                                "Failed to parse credential issuer configuration at path '%s': %s",
-                                fullPath, e));
+            var regex = String.format("/%s/connections/([^/]+)/[^/]+", cri.getId());
+            var pattern = Pattern.compile(regex);
+            var matcher = pattern.matcher(fullPath);
+
+            var data =
+                    allCriParameters.entrySet().stream()
+                            .filter(e -> pattern.matcher(e.getKey()).matches())
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            if (data.size() > 1) {
+
+                if (matcher.find()) {
+                    var keyPrefix =
+                            String.format("/%s/connections/%s", cri.getId(), matcher.group(1));
+                    var criConfig =
+                            CriConfig.builder()
+                                    .componentId(
+                                            data.get(String.format("%s/componentId", keyPrefix)))
+                                    .signingKey(data.get(String.format("%s/signingKey", keyPrefix)))
+                                    .build();
+                    var issuer = criConfig.getComponentId();
+                    issuerToCriMap.put(issuer, cri);
+                }
+            } else {
+                try {
+                    var criConfig = OBJECT_MAPPER.readValue(value, CriConfig.class);
+                    var issuer = criConfig.getComponentId();
+                    issuerToCriMap.put(issuer, cri);
+                } catch (JsonProcessingException e) {
+                    throw new ConfigParseException(
+                            String.format(
+                                    "Failed to parse credential issuer configuration at path '%s': %s",
+                                    fullPath, e));
+                }
             }
         }
+
         return issuerToCriMap;
     }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -144,10 +144,21 @@ public abstract class ConfigService {
                         connection);
         var parameters =
                 getParametersByPrefix(prefix).entrySet().stream()
-                        .collect(
-                                Collectors.toMap(
-                                        entry -> entry.getKey().substring(prefix.length() + 1),
-                                        Map.Entry::getValue));
+                        .map(
+                                entry ->
+                                        Map.entry(
+                                                entry.getKey().substring(prefix.length() + 1),
+                                                entry.getValue()))
+                        .map(
+                                entry -> {
+                                    String key = entry.getKey();
+                                    String value = entry.getValue();
+                                    if (key.equals("signingKey") || key.equals("encryptionKey")) {
+                                        return Map.entry(key, value.replace("\\", ""));
+                                    }
+                                    return Map.entry(key, value);
+                                })
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         if (parameters.size() > 1) {
             var returnObject = OBJECT_MAPPER.convertValue(parameters, configType);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -124,6 +124,7 @@ public abstract class ConfigService {
     }
 
     public OauthCriConfig getOauthCriConfigForConnection(String connection, Cri cri) {
+
         return getCriConfigForType(connection, cri, OauthCriConfig.class);
     }
 
@@ -142,20 +143,22 @@ public abstract class ConfigService {
                         ConfigurationVariable.CREDENTIAL_ISSUER_CONFIG.getPath(),
                         criId,
                         connection);
-        var parameters =
-                getParametersByPrefix(prefix).entrySet().stream()
-                        .map(
-                                entry -> {
-                                    var key = entry.getKey().substring(prefix.length() + 1);
-                                    var value = entry.getValue();
-                                    if (key.equals("signingKey") || key.equals("encryptionKey")) {
-                                        value = value.replace("\\", "");
-                                    }
-                                    return Map.entry(key, value);
-                                })
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
+        var parameters = getParametersByPrefix(prefix);
         if (parameters.size() > 1) {
+            parameters =
+                    parameters.entrySet().stream()
+                            .map(
+                                    entry -> {
+                                        var key = entry.getKey().substring(prefix.length() + 1);
+                                        var value = entry.getValue();
+                                        if (key.equals("signingKey")
+                                                || key.equals("encryptionKey")) {
+                                            value = value.replace("\\", "");
+                                        }
+                                        return Map.entry(key, value);
+                                    })
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
             return OBJECT_MAPPER.convertValue(parameters, configType);
         }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
@@ -42,9 +42,7 @@ public abstract class YamlParametersConfigService extends ConfigService {
     public Map<String, String> getParametersByPrefix(String path) {
         return parameters.entrySet().stream()
                 .filter(e -> e.getKey().startsWith(path))
-                .collect(
-                        Collectors.toMap(
-                                e -> e.getKey().substring(path.length()), Map.Entry::getValue));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     protected void updateParameters(Map<String, String> map, String yaml) {

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -88,19 +88,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://address-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://address-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://address-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://address-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/address",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://address-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://address-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://address-cri.stubs.account.gov.uk/token
+          credentialUrl: https://address-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://address-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/address
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://address-cri.stubs.account.gov.uk/.well-known/jwks.json
     dcmaw:
       id: dcmaw
       name: "Document Checking - Mobile App and Web"
@@ -109,19 +108,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://dcmaw-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://dcmaw-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://dcmaw-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}","encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://dcmaw-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/dcmaw",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://dcmaw-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://dcmaw-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://dcmaw-cri.stubs.account.gov.uk/token
+          credentialUrl: https://dcmaw-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://dcmaw-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dcmaw
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://dcmaw-cri.stubs.account.gov.uk/.well-known/jwks.json
     dcmawAsync:
       id: dcmawAsync
       name: "Document Checking - Mobile App and Web - Async"
@@ -130,16 +128,16 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "credentialUrl": "https://dcmaw-async.stubs.account.gov.uk/async/credential",
-          "tokenUrl":"https://dcmaw-async.stubs.account.gov.uk/async/token",
-          "clientId": "dummyClientId",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}","encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://dcmaw-async.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/dcmawAsync",
-          "requiresApiKey": "false",
-          "jwksUrl":"https://dcmaw-async.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          credentialUrl: https://dcmaw-async.stubs.account.gov.uk/async/credential
+          tokenUrl: https://dcmaw-async.stubs.account.gov.uk/async/token
+          clientId: dummyClientId
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://dcmaw-async.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dcmawAsync
+          requiresApiKey: false
+          jwksUrl: https://dcmaw-async.stubs.account.gov.uk/.well-known/jwks.json
     fraud:
       id: fraud
       name: Fraud
@@ -148,19 +146,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://fraud-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://fraud-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://fraud-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://fraud-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/fraud",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://fraud-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://fraud-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://fraud-cri.stubs.account.gov.uk/token
+          credentialUrl: https://fraud-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://fraud-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/fraud
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://fraud-cri.stubs.account.gov.uk/.well-known/jwks.json
     experianKbv:
       id: experianKbv
       name: Experian KBV
@@ -169,19 +166,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://experian-kbv-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://experian-kbv-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://experian-kbv-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://experian-kbv-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/kbv",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://experian-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://experian-kbv-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://experian-kbv-cri.stubs.account.gov.uk/token
+          credentialUrl: https://experian-kbv-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://experian-kbv-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/kbv
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://experian-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json
     ukPassport:
       id: ukPassport
       name: ukPassport
@@ -190,19 +186,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://passport-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://passport-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://passport-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://passport-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/ukPassport",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://passport-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://passport-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://passport-cri.stubs.account.gov.uk/token
+          credentialUrl: https://passport-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://passport-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/ukPassport
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://passport-cri.stubs.account.gov.uk/.well-known/jwks.json
     drivingLicence:
       id: drivingLicence
       name: Driving Licence
@@ -211,19 +206,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address,drivingPermit"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://driving-license-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://driving-license-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://driving-license-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://driving-license-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/drivingLicence",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://driving-license-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://driving-license-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://driving-license-cri.stubs.account.gov.uk/token
+          credentialUrl: https://driving-license-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://driving-license-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/drivingLicence
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://driving-license-cri.stubs.account.gov.uk/.well-known/jwks.json
     claimedIdentity:
       id: claimedIdentity
       name: ClaimedIdentity
@@ -232,19 +226,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://claimed-identity-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://claimed-identity-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://claimed-identity-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://claimed-identity-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/claimedIdentity",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://claimed-identity-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://claimed-identity-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://claimed-identity-cri.stubs.account.gov.uk/token
+          credentialUrl: https://claimed-identity-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://claimed-identity-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/claimedIdentity
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://claimed-identity-cri.stubs.account.gov.uk/.well-known/jwks.json
     f2f:
       id: f2f
       name: Face to Face
@@ -253,19 +246,18 @@ core:
       allowedSharedAttributes: "name,birthDate,emailAddress"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://f2f-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://f2f-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://f2f-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://f2f-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/f2f",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://f2f-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://f2f-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://f2f-cri.stubs.account.gov.uk/token
+          credentialUrl: https://f2f-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://f2f-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/f2f
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://f2f-cri.stubs.account.gov.uk/.well-known/jwks.json
     nino:
       id: nino
       name: NINO
@@ -274,19 +266,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://nino-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://nino-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://nino-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://nino-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/nino",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://nino-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://nino-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://nino-cri.stubs.account.gov.uk/token
+          credentialUrl: https://nino-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://nino-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/nino
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://nino-cri.stubs.account.gov.uk/.well-known/jwks.json
     bav:
       id: bav
       name: Bank account verification
@@ -295,19 +286,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://bav-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://bav-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://bav-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://bav-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/bav",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"true",
-          "jwksUrl":"https://bav-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://bav-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://bav-cri.stubs.account.gov.uk/token
+          credentialUrl: https://bav-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://bav-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/bav
+          requiresApiKey: false
+          requiresAdditionalEvidence: true
+          jwksUrl: https://bav-cri.stubs.account.gov.uk/.well-known/jwks.json
     dwpKbv:
       id: dwpKbv
       name: DWP KBV
@@ -316,19 +306,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://dwp-kbv-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://dwp-kbv-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://dwp-kbv-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://dwp-kbv-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/dwpKbv",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://dwp-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://dwp-kbv-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://dwp-kbv-cri.stubs.account.gov.uk/token
+          credentialUrl: https://dwp-kbv-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://dwp-kbv-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dwpKbv
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://dwp-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json
     ticf:
       id: ticf
       name: Threat Intelligence and Counter Fraud
@@ -336,22 +325,20 @@ core:
       unavailable: "false"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "credentialUrl": "https://ticf.stubs.account.gov.uk/risk-assessment",
-          "signingKey": "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}",
-          "componentId": "https://ticf.stubs.account.gov.uk",
-          "requiresApiKey": "true",
-          "requestTimeout": 5
-        }'
+        stub:
+          credentialUrl: https://ticf.stubs.account.gov.uk/risk-assessment
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}'
+          componentId: https://ticf.stubs.account.gov.uk
+          requiresApiKey: true
+          requestTimeout: 5
     hmrcMigration:
       id: hmrcMigration
       name: HMRC migration
       activeConnection: "stub"
       connections:
-        stub: '{
-          "signingKey": "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}",
-          "componentId": "https://orch.stubs.account.gov.uk/migration/v1"
-        }'
+        stub:
+          signingKey: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
+          componentId: "https://orch.stubs.account.gov.uk/migration/v1"
   local:
     asyncQueue:
       apiBaseUrl: "https://queue.stubs.account.gov.uk"

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -67,7 +67,7 @@ core:
     # Test CIMIT config
     config:
       NEEDS-ENHANCED-VERIFICATION:
-        - event: "/journey/enhanced-verification"
+        - event: /journey/enhanced-verification
       NEEDS-ALTERNATE-DOC:
         - event: /journey/alternate-doc-invalid-dl
           document: drivingPermit

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -65,15 +65,14 @@ core:
     componentId: "https://cimit.stubs.account.gov.uk"
     signingKey: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
     # Test CIMIT config
-    config: '{
-      "NEEDS-ENHANCED-VERIFICATION":[
-        {"event":"/journey/enhanced-verification"}
-      ],
-      "NEEDS-ALTERNATE-DOC":[
-        {"event":"/journey/alternate-doc-invalid-dl","document":"drivingPermit"},
-        {"event":"/journey/alternate-doc-invalid-passport","document":"passport"}
-      ]
-    }'
+    config:
+      NEEDS-ENHANCED-VERIFICATION:
+        - event: "/journey/enhanced-verification"
+      NEEDS-ALTERNATE-DOC:
+        - event: /journey/alternate-doc-invalid-dl
+          document: drivingPermit
+        - event: /journey/alternate-doc-invalid-passport
+          document: passport
     apiBaseUrl: "https://cimit-api.stubs.account.gov.uk"
   evcs:
     applicationUrl: "https://evcs.stubs.account.gov.uk"


### PR DESCRIPTION
## Proposed changes
### What changed

- ConfigServices

### Why did it change

- To change config files to pure yaml, appropriate staging is required. We need to support both formats to avoid any application downtime. Once all config will be in yaml, another PR will be required to remove json support. This will significantly improve the readability of the code.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7877](https://govukverify.atlassian.net/browse/PYIC-7877)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-7877]: https://govukverify.atlassian.net/browse/PYIC-7877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ