### PR TITLE
Pyic 7877 Add config support for pure yaml and json format

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -24,6 +24,7 @@ public enum ConfigurationVariable {
     CREDENTIAL_ISSUER_ACTIVE_CONNECTION("credentialIssuers/%s/activeConnection"),
     CREDENTIAL_ISSUER_CONNECTION_PREFIX("credentialIssuers/%s/connections"),
     CREDENTIAL_ISSUER_CONFIG("credentialIssuers/%s/connections/%s"),
+    CREDENTIAL_ISSUER_COMPONENT_ID("credentialIssuers/%s/connections/%s/componentId"),
     CREDENTIAL_ISSUER_ENABLED("credentialIssuers/%s/enabled"),
     CREDENTIAL_ISSUER_HISTORIC_SIGNING_KEYS("credentialIssuers/%s/historicSigningKeys"),
     CREDENTIAL_ISSUER_SHARED_ATTRIBUTES("credentialIssuers/%s/allowedSharedAttributes"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
@@ -93,6 +93,12 @@ public class AppConfigService extends YamlParametersConfigService {
         return super.getParametersByPrefixYaml(path);
     }
 
+    @Override
+    protected boolean isConfigInYaml() {
+        reloadParameters();
+        return super.isConfigInYaml();
+    }
+
     private void reloadParameters() {
         var profileId = getEnvironmentVariable(EnvironmentVariable.APP_CONFIG_PROFILE_ID);
         var paramsRaw = appConfigProvider.get(profileId);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
@@ -87,6 +87,12 @@ public class AppConfigService extends YamlParametersConfigService {
         return super.getParametersByPrefix(path);
     }
 
+    @Override
+    public Map<String, String> getParametersByPrefixYaml(String path) {
+        reloadParameters();
+        return super.getParametersByPrefixYaml(path);
+    }
+
     private void reloadParameters() {
         var profileId = getEnvironmentVariable(EnvironmentVariable.APP_CONFIG_PROFILE_ID);
         var paramsRaw = appConfigProvider.get(profileId);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
@@ -93,12 +93,6 @@ public class AppConfigService extends YamlParametersConfigService {
         return super.getParametersByPrefixYaml(path);
     }
 
-    @Override
-    protected boolean isConfigInYaml() {
-        reloadParameters();
-        return super.isConfigInYaml();
-    }
-
     private void reloadParameters() {
         var profileId = getEnvironmentVariable(EnvironmentVariable.APP_CONFIG_PROFILE_ID);
         var paramsRaw = appConfigProvider.get(profileId);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -65,8 +65,6 @@ public abstract class ConfigService {
 
     protected abstract String getSecret(String path);
 
-    protected abstract boolean isConfigInYaml();
-
     public String getEnvironmentVariable(EnvironmentVariable environmentVariable) {
         return System.getenv(environmentVariable.name());
     }
@@ -317,5 +315,10 @@ public abstract class ConfigService {
             }
         }
         return null;
+    }
+
+    private boolean isConfigInYaml() {
+        var path = "self/configFormat";
+        return getParameter(path).equals("yaml");
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -290,7 +290,7 @@ public abstract class ConfigService {
     public Map<String, Cri> getIssuerCrisInYaml() {
         var prefix = resolvePath("credentialIssuers");
         var pattern = Pattern.compile("([^/]+)/connections/[^/]+/componentId$");
-        return getParametersByPrefix(prefix).entrySet().stream()
+        return getParametersByPrefixYaml(prefix).entrySet().stream()
                 .filter(entry -> pattern.matcher(entry.getKey()).matches())
                 .collect(
                         Collectors.toMap(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -65,7 +65,7 @@ public abstract class ConfigService {
 
     protected abstract String getSecret(String path);
 
-    protected abstract boolean isCriConfigInYaml();
+    protected abstract boolean isConfigInYaml();
 
     public String getEnvironmentVariable(EnvironmentVariable environmentVariable) {
         return System.getenv(environmentVariable.name());
@@ -145,7 +145,7 @@ public abstract class ConfigService {
 
     private <T extends CriConfig> T getCriConfigForType(
             String connection, Cri cri, Class<T> configType) {
-        if (isCriConfigInYaml()) {
+        if (isConfigInYaml()) {
             return getCriConfigForTypeInYaml(cri, connection, configType);
         }
 
@@ -213,7 +213,7 @@ public abstract class ConfigService {
     }
 
     public Map<String, List<MitigationRoute>> getCimitConfig() throws ConfigException {
-        if (isCriConfigInYaml()) {
+        if (isConfigInYaml()) {
             return getCimitConfigInYaml();
         }
 
@@ -259,7 +259,7 @@ public abstract class ConfigService {
     }
 
     public Map<String, Cri> getIssuerCris() {
-        if (isCriConfigInYaml()) {
+        if (isConfigInYaml()) {
             return getIssuerCrisInYaml();
         }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -221,7 +221,7 @@ public abstract class ConfigService {
         }
     }
 
-    public Map<String, List<MitigationRoute>> getCimitConfigInYaml() throws ConfigException {
+    private Map<String, List<MitigationRoute>> getCimitConfigInYaml() throws ConfigException {
         var parameters = getParametersByPrefixYaml(ConfigurationVariable.CIMIT_CONFIG.getPath());
         var parsedData = new HashMap<String, List<MitigationRoute>>();
         for (var entry : parameters.entrySet()) {
@@ -281,7 +281,7 @@ public abstract class ConfigService {
         return issuerToCriMap;
     }
 
-    public Map<String, Cri> getIssuerCrisYaml() {
+    private Map<String, Cri> getIssuerCrisYaml() {
         var issuerToCri = new HashMap<String, Cri>();
         for (var cri : Cri.values()) {
             if (cri.getId().equals(Cri.CIMIT.getId())) {
@@ -297,7 +297,7 @@ public abstract class ConfigService {
                 var componentId = getParameter(path);
                 issuerToCri.put(componentId, cri);
             } catch (ConfigParameterNotFoundException e) {
-                LOGGER.info(
+                LOGGER.warn(
                         LogHelper.buildLogMessage(
                                 String.format("Issuer for CRI: %s not configured", cri.getId())));
             }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
@@ -138,24 +138,13 @@ public class SsmConfigService extends ConfigService {
     }
 
     @Override
-    protected boolean isConfigInYaml() {
-        var basePath = "self/configFormat";
-        try {
-            var configFormat = ssmProvider.get(resolvePath(basePath));
-            return configFormat.equals("yaml");
-        } catch (ParameterNotFoundException e) {
-            throw new ConfigParameterNotFoundException("Can not detect config format");
-        }
-    }
-
-    @Override
     protected Map<String, String> getParametersByPrefix(String path) {
         return ssmProvider.getMultiple(resolvePath(path));
     }
 
     @Override
     protected Map<String, String> getParametersByPrefixYaml(String path) {
-        var parameters = ssmProvider.recursive().getMultiple(resolvePath(path));
+        var parameters = ssmProvider.getMultiple(resolvePath(path));
         if (parameters.isEmpty()) {
             throw new ConfigParameterNotFoundException("SSM parameter not found for path: " + path);
         }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
@@ -139,7 +139,7 @@ public class SsmConfigService extends ConfigService {
     }
 
     @Override
-    protected boolean isCriConfigInYaml() {
+    protected boolean isConfigInYaml() {
         var criId = Cri.ADDRESS.getId();
         var activeConnection = getActiveConnection(Cri.ADDRESS);
         var basePath =

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
@@ -145,16 +145,20 @@ public class SsmConfigService extends ConfigService {
         var basePath =
                 String.format("credentialIssuers/%s/connections/%s", criId, activeConnection);
         try {
+            LOGGER.error(LogHelper.buildLogMessage("Checking config if it is in yaml or json"));
             ssmProvider.get(resolvePath(basePath));
         } catch (ParameterNotFoundException e) {
+            LOGGER.error(LogHelper.buildLogMessage("Config in json"));
             return false;
         }
+        LOGGER.error(LogHelper.buildLogMessage("Config in yaml"));
+
         return true;
     }
 
     @Override
     protected Map<String, String> getParametersByPrefix(String path) {
-        return ssmProvider.getMultiple(resolvePath(path));
+        return ssmProvider.getMultiple(resolvePath(path.endsWith("/") ? path : path + "/"));
     }
 
     @Override

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
@@ -145,33 +145,28 @@ public class SsmConfigService extends ConfigService {
         var basePath =
                 String.format("credentialIssuers/%s/connections/%s", criId, activeConnection);
         try {
-            LOGGER.error(LogHelper.buildLogMessage("Checking config if it is in yaml or json"));
             ssmProvider.get(resolvePath(basePath));
         } catch (ParameterNotFoundException e) {
-            LOGGER.error(LogHelper.buildLogMessage("Config in json"));
-            return false;
+            return true;
         }
-        LOGGER.error(LogHelper.buildLogMessage("Config in yaml"));
-
-        return true;
+        return false;
     }
 
     @Override
     protected Map<String, String> getParametersByPrefix(String path) {
-        return ssmProvider.getMultiple(resolvePath(path.endsWith("/") ? path : path + "/"));
+        return ssmProvider.recursive().getMultiple(resolvePath(path));
     }
 
     @Override
     protected Map<String, String> getParametersByPrefixYaml(String path) {
-        var parameters = ssmProvider.getMultiple(path);
+        var parameters = ssmProvider.recursive().getMultiple(resolvePath(path));
         if (parameters.isEmpty()) {
             throw new ConfigParameterNotFoundException("SSM parameter not found for path: " + path);
         }
         return parameters;
     }
 
-    @Override
-    protected String resolvePath(String path) {
+    private String resolvePath(String path) {
         return String.format(CORE_BASE_PATH, getEnvironmentVariable(ENVIRONMENT)) + path;
     }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
@@ -18,7 +18,6 @@ import software.amazon.lambda.powertools.parameters.ParamManager;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 
@@ -140,16 +139,13 @@ public class SsmConfigService extends ConfigService {
 
     @Override
     protected boolean isConfigInYaml() {
-        var criId = Cri.ADDRESS.getId();
-        var activeConnection = getActiveConnection(Cri.ADDRESS);
-        var basePath =
-                String.format("credentialIssuers/%s/connections/%s", criId, activeConnection);
+        var basePath = "self/configFormat";
         try {
-            ssmProvider.get(resolvePath(basePath));
+            var configFormat = ssmProvider.get(resolvePath(basePath));
+            return configFormat.equals("yaml");
         } catch (ParameterNotFoundException e) {
-            return true;
+            throw new ConfigParameterNotFoundException("Can not detect config format");
         }
-        return false;
     }
 
     @Override

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
@@ -143,13 +143,13 @@ public class SsmConfigService extends ConfigService {
         var criId = Cri.ADDRESS.getId();
         var activeConnection = getActiveConnection(Cri.ADDRESS);
         var basePath =
-                String.format("/credentialIssuers/%s/connections/%s", criId, activeConnection);
+                String.format("credentialIssuers/%s/connections/%s", criId, activeConnection);
         try {
             ssmProvider.get(resolvePath(basePath));
         } catch (ParameterNotFoundException e) {
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 
     @Override

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/SsmConfigService.java
@@ -150,7 +150,7 @@ public class SsmConfigService extends ConfigService {
 
     @Override
     protected Map<String, String> getParametersByPrefix(String path) {
-        return ssmProvider.recursive().getMultiple(resolvePath(path));
+        return ssmProvider.getMultiple(resolvePath(path));
     }
 
     @Override

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
@@ -8,7 +8,6 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -51,20 +50,18 @@ public abstract class YamlParametersConfigService extends ConfigService {
 
     @Override
     public Map<String, String> getParametersByPrefixYaml(String path) {
-        return parameters.entrySet().stream()
-                .filter(e -> e.getKey().startsWith(path))
-                .collect(
-                        Collectors.collectingAndThen(
+        var lookupParams =
+                parameters.entrySet().stream()
+                        .filter(e -> e.getKey().startsWith(path))
+                        .collect(
                                 Collectors.toMap(
                                         entry -> entry.getKey().substring(path.length() + 1),
-                                        Map.Entry::getValue),
-                                map ->
-                                        Optional.of(map)
-                                                .filter(m -> !m.isEmpty())
-                                                .orElseThrow(
-                                                        () ->
-                                                                new ConfigParameterNotFoundException(
-                                                                        path))));
+                                        Map.Entry::getValue));
+
+        if (lookupParams.isEmpty()) {
+            throw new ConfigParameterNotFoundException(path);
+        }
+        return lookupParams;
     }
 
     protected void updateParameters(Map<String, String> map, String yaml) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
@@ -96,8 +96,8 @@ public abstract class YamlParametersConfigService extends ConfigService {
     }
 
     @Override
-    protected boolean isCriConfigInYaml() {
-        var pattern = Pattern.compile("^credentialIssuers/address/connections/[^/]+/[^/]+.*$");
+    protected boolean isConfigInYaml() {
+        var pattern = Pattern.compile("credentialIssuers/address/connections/[^/]+/[^/]+$");
         for (String key : parameters.keySet()) {
             if (pattern.matcher(key).matches()) {
                 return true;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
@@ -8,7 +8,6 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION;
@@ -76,6 +75,7 @@ public abstract class YamlParametersConfigService extends ConfigService {
     private void addJsonConfig(Map<String, String> map, JsonNode tree, String prefix) {
         switch (tree.getNodeType()) {
             case BOOLEAN, NUMBER, STRING -> map.put(prefix.substring(1), tree.asText());
+            // Required to add CIMIT config which is declared as array in config file
             case ARRAY -> map.put(prefix.substring(1), tree.toString());
             case OBJECT ->
                     tree.properties()
@@ -90,15 +90,5 @@ public abstract class YamlParametersConfigService extends ConfigService {
                             String.format(
                                     "Invalid config of type %s at %s", tree.getNodeType(), prefix));
         }
-    }
-
-    @Override
-    protected boolean isConfigInYaml() {
-        var configFormat = parameters.get("self/configFormat");
-        if (Objects.isNull(configFormat)) {
-            throw new ConfigParameterNotFoundException(
-                    "Config parameter: configFormat doesn't exist.");
-        }
-        return configFormat.equals("yaml");
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
@@ -8,7 +8,6 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION;
@@ -94,12 +93,7 @@ public abstract class YamlParametersConfigService extends ConfigService {
 
     @Override
     protected boolean isConfigInYaml() {
-        var pattern = Pattern.compile("credentialIssuers/address/connections/[^/]+/[^/]+$");
-        for (String key : parameters.keySet()) {
-            if (pattern.matcher(key).matches()) {
-                return true;
-            }
-        }
-        return false;
+        var configFormat = parameters.get("self/configFormat");
+        return configFormat.equals("yaml");
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
@@ -8,6 +8,7 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION;
@@ -94,6 +95,10 @@ public abstract class YamlParametersConfigService extends ConfigService {
     @Override
     protected boolean isConfigInYaml() {
         var configFormat = parameters.get("self/configFormat");
+        if (Objects.isNull(configFormat)) {
+            throw new ConfigParameterNotFoundException(
+                    "Config parameter: configFormat doesn't exist.");
+        }
         return configFormat.equals("yaml");
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -59,6 +59,7 @@ class AppConfigServiceTest {
             """
         core:
           self:
+            configFormat: json
             componentId: "test-component-id"
             bearerTokenTtl: 1800
             someStringList: "a,list,of,strings"
@@ -112,6 +113,7 @@ class AppConfigServiceTest {
             """
         core:
           self:
+            configFormat: malformed
             componentId: "test-component-id"
             bearerTokenTtl: 1800
             someStringList: "a,list,of,strings"
@@ -359,6 +361,8 @@ class AppConfigServiceTest {
         var testRawParametersInvalidCimit =
                 """
             core:
+              self:
+                configFormat: json
               cimit:
                 config: '{
                   notvalid: at-all

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceYamlTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceYamlTest.java
@@ -1,0 +1,236 @@
+package uk.gov.di.ipv.core.library.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.lambda.powertools.parameters.AppConfigProvider;
+import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.gov.di.ipv.core.library.domain.Cri;
+import uk.gov.di.ipv.core.library.dto.CriConfig;
+import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
+import uk.gov.di.ipv.core.library.dto.RestCriConfig;
+import uk.gov.di.ipv.core.library.exceptions.ConfigException;
+import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
+import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class AppConfigServiceYamlTest {
+    private static final String TEST_RAW_PARAMETERS =
+            """
+        core:
+          self:
+            componentId: "test-component-id"
+            bearerTokenTtl: 1800
+            someStringList: "a,list,of,strings"
+          credentialIssuers:
+            address:
+              activeConnection: main
+              connections:
+                main:
+                  componentId: main-issuer
+                  authorizeUrl: https://testAuthoriseUrl
+                  tokenUrl: https://testTokenUrl
+                  credentialUrl: https://testCredentialUrl
+                  clientId: ipv-core-test
+                  signingKey: '{\\"kty\\":\\"EC\\",\\"kid\\":\\"test-fixtures-ec-key\\",\\"use\\":\\"sig\\",\\"d\\":\\"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU\\",\\"crv\\":\\"P-256\\",\\"x\\":\\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\\",\\"y\\":\\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\\"}' # pragma: allowlist secret
+                  encryptionKey: '{\\"kty\\":\\"RSA\\",\\"e\\":\\"AQAB\\",\\"use\\":\\"enc\\",\\"kid\\":\\"nfwejnfwefcojwnk\\",\\"n\\":\\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\\"}' # pragma: allowlist secret
+                  clientCallbackUrl: https://testClientCallBackUrl
+                  requiresApiKey: true
+                  requiresAdditionalEvidence: false
+                  jwksUrl: https://testWellKnownUrl
+                stub:
+                  componentId: stub-issuer
+              historicSigningKeys: '{"kty":"EC","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}/{"kty":"EC","crv":"P-256","x":"MjTFSolNjla11Dl8Zk9UpcpnMyWumfjIbO1E-0c8v-E","y":"xTdKNukh5sOvMgNTKjo0hVYNNcAS-N7X1R1S0cjllTo"}' # pragma: allowlist secret
+            dcmaw:
+              activeConnection: test
+              connections:
+                test:
+                  componentId: dcmaw-issuer
+          featureFlags:
+            testFeatureFlag: false
+            anotherFeatureFlag: true
+          features:
+            testFeature:
+              featureFlags:
+                testFeatureFlag: true
+              self:
+                componentId: "alternate-component-id"
+          cimit:
+            config:
+              NEEDS-ALTERNATE-DOC:
+                - event: /journey/alternate-doc-invalid-dl
+                  document: drivingPermit
+          clients:
+            testClient:
+              validRedirectUrls: a,list,of,strings
+    """;
+    @Mock Cri criMock;
+    @Mock AppConfigProvider appConfigProvider;
+    @Mock SecretsProvider secretsProvider;
+    AppConfigService configService;
+
+    @BeforeEach
+    void setUp() {
+        configService = new AppConfigService(appConfigProvider, secretsProvider);
+        lenient().when(appConfigProvider.get(any())).thenReturn(TEST_RAW_PARAMETERS);
+    }
+
+    // CIMIT config
+
+    @Test
+    void shouldFetchCimitConfig() throws ConfigException {
+        // Act
+        var cimitConfig = configService.getCimitConfig();
+
+        // Assert
+        assertEquals(
+                "/journey/alternate-doc-invalid-dl",
+                cimitConfig.get("NEEDS-ALTERNATE-DOC").get(0).event());
+        assertEquals("drivingPermit", cimitConfig.get("NEEDS-ALTERNATE-DOC").get(0).document());
+    }
+
+    @Test
+    void shouldThrowErrorOnInvalidCimitConfig() {
+        // Arrange
+        var testRawParametersInvalidCimit =
+                """
+            core:
+              cimit:
+                config:
+                  notvalid: at-all
+              credentialIssuers:
+                address:
+                  connections:
+                    main:
+                      componentId: main-issuer
+        """;
+        when(appConfigProvider.get(any())).thenReturn(testRawParametersInvalidCimit);
+        configService = new AppConfigService(appConfigProvider, secretsProvider);
+
+        // Act & Assert
+        assertThrows(ConfigException.class, () -> configService.getCimitConfig());
+    }
+
+    // Get CRI by issuer
+
+    @Test
+    void shouldReturnIssuerCris() {
+        // Act & Assert
+        var config = configService.getIssuerCris();
+
+        assertEquals(
+                Map.of("stub-issuer", ADDRESS, "main-issuer", ADDRESS, "dcmaw-issuer", DCMAW),
+                config);
+    }
+
+    // OAuth CRI config
+
+    @Nested
+    @DisplayName("credential issuer config")
+    class ActiveOauthCriConfig {
+        private final OauthCriConfig expectedOauthCriConfig =
+                OauthCriConfig.builder()
+                        .tokenUrl(URI.create("https://testTokenUrl"))
+                        .credentialUrl(URI.create("https://testCredentialUrl"))
+                        .authorizeUrl(URI.create("https://testAuthoriseUrl"))
+                        .clientId("ipv-core-test")
+                        .signingKey(EC_PRIVATE_KEY_JWK)
+                        .encryptionKey(RSA_ENCRYPTION_PUBLIC_JWK)
+                        .componentId("main-issuer")
+                        .clientCallbackUrl(URI.create("https://testClientCallBackUrl"))
+                        .requiresApiKey(true)
+                        .requiresAdditionalEvidence(false)
+                        .jwksUrl(URI.create("https://testWellKnownUrl"))
+                        .build();
+
+        @Test
+        void getOauthCriActiveConnectionConfigShouldGetCredentialIssuerFromParameterStore() {
+            // Act
+            var result = configService.getOauthCriActiveConnectionConfig(ADDRESS);
+
+            // Assert
+            assertEquals(expectedOauthCriConfig, result);
+        }
+
+        @Test
+        void getOauthCriConfigShouldGetConfigForCriOauthSessionItem() {
+            // Act
+            var result =
+                    configService.getOauthCriConfig(
+                            CriOAuthSessionItem.builder()
+                                    .criId(ADDRESS.getId())
+                                    .connection("main")
+                                    .build());
+
+            // Assert
+            assertEquals(expectedOauthCriConfig, result);
+        }
+
+        @Test
+        void getOauthCriConfigForConnectionShouldGetOauthCriConfig() {
+            // Act
+            var result = configService.getOauthCriConfigForConnection("main", ADDRESS);
+
+            // Assert
+            assertEquals(expectedOauthCriConfig, result);
+        }
+
+        @Test
+        void getOauthCriConfigForConnectionShouldThrowIfNoCriConfigFound() {
+            // Act & Assert
+            assertThrows(
+                    ConfigParameterNotFoundException.class,
+                    () -> configService.getOauthCriConfigForConnection("stub", Cri.PASSPORT));
+        }
+
+        @Test
+        void getRestCriConfigShouldReturnARestCriConfig() throws URISyntaxException {
+            // Act
+            var result = configService.getRestCriConfigForConnection("main", ADDRESS);
+
+            // Assert
+            assertEquals(
+                    RestCriConfig.builder()
+                            .credentialUrl(new URI("https://testCredentialUrl"))
+                            .requiresApiKey(true)
+                            .signingKey(EC_PRIVATE_KEY_JWK)
+                            .componentId("main-issuer")
+                            .build(),
+                    result);
+        }
+
+        @Test
+        void getCriConfigShouldReturnACriConfig() {
+            // Act
+            var result = configService.getCriConfig(ADDRESS);
+
+            // Assert
+            assertEquals(
+                    CriConfig.builder()
+                            .signingKey(EC_PRIVATE_KEY_JWK)
+                            .componentId("main-issuer")
+                            .build(),
+                    result);
+        }
+    }
+}

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceYamlTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceYamlTest.java
@@ -138,9 +138,7 @@ class AppConfigServiceYamlTest {
         // Act & Assert
         var config = configService.getIssuerCris();
 
-        assertEquals(
-                Map.of("stub-issuer", ADDRESS, "main-issuer", ADDRESS, "dcmaw-issuer", DCMAW),
-                config);
+        assertEquals(Map.of("main-issuer", ADDRESS, "dcmaw-issuer", DCMAW), config);
     }
 
     // OAuth CRI config

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceYamlTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceYamlTest.java
@@ -39,6 +39,7 @@ class AppConfigServiceYamlTest {
             """
         core:
           self:
+            configFormat: yaml
             componentId: "test-component-id"
             bearerTokenTtl: 1800
             someStringList: "a,list,of,strings"
@@ -115,6 +116,8 @@ class AppConfigServiceYamlTest {
         var testRawParametersInvalidCimit =
                 """
             core:
+              self:
+                configFormat: yaml
               cimit:
                 config:
                   notvalid: at-all

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
@@ -56,7 +56,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.quality.Strictness.LENIENT;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ENVIRONMENT;
-import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
+import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.Cri.PASSPORT;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK_DOUBLE_ENCODED;
@@ -140,7 +140,10 @@ class SsmConfigServiceTest {
         @Test
         void getOauthCriActiveConnectionConfigShouldGetCredentialIssuerFromParameterStore() {
             environmentVariables.set("ENVIRONMENT", "test");
-
+            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                    .thenReturn("stub");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
                     .thenReturn("stub");
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
@@ -154,6 +157,10 @@ class SsmConfigServiceTest {
         @Test
         void getOauthCriConfigShouldGetConfigForCriOauthSessionItem() {
             environmentVariables.set("ENVIRONMENT", "test");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                    .thenReturn("stub");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(oauthCriJsonConfig);
 
@@ -170,6 +177,10 @@ class SsmConfigServiceTest {
         @Test
         void getOauthCriConfigForConnectionShouldGetOauthCriConfig() {
             environmentVariables.set("ENVIRONMENT", "test");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                    .thenReturn("stub");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(oauthCriJsonConfig);
 
@@ -181,6 +192,10 @@ class SsmConfigServiceTest {
         @Test
         void getOauthCriConfigForConnectionShouldThrowIfNoCriConfigFound() {
             environmentVariables.set("ENVIRONMENT", "test");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                    .thenReturn("stub");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
@@ -192,6 +207,10 @@ class SsmConfigServiceTest {
         @Test
         void getOauthCriConfigForConnectionShouldThrowIfCriConfigMalformed() {
             environmentVariables.set("ENVIRONMENT", "test");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                    .thenReturn("stub");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn("not-json");
 
@@ -204,14 +223,18 @@ class SsmConfigServiceTest {
         void getRestCriConfigShouldReturnARestCriConfig() throws Exception {
             environmentVariables.set("ENVIRONMENT", "test");
 
+            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                    .thenReturn("stub");
             when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                    .thenThrow(ParameterNotFoundException.class);
+            when(ssmProvider.get("/test/core/credentialIssuers/dcmaw/connections/stub"))
                     .thenReturn(
                             String.format(
                                     "{\"credentialUrl\":\"https://testCredentialUrl\",\"signingKey\":%s,\"componentId\":\"https://testComponentId\",\"requiresApiKey\":\"true\"}",
                                     EC_PRIVATE_KEY_JWK_DOUBLE_ENCODED));
 
             RestCriConfig restCriConfig =
-                    configService.getRestCriConfigForConnection("stub", ADDRESS);
+                    configService.getRestCriConfigForConnection("stub", DCMAW);
 
             var expectedRestCriConfig =
                     RestCriConfig.builder()
@@ -228,6 +251,10 @@ class SsmConfigServiceTest {
         void getCriConfigShouldReturnACriConfig() {
             environmentVariables.set("ENVIRONMENT", "test");
 
+            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                    .thenReturn("stub");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
                     .thenReturn("stub");
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
@@ -580,6 +607,10 @@ class SsmConfigServiceTest {
     void shouldFetchCimitConfig(String cimitSsmConfig, String expectedDocument)
             throws ConfigException {
         environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                .thenReturn("stub");
+        when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                .thenThrow(ParameterNotFoundException.class);
         when(ssmProvider.get("/test/core/cimit/config")).thenReturn(cimitSsmConfig);
         Map<String, List<MitigationRoute>> expectedCimitConfig =
                 Map.of(
@@ -605,6 +636,10 @@ class SsmConfigServiceTest {
     @Test
     void shouldThrowErrorOnInvalidCimitConfig() {
         environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                .thenReturn("stub");
+        when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                .thenThrow(ParameterNotFoundException.class);
         when(ssmProvider.get("/test/core/cimit/config")).thenReturn("}");
         assertThrows(ConfigException.class, () -> configService.getCimitConfig());
     }
@@ -635,6 +670,10 @@ class SsmConfigServiceTest {
         @BeforeEach
         void setup() {
             environmentVariables.set("ENVIRONMENT", "test");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
+                    .thenReturn("stub");
+            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
+                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.getMultiple("/test/core/credentialIssuers"))
                     .thenReturn(
                             Map.of(
@@ -657,9 +696,9 @@ class SsmConfigServiceTest {
                             "https://stub-ticf-component-id",
                             Cri.TICF,
                             "https://main-dcmaw-component-id",
-                            Cri.DCMAW,
+                            DCMAW,
                             "https://stub-dcmaw-component-id",
-                            Cri.DCMAW),
+                            DCMAW),
                     configService.getIssuerCris());
         }
     }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
@@ -81,6 +81,8 @@ class SsmConfigServiceTest {
 
     @Mock SSMProvider ssmProvider;
 
+    @Mock private SSMProvider ssmRecursiveMock;
+
     @Mock SecretsProvider secretsProvider;
 
     private ConfigService configService;
@@ -137,13 +139,17 @@ class SsmConfigServiceTest {
                         .jwksUrl(URI.create("https://testWellKnownUrl"))
                         .build();
 
-        @Test
-        void getOauthCriActiveConnectionConfigShouldGetCredentialIssuerFromParameterStore() {
-            environmentVariables.set("ENVIRONMENT", "test");
+        @BeforeEach
+        void setup() {
             when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
                     .thenReturn("stub");
             when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.class);
+                    .thenReturn("just-to-pass-json");
+        }
+
+        @Test
+        void getOauthCriActiveConnectionConfigShouldGetCredentialIssuerFromParameterStore() {
+            environmentVariables.set("ENVIRONMENT", "test");
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
                     .thenReturn("stub");
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
@@ -157,10 +163,6 @@ class SsmConfigServiceTest {
         @Test
         void getOauthCriConfigShouldGetConfigForCriOauthSessionItem() {
             environmentVariables.set("ENVIRONMENT", "test");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(oauthCriJsonConfig);
 
@@ -177,10 +179,6 @@ class SsmConfigServiceTest {
         @Test
         void getOauthCriConfigForConnectionShouldGetOauthCriConfig() {
             environmentVariables.set("ENVIRONMENT", "test");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(oauthCriJsonConfig);
 
@@ -192,10 +190,6 @@ class SsmConfigServiceTest {
         @Test
         void getOauthCriConfigForConnectionShouldThrowIfNoCriConfigFound() {
             environmentVariables.set("ENVIRONMENT", "test");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
@@ -207,10 +201,6 @@ class SsmConfigServiceTest {
         @Test
         void getOauthCriConfigForConnectionShouldThrowIfCriConfigMalformed() {
             environmentVariables.set("ENVIRONMENT", "test");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn("not-json");
 
@@ -223,10 +213,6 @@ class SsmConfigServiceTest {
         void getRestCriConfigShouldReturnARestCriConfig() throws Exception {
             environmentVariables.set("ENVIRONMENT", "test");
 
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/dcmaw/connections/stub"))
                     .thenReturn(
                             String.format(
@@ -251,10 +237,6 @@ class SsmConfigServiceTest {
         void getCriConfigShouldReturnACriConfig() {
             environmentVariables.set("ENVIRONMENT", "test");
 
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.class);
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
                     .thenReturn("stub");
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections/stub"))
@@ -610,7 +592,7 @@ class SsmConfigServiceTest {
         when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
                 .thenReturn("stub");
         when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                .thenThrow(ParameterNotFoundException.class);
+                .thenReturn("just-to-pass-json");
         when(ssmProvider.get("/test/core/cimit/config")).thenReturn(cimitSsmConfig);
         Map<String, List<MitigationRoute>> expectedCimitConfig =
                 Map.of(
@@ -639,7 +621,7 @@ class SsmConfigServiceTest {
         when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
                 .thenReturn("stub");
         when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                .thenThrow(ParameterNotFoundException.class);
+                .thenReturn("just-to-pass-json");
         when(ssmProvider.get("/test/core/cimit/config")).thenReturn("}");
         assertThrows(ConfigException.class, () -> configService.getCimitConfig());
     }
@@ -673,8 +655,10 @@ class SsmConfigServiceTest {
             when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
                     .thenReturn("stub");
             when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.class);
-            when(ssmProvider.getMultiple("/test/core/credentialIssuers"))
+                    .thenReturn("just-to-pass-json");
+
+            when(ssmProvider.recursive()).thenReturn(ssmRecursiveMock);
+            when(ssmRecursiveMock.getMultiple("/test/core/credentialIssuers"))
                     .thenReturn(
                             Map.of(
                                     "ticf/connections/stub",

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
@@ -141,10 +141,7 @@ class SsmConfigServiceTest {
 
         @BeforeEach
         void setup() {
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenReturn("just-to-pass-json");
+            when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("json");
         }
 
         @Test
@@ -589,10 +586,7 @@ class SsmConfigServiceTest {
     void shouldFetchCimitConfig(String cimitSsmConfig, String expectedDocument)
             throws ConfigException {
         environmentVariables.set("ENVIRONMENT", "test");
-        when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                .thenReturn("stub");
-        when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                .thenReturn("just-to-pass-json");
+        when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("json");
         when(ssmProvider.get("/test/core/cimit/config")).thenReturn(cimitSsmConfig);
         Map<String, List<MitigationRoute>> expectedCimitConfig =
                 Map.of(
@@ -618,10 +612,7 @@ class SsmConfigServiceTest {
     @Test
     void shouldThrowErrorOnInvalidCimitConfig() {
         environmentVariables.set("ENVIRONMENT", "test");
-        when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                .thenReturn("stub");
-        when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                .thenReturn("just-to-pass-json");
+        when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("json");
         when(ssmProvider.get("/test/core/cimit/config")).thenReturn("}");
         assertThrows(ConfigException.class, () -> configService.getCimitConfig());
     }
@@ -652,10 +643,7 @@ class SsmConfigServiceTest {
         @BeforeEach
         void setup() {
             environmentVariables.set("ENVIRONMENT", "test");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenReturn("just-to-pass-json");
+            when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("json");
 
             when(ssmProvider.recursive()).thenReturn(ssmRecursiveMock);
             when(ssmRecursiveMock.getMultiple("/test/core/credentialIssuers"))

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
@@ -645,8 +645,7 @@ class SsmConfigServiceTest {
             environmentVariables.set("ENVIRONMENT", "test");
             when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("json");
 
-            when(ssmProvider.recursive()).thenReturn(ssmRecursiveMock);
-            when(ssmRecursiveMock.getMultiple("/test/core/credentialIssuers"))
+            when(ssmProvider.getMultiple("/test/core/credentialIssuers"))
                     .thenReturn(
                             Map.of(
                                     "ticf/connections/stub",

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
@@ -49,9 +49,6 @@ class SsmConfigServiceYamlTest {
 
     public static final CriOAuthSessionItem CRI_OAUTH_SESSION_ITEM =
             CriOAuthSessionItem.builder().criId("ukPassport").connection("main").build();
-    private static final String TEST_CERT =
-            "MIIC/TCCAeWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwHhcNMjExMjE3MTEwNTM5WhcNMjIxMjE3MTEwNTM5WjAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDYIxWKwYNoz2MIDvYb2ip4nhCOGUccufIqwSHXl5FBOoOxOZh1rV57sWhdKO/hyZYbF5YUYTwzV4rW7DgLkfx0sN/p5igk74BZRSXvV/s+XCkVC5c0NDhNGh6WK5rc8Qbm0Ad5vEO1JpQih5y2mPGCwfLBqcY8AC7fwZinP/4YoMTCtEk5ueA0HwZLHXOEMWl/QCkj7WlSBL4i6ozk4So3RFL4awYP6nvhY7OLAcad7g/ZW0dXvztPOJnT9rwi1p6BNoD/Zk6jMJHhbvKyGsluUy7PYVGYCQ36Uuzby2Jq8cG5qNS+CBjy0/d/RmrClKd7gcnLY/J5NOC+YSynoHXRAgMBAAGjKjAoMA4GA1UdDwEB/wQEAwIFoDAWBgNVHSUBAf8EDDAKBggrBgEFBQcDBDANBgkqhkiG9w0BAQsFAAOCAQEAvHT2AGTymh02A9HWrnGm6PEXx2Ye3NXV9eJNU1z6J298mS2kYq0Z4D0hj9i8+IoCQRbWOxLTAWBNt/CmH7jWltE4uqoAwTZD6mDgkC2eo5dY+RcuydsvJNfTcvUOyi47KKGGEcddfLti4NuX51BQIY5vSBfqZXt8+y28WuWqBMh6eny2wJtxNHo20wQei5g7w19lqwJu2F+l/ykX9K5DHjhXqZUJ77YWmY8sy/WROLjOoZZRy6YuzV8S/+c/nsPzqDAkD4rpWwASjsEDaTcH22xpGq5XUAf1hwwNsuiyXKGUHCxafYYS781LR8pLg6DpEAgcn8tBbq6MoiEGVeOp7Q=="; // pragma: allowlist secret
-    private static final String TEST_CERT_FS01 = "not a real cert";
 
     @SystemStub private EnvironmentVariables environmentVariables;
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
@@ -133,10 +133,7 @@ class SsmConfigServiceYamlTest {
 
         @BeforeEach
         void setup() {
-            when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                    .thenThrow(ParameterNotFoundException.class);
+            when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("yaml");
         }
 
         @Test
@@ -286,10 +283,7 @@ class SsmConfigServiceYamlTest {
             throws ConfigException {
         environmentVariables.set("ENVIRONMENT", "test");
 
-        when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                .thenReturn("stub");
-        when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                .thenThrow(ParameterNotFoundException.class);
+        when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("yaml");
 
         when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
         when(ssmProvider.recursive().getMultiple("/test/core/cimit/config")).thenReturn(cimitData);
@@ -320,10 +314,7 @@ class SsmConfigServiceYamlTest {
     void shouldThrowErrorOnInvalidCimitConfig() {
         environmentVariables.set("ENVIRONMENT", "test");
 
-        when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
-                .thenReturn("stub");
-        when(ssmProvider.get("/test/core/credentialIssuers/address/connections/stub"))
-                .thenThrow(ParameterNotFoundException.class);
+        when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("yaml");
 
         when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
 
@@ -339,6 +330,8 @@ class SsmConfigServiceYamlTest {
         @BeforeEach
         void setup() {
             environmentVariables.set("ENVIRONMENT", "test");
+
+            when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("yaml");
 
             when(ssmProvider.get("/test/core/credentialIssuers/address/activeConnection"))
                     .thenReturn("stub");

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
@@ -1,0 +1,332 @@
+package uk.gov.di.ipv.core.library.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
+import software.amazon.lambda.powertools.parameters.SSMProvider;
+import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
+import uk.gov.di.ipv.core.library.domain.Cri;
+import uk.gov.di.ipv.core.library.domain.MitigationRoute;
+import uk.gov.di.ipv.core.library.dto.CriConfig;
+import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
+import uk.gov.di.ipv.core.library.dto.RestCriConfig;
+import uk.gov.di.ipv.core.library.exceptions.ConfigException;
+import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
+import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.LENIENT;
+import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PUBLIC_JWK_2;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PUBLIC_JWK;
+import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.TEST_EC_PUBLIC_JWK;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class SsmConfigServiceYamlTest {
+
+    public static final CriOAuthSessionItem CRI_OAUTH_SESSION_ITEM =
+            CriOAuthSessionItem.builder().criId("ukPassport").connection("main").build();
+    private static final String TEST_CERT =
+            "MIIC/TCCAeWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwHhcNMjExMjE3MTEwNTM5WhcNMjIxMjE3MTEwNTM5WjAsMR0wGwYDVQQDDBRjcmktdWstcGFzc3BvcnQtYmFjazELMAkGA1UEBhMCR0IwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDYIxWKwYNoz2MIDvYb2ip4nhCOGUccufIqwSHXl5FBOoOxOZh1rV57sWhdKO/hyZYbF5YUYTwzV4rW7DgLkfx0sN/p5igk74BZRSXvV/s+XCkVC5c0NDhNGh6WK5rc8Qbm0Ad5vEO1JpQih5y2mPGCwfLBqcY8AC7fwZinP/4YoMTCtEk5ueA0HwZLHXOEMWl/QCkj7WlSBL4i6ozk4So3RFL4awYP6nvhY7OLAcad7g/ZW0dXvztPOJnT9rwi1p6BNoD/Zk6jMJHhbvKyGsluUy7PYVGYCQ36Uuzby2Jq8cG5qNS+CBjy0/d/RmrClKd7gcnLY/J5NOC+YSynoHXRAgMBAAGjKjAoMA4GA1UdDwEB/wQEAwIFoDAWBgNVHSUBAf8EDDAKBggrBgEFBQcDBDANBgkqhkiG9w0BAQsFAAOCAQEAvHT2AGTymh02A9HWrnGm6PEXx2Ye3NXV9eJNU1z6J298mS2kYq0Z4D0hj9i8+IoCQRbWOxLTAWBNt/CmH7jWltE4uqoAwTZD6mDgkC2eo5dY+RcuydsvJNfTcvUOyi47KKGGEcddfLti4NuX51BQIY5vSBfqZXt8+y28WuWqBMh6eny2wJtxNHo20wQei5g7w19lqwJu2F+l/ykX9K5DHjhXqZUJ77YWmY8sy/WROLjOoZZRy6YuzV8S/+c/nsPzqDAkD4rpWwASjsEDaTcH22xpGq5XUAf1hwwNsuiyXKGUHCxafYYS781LR8pLg6DpEAgcn8tBbq6MoiEGVeOp7Q=="; // pragma: allowlist secret
+    private static final String TEST_CERT_FS01 = "not a real cert";
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
+    @SystemStub private SystemProperties systemProperties;
+
+    @Mock SSMProvider ssmProvider;
+
+    @Mock SecretsProvider secretsProvider;
+
+    private ConfigService configService;
+
+    @BeforeEach
+    void setUp() {
+        configService = new SsmConfigService(ssmProvider, secretsProvider);
+    }
+
+    @Test
+    void getParameterShouldGetParameterFromSsm() {
+        var testComponentId = "test-component-id";
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/self/componentId")).thenReturn(testComponentId);
+
+        var value = configService.getParameter(ConfigurationVariable.COMPONENT_ID);
+
+        assertEquals(testComponentId, value);
+    }
+
+    @Test
+    void getParameterShouldThrowIfMissingInSsm() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.get("/test/core/self/componentId"))
+                .thenThrow(ParameterNotFoundException.class);
+
+        assertThrows(
+                ConfigParameterNotFoundException.class,
+                () -> configService.getParameter(ConfigurationVariable.COMPONENT_ID));
+    }
+
+    @Nested
+    @DisplayName("active credential issuer config")
+    class ActiveOauthCriConfig {
+
+        private final Map<String, String> criStubConnection =
+                Map.of(
+                        "tokenUrl",
+                        "https://testTokenUrl",
+                        "credentialUrl",
+                        "https://testCredentialUrl",
+                        "authorizeUrl",
+                        "https://testAuthoriseUrl",
+                        "clientId",
+                        "ipv-core-test",
+                        "signingKey",
+                        EC_PRIVATE_KEY_JWK,
+                        "encryptionKey",
+                        RSA_ENCRYPTION_PUBLIC_JWK,
+                        "componentId",
+                        "https://testComponentId",
+                        "clientCallbackUrl",
+                        "https://testClientCallBackUrl",
+                        "requiresApiKey",
+                        String.valueOf(true),
+                        "jwksUrl",
+                        "https://testWellKnownUrl");
+
+        private final OauthCriConfig expectedOauthCriConfig =
+                OauthCriConfig.builder()
+                        .tokenUrl(URI.create("https://testTokenUrl"))
+                        .credentialUrl(URI.create("https://testCredentialUrl"))
+                        .authorizeUrl(URI.create("https://testAuthoriseUrl"))
+                        .clientId("ipv-core-test")
+                        .signingKey(EC_PRIVATE_KEY_JWK)
+                        .encryptionKey(RSA_ENCRYPTION_PUBLIC_JWK)
+                        .componentId("https://testComponentId")
+                        .clientCallbackUrl(URI.create("https://testClientCallBackUrl"))
+                        .requiresApiKey(true)
+                        .requiresAdditionalEvidence(false)
+                        .jwksUrl(URI.create("https://testWellKnownUrl"))
+                        .build();
+
+        @Test
+        void getOauthCriActiveConnectionConfigShouldGetCredentialIssuerFromParameterStore() {
+            environmentVariables.set("ENVIRONMENT", "test");
+
+            when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
+                    .thenReturn("stub");
+            when(ssmProvider.getMultiple(
+                            "/test/core/credentialIssuers/ukPassport/connections/stub"))
+                    .thenReturn(criStubConnection);
+
+            OauthCriConfig result = configService.getOauthCriActiveConnectionConfig(Cri.PASSPORT);
+
+            assertEquals(expectedOauthCriConfig, result);
+        }
+
+        @Test
+        void getOauthCriConfigShouldGetConfigForCriOauthSessionItem() {
+            environmentVariables.set("ENVIRONMENT", "test");
+
+            when(ssmProvider.getMultiple(
+                            "/test/core/credentialIssuers/ukPassport/connections/stub"))
+                    .thenReturn(criStubConnection);
+
+            OauthCriConfig result =
+                    configService.getOauthCriConfig(
+                            CriOAuthSessionItem.builder()
+                                    .criId(Cri.PASSPORT.getId())
+                                    .connection("stub")
+                                    .build());
+
+            assertEquals(expectedOauthCriConfig, result);
+        }
+
+        @Test
+        void getOauthCriConfigForConnectionShouldGetOauthCriConfig() {
+            environmentVariables.set("ENVIRONMENT", "test");
+
+            when(ssmProvider.getMultiple(
+                            "/test/core/credentialIssuers/ukPassport/connections/stub"))
+                    .thenReturn(criStubConnection);
+
+            var result = configService.getOauthCriConfigForConnection("stub", Cri.PASSPORT);
+
+            assertEquals(expectedOauthCriConfig, result);
+        }
+
+        @Test
+        void getOauthCriConfigForConnectionShouldThrowIfNoCriConfigFound() {
+            environmentVariables.set("ENVIRONMENT", "test");
+
+            assertThrows(
+                    ConfigParameterNotFoundException.class,
+                    () -> configService.getOauthCriConfigForConnection("stub", Cri.PASSPORT));
+        }
+
+        @Test
+        void getRestCriConfigShouldReturnARestCriConfig() throws Exception {
+            environmentVariables.set("ENVIRONMENT", "test");
+
+            when(ssmProvider.getMultiple("/test/core/credentialIssuers/address/connections/stub"))
+                    .thenReturn(
+                            Map.of(
+                                    "credentialUrl",
+                                    "https://testCredentialUrl",
+                                    "signingKey",
+                                    EC_PRIVATE_KEY_JWK,
+                                    "componentId",
+                                    "https://testComponentId",
+                                    "requiresApiKey",
+                                    "true"));
+
+            RestCriConfig restCriConfig =
+                    configService.getRestCriConfigForConnection("stub", ADDRESS);
+
+            var expectedRestCriConfig =
+                    RestCriConfig.builder()
+                            .credentialUrl(new URI("https://testCredentialUrl"))
+                            .requiresApiKey(true)
+                            .signingKey(EC_PRIVATE_KEY_JWK)
+                            .componentId("https://testComponentId")
+                            .build();
+
+            assertEquals(expectedRestCriConfig, restCriConfig);
+        }
+
+        @Test
+        void getCriConfigShouldReturnACriConfig() {
+            environmentVariables.set("ENVIRONMENT", "test");
+
+            when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
+                    .thenReturn("stub");
+            when(ssmProvider.getMultiple(
+                            "/test/core/credentialIssuers/ukPassport/connections/stub"))
+                    .thenReturn(
+                            Map.of(
+                                    "signingKey",
+                                    EC_PRIVATE_KEY_JWK,
+                                    "componentId",
+                                    "https://testComponentId"));
+
+            CriConfig criConfig = configService.getCriConfig(Cri.PASSPORT);
+
+            var expectedCriConfig =
+                    CriConfig.builder()
+                            .signingKey(EC_PRIVATE_KEY_JWK)
+                            .componentId("https://testComponentId")
+                            .build();
+
+            assertEquals(expectedCriConfig, criConfig);
+        }
+    }
+
+    @Test
+    void shouldReturnSlashSeparatedHistoricSigningKeys() {
+        environmentVariables.set("ENVIRONMENT", "test");
+
+        when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/historicSigningKeys"))
+                .thenReturn(String.format("%s/%s", TEST_EC_PUBLIC_JWK, EC_PUBLIC_JWK_2));
+
+        var result = configService.getHistoricSigningKeys(Cri.PASSPORT.getId());
+
+        assertEquals(TEST_EC_PUBLIC_JWK, result.get(0));
+        assertEquals(EC_PUBLIC_JWK_2, result.get(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideConfiguredSsmCimitConfig")
+    void shouldFetchCimitConfig(Map<String, String> cimitData, String expectedDocument)
+            throws ConfigException {
+        environmentVariables.set("ENVIRONMENT", "test");
+
+        when(ssmProvider.getMultiple("/test/core/cimit/config")).thenReturn(cimitData);
+        Map<String, List<MitigationRoute>> expectedCimitConfig =
+                Map.of(
+                        "X01",
+                        List.of(new MitigationRoute("/journey/do-a-thing", expectedDocument)));
+        Map<String, List<MitigationRoute>> cimitConfig = configService.getCimitConfig();
+        assertEquals(
+                expectedCimitConfig.get("X01").get(0).event(),
+                cimitConfig.get("X01").get(0).event());
+        assertEquals(
+                expectedCimitConfig.get("X01").get(0).document(),
+                cimitConfig.get("X01").get(0).document());
+    }
+
+    private static Stream<Arguments> provideConfiguredSsmCimitConfig() {
+        return Stream.of(
+                Arguments.of(Map.of("X01", "[{\"event\": \"/journey/do-a-thing\"}]"), null),
+                Arguments.of(
+                        Map.of(
+                                "X01",
+                                "[{\"event\": \"/journey/do-a-thing\", \"document\": \"drivingPermit\"}]"),
+                        "drivingPermit"));
+    }
+
+    @Test
+    void shouldThrowErrorOnInvalidCimitConfig() {
+        environmentVariables.set("ENVIRONMENT", "test");
+        when(ssmProvider.getMultiple("/test/core/cimit/config"))
+                .thenReturn(Map.of("/test/core/cimit/config/restOfPath", "}"));
+        assertThrows(ConfigException.class, () -> configService.getCimitConfig());
+    }
+
+    @Nested
+    @MockitoSettings(strictness = LENIENT)
+    class GetCriByIssuerTests {
+        @BeforeEach
+        void setup() {
+            environmentVariables.set("ENVIRONMENT", "test");
+            when(ssmProvider.getMultiple("/test/core/credentialIssuers"))
+                    .thenReturn(
+                            Map.of(
+                                    "ticf/connections/stub/componentId",
+                                    "https://stub-ticf-component-id",
+                                    "ticf/connections/main/componentId",
+                                    "https://main-ticf-component-id",
+                                    "dcmaw/connections/stub/componentId",
+                                    "https://stub-dcmaw-component-id",
+                                    "dcmaw/connections/main/componentId",
+                                    "https://main-dcmaw-component-id"));
+        }
+
+        @Test
+        void shouldReturnCriForValidIssuers() {
+            assertEquals(
+                    Map.of(
+                            "https://main-ticf-component-id",
+                            Cri.TICF,
+                            "https://stub-ticf-component-id",
+                            Cri.TICF,
+                            "https://main-dcmaw-component-id",
+                            Cri.DCMAW,
+                            "https://stub-dcmaw-component-id",
+                            Cri.DCMAW),
+                    configService.getIssuerCris());
+        }
+    }
+}

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
@@ -56,8 +56,6 @@ class SsmConfigServiceYamlTest {
 
     @Mock SSMProvider ssmProvider;
 
-    @Mock SSMProvider ssmProviderRecursive;
-
     @Mock SecretsProvider secretsProvider;
 
     private ConfigService configService;
@@ -142,11 +140,8 @@ class SsmConfigServiceYamlTest {
 
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
                     .thenReturn("stub");
-            when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
-            when(ssmProvider
-                            .recursive()
-                            .getMultiple(
-                                    "/test/core/credentialIssuers/ukPassport/connections/stub"))
+            when(ssmProvider.getMultiple(
+                            "/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(criStubConnection);
 
             OauthCriConfig result = configService.getOauthCriActiveConnectionConfig(Cri.PASSPORT);
@@ -158,11 +153,8 @@ class SsmConfigServiceYamlTest {
         void getOauthCriConfigShouldGetConfigForCriOauthSessionItem() {
             environmentVariables.set("ENVIRONMENT", "test");
 
-            when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
-            when(ssmProvider
-                            .recursive()
-                            .getMultiple(
-                                    "/test/core/credentialIssuers/ukPassport/connections/stub"))
+            when(ssmProvider.getMultiple(
+                            "/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(criStubConnection);
 
             OauthCriConfig result =
@@ -179,11 +171,8 @@ class SsmConfigServiceYamlTest {
         void getOauthCriConfigForConnectionShouldGetOauthCriConfig() {
             environmentVariables.set("ENVIRONMENT", "test");
 
-            when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
-            when(ssmProvider
-                            .recursive()
-                            .getMultiple(
-                                    "/test/core/credentialIssuers/ukPassport/connections/stub"))
+            when(ssmProvider.getMultiple(
+                            "/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(criStubConnection);
 
             var result = configService.getOauthCriConfigForConnection("stub", Cri.PASSPORT);
@@ -195,8 +184,6 @@ class SsmConfigServiceYamlTest {
         void getOauthCriConfigForConnectionShouldThrowIfNoCriConfigFound() {
             environmentVariables.set("ENVIRONMENT", "test");
 
-            when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
-
             assertThrows(
                     ConfigParameterNotFoundException.class,
                     () -> configService.getOauthCriConfigForConnection("stub", Cri.PASSPORT));
@@ -206,10 +193,7 @@ class SsmConfigServiceYamlTest {
         void getRestCriConfigShouldReturnARestCriConfig() throws Exception {
             environmentVariables.set("ENVIRONMENT", "test");
 
-            when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
-            when(ssmProvider
-                            .recursive()
-                            .getMultiple("/test/core/credentialIssuers/address/connections/stub"))
+            when(ssmProvider.getMultiple("/test/core/credentialIssuers/address/connections/stub"))
                     .thenReturn(
                             Map.of(
                                     "credentialUrl",
@@ -240,11 +224,8 @@ class SsmConfigServiceYamlTest {
             environmentVariables.set("ENVIRONMENT", "test");
             when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
                     .thenReturn("stub");
-            when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
-            when(ssmProvider
-                            .recursive()
-                            .getMultiple(
-                                    "/test/core/credentialIssuers/ukPassport/connections/stub"))
+            when(ssmProvider.getMultiple(
+                            "/test/core/credentialIssuers/ukPassport/connections/stub"))
                     .thenReturn(
                             Map.of(
                                     "signingKey",
@@ -285,8 +266,7 @@ class SsmConfigServiceYamlTest {
 
         when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("yaml");
 
-        when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
-        when(ssmProvider.recursive().getMultiple("/test/core/cimit/config")).thenReturn(cimitData);
+        when(ssmProvider.getMultiple("/test/core/cimit/config")).thenReturn(cimitData);
         Map<String, List<MitigationRoute>> expectedCimitConfig =
                 Map.of(
                         "X01",
@@ -316,9 +296,7 @@ class SsmConfigServiceYamlTest {
 
         when(ssmProvider.get("/test/core/self/configFormat")).thenReturn("yaml");
 
-        when(ssmProvider.recursive()).thenReturn(ssmProviderRecursive);
-
-        when(ssmProvider.recursive().getMultiple("/test/core/cimit/config"))
+        when(ssmProvider.getMultiple("/test/core/cimit/config"))
                 .thenReturn(Map.of("/test/core/cimit/config/restOfPath", "}"));
 
         assertThrows(ConfigException.class, () -> configService.getCimitConfig());

--- a/libs/common-services/src/test/resources/test-parameters.yaml
+++ b/libs/common-services/src/test/resources/test-parameters.yaml
@@ -1,6 +1,7 @@
 ---
 core:
   self:
+    configFormat: json
     componentId: "test-component-id"
   credentialIssuers:
     address:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -63,15 +63,14 @@ core:
     componentId: "https://cimit.stubs.account.gov.uk"
     signingKey: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
     # Test CIMIT config
-    config: '{
-      "NEEDS-ENHANCED-VERIFICATION":[
-        {"event":"/journey/enhanced-verification"}
-      ],
-      "NEEDS-ALTERNATE-DOC":[
-        {"event":"/journey/alternate-doc-invalid-dl","document":"drivingPermit"},
-        {"event":"/journey/alternate-doc-invalid-passport","document":"passport"}
-      ]
-    }'
+    config:
+      NEEDS-ENHANCED-VERIFICATION:
+        - event: /journey/enhanced-verification
+      NEEDS-ALTERNATE-DOC:
+        - event: /journey/alternate-doc-invalid-dl
+          document: drivingPermit
+        - event: /journey/alternate-doc-invalid-passport
+          document: passport
     apiBaseUrl: "https://cimit-api.stubs.account.gov.uk"
   evcs:
     applicationUrl: "https://evcs.stubs.account.gov.uk"
@@ -86,19 +85,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://address-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://address-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://address-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://address-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/address",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://address-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://address-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://address-cri.stubs.account.gov.uk/token
+          credentialUrl: https://address-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://address-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/address
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://address-cri.stubs.account.gov.uk/.well-known/jwks.json
     dcmaw:
       id: dcmaw
       name: "Document Checking - Mobile App and Web"
@@ -107,19 +105,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://dcmaw-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://dcmaw-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://dcmaw-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}","encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://dcmaw-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/dcmaw",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://dcmaw-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://dcmaw-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://dcmaw-cri.stubs.account.gov.uk/token
+          credentialUrl: https://dcmaw-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://dcmaw-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dcmaw
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://dcmaw-cri.stubs.account.gov.uk/.well-known/jwks.json
     dcmawAsync:
       id: dcmawAsync
       name: "Document Checking - Mobile App and Web - Async"
@@ -128,16 +125,16 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "credentialUrl": "https://dcmaw-async.stubs.account.gov.uk/async/credential",
-          "tokenUrl":"https://dcmaw-async.stubs.account.gov.uk/async/token",
-          "clientId": "dummyClientId",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}","encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://dcmaw-async.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/dcmawAsync",
-          "requiresApiKey": "false",
-          "jwksUrl":"https://dcmaw-async.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          credentialUrl: https://dcmaw-async.stubs.account.gov.uk/async/credential
+          tokenUrl: https://dcmaw-async.stubs.account.gov.uk/async/token
+          clientId: dummyClientId
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://dcmaw-async.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dcmawAsync
+          requiresApiKey: false
+          jwksUrl: https://dcmaw-async.stubs.account.gov.uk/.well-known/jwks.json
     fraud:
       id: fraud
       name: Fraud
@@ -146,19 +143,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://fraud-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://fraud-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://fraud-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://fraud-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/fraud",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://fraud-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://fraud-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://fraud-cri.stubs.account.gov.uk/token
+          credentialUrl: https://fraud-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://fraud-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/fraud
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://fraud-cri.stubs.account.gov.uk/.well-known/jwks.json
     experianKbv:
       id: experianKbv
       name: Experian KBV
@@ -167,19 +163,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://experian-kbv-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://experian-kbv-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://experian-kbv-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://experian-kbv-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/kbv",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://experian-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://experian-kbv-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://experian-kbv-cri.stubs.account.gov.uk/token
+          credentialUrl: https://experian-kbv-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://experian-kbv-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/kbv
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://experian-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json
     ukPassport:
       id: ukPassport
       name: ukPassport
@@ -188,19 +183,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://passport-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://passport-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://passport-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://passport-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/ukPassport",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://passport-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://passport-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://passport-cri.stubs.account.gov.uk/token
+          credentialUrl: https://passport-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://passport-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/ukPassport
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://passport-cri.stubs.account.gov.uk/.well-known/jwks.json
     drivingLicence:
       id: drivingLicence
       name: Driving Licence
@@ -209,19 +203,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address,drivingPermit"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://driving-license-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://driving-license-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://driving-license-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://driving-license-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/drivingLicence",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://driving-license-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://driving-license-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://driving-license-cri.stubs.account.gov.uk/token
+          credentialUrl: https://driving-license-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://driving-license-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/drivingLicence
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://driving-license-cri.stubs.account.gov.uk/.well-known/jwks.json
     claimedIdentity:
       id: claimedIdentity
       name: ClaimedIdentity
@@ -230,19 +223,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://claimed-identity-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://claimed-identity-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://claimed-identity-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://claimed-identity-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/claimedIdentity",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://claimed-identity-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://claimed-identity-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://claimed-identity-cri.stubs.account.gov.uk/token
+          credentialUrl: https://claimed-identity-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://claimed-identity-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/claimedIdentity
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://claimed-identity-cri.stubs.account.gov.uk/.well-known/jwks.json
     f2f:
       id: f2f
       name: Face to Face
@@ -251,19 +243,18 @@ core:
       allowedSharedAttributes: "name,birthDate,emailAddress"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://f2f-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://f2f-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://f2f-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://f2f-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/f2f",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://f2f-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://f2f-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://f2f-cri.stubs.account.gov.uk/token
+          credentialUrl: https://f2f-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://f2f-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/f2f
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://f2f-cri.stubs.account.gov.uk/.well-known/jwks.json
     nino:
       id: nino
       name: NINO
@@ -272,19 +263,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://nino-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://nino-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://nino-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://nino-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/nino",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://nino-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://nino-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://nino-cri.stubs.account.gov.uk/token
+          credentialUrl: https://nino-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://nino-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/nino
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://nino-cri.stubs.account.gov.uk/.well-known/jwks.json
     bav:
       id: bav
       name: Bank account verification
@@ -293,19 +283,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://bav-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://bav-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://bav-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://bav-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/bav",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"true",
-          "jwksUrl":"https://bav-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://bav-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://bav-cri.stubs.account.gov.uk/token
+          credentialUrl: https://bav-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://bav-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/bav
+          requiresApiKey: false
+          requiresAdditionalEvidence: true
+          jwksUrl: https://bav-cri.stubs.account.gov.uk/.well-known/jwks.json
     dwpKbv:
       id: dwpKbv
       name: DWP KBV
@@ -314,19 +303,18 @@ core:
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "authorizeUrl":"https://dwp-kbv-cri.stubs.account.gov.uk/authorize",
-          "tokenUrl":"https://dwp-kbv-cri.stubs.account.gov.uk/token",
-          "credentialUrl":"https://dwp-kbv-cri.stubs.account.gov.uk/credentials/issue",
-          "clientId":"ipv-core-local",
-          "signingKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "encryptionKey":"{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}",
-          "componentId":"https://dwp-kbv-cri.stubs.account.gov.uk",
-          "clientCallbackUrl":"http://localhost:4501/credential-issuer/callback/dwpKbv",
-          "requiresApiKey":"false",
-          "requiresAdditionalEvidence":"false",
-          "jwksUrl":"https://dwp-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json"
-        }'
+        stub:
+          authorizeUrl: https://dwp-kbv-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://dwp-kbv-cri.stubs.account.gov.uk/token
+          credentialUrl: https://dwp-kbv-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://dwp-kbv-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dwpKbv
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://dwp-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json
     ticf:
       id: ticf
       name: Threat Intelligence and Counter Fraud
@@ -334,13 +322,12 @@ core:
       unavailable: "false"
       activeConnection: "stub"
       connections:
-        stub: '{
-          "credentialUrl": "https://ticf.stubs.account.gov.uk/risk-assessment",
-          "signingKey": "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}",
-          "componentId": "https://ticf.stubs.account.gov.uk",
-          "requiresApiKey": "true",
-          "requestTimeout": 5
-        }'
+        stub:
+          credentialUrl: https://ticf.stubs.account.gov.uk/risk-assessment
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}'
+          componentId: https://ticf.stubs.account.gov.uk
+          requiresApiKey: true
+          requestTimeout: 5
   local:
     asyncQueue:
       apiBaseUrl: "https://queue.stubs.account.gov.uk"

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -3,6 +3,7 @@
 ---
 core:
   self:
+    configFormat: "yaml"
     componentId: "https://identity.local.account.gov.uk"
     audienceForClients: "https://identity.local.account.gov.uk"
     jwtTtlSeconds: 3600


### PR DESCRIPTION
## Proposed changes
### What changed

- ConfigServices

### Why did it change

- To change config files to pure yaml, appropriate staging is required. We need to support both formats to avoid any application downtime. Once all config will be in yaml, another PR will be required to remove json support. This will significantly improve the readability of the code.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7877](https://govukverify.atlassian.net/browse/PYIC-7877)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-7877]: https://govukverify.atlassian.net/browse/PYIC-7877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ