### PR TITLE
PYIC-8411: Handle decommissioned CRI config

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
@@ -21,6 +21,7 @@ public enum Cri {
     F2F("f2f"),
     NINO("nino"),
     PASSPORT("ukPassport"),
+    HMRC_MIGRATION("hmrcMigration"),
     TICF("ticf");
 
     private final String id;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/Cri.java
@@ -21,7 +21,6 @@ public enum Cri {
     F2F("f2f"),
     NINO("nino"),
     PASSPORT("ukPassport"),
-    HMRC_MIGRATION("hmrcMigration"),
     TICF("ticf");
 
     private final String id;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -228,7 +228,11 @@ public abstract class ConfigService {
         Matcher matcher = pattern.matcher(parameterPath);
 
         if (matcher.find()) {
-            return Cri.fromId(matcher.group(1));
+            try {
+                return Cri.fromId(matcher.group(1));
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
         }
         return null;
     }


### PR DESCRIPTION
## Proposed changes
### What changed

- Handle decommissioned CRI config

### Why did it change

- Config is used to determine CRIs for getIssuerCris. This means we need to either handle unknown CRI configs or remove the config before this core-back PR. I am keener on removing config after having removed any possible usage. We could break this PR down or allow unknown CRI configs to exist, but ignore them.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8411](https://govukverify.atlassian.net/browse/PYIC-8411)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8411]: https://govukverify.atlassian.net/browse/PYIC-8411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ