### PR TITLE
PYIC-7189: SPIKE repeat CRI callbacks

### DIFF
--- a/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/pact/dcmawasynccri/ContractTest.java
+++ b/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/pact/dcmawasynccri/ContractTest.java
@@ -63,12 +63,16 @@ class ContractTest {
     private static final String IPV_CORE_CLIENT_ID = "ipv-core";
     private static final Clock CURRENT_TIME =
             Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC);
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
     public static final CriOAuthSessionItem CRI_OAUTH_SESSION_ITEM =
             new CriOAuthSessionItem(
                     "dummySessionId",
                     "dummyOAuthSessionId",
                     DCMAW_ASYNC.getId(),
                     "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
                     900);
 
     @Pact(provider = "DcmawAsyncCriProvider", consumer = "IpvCoreBack")

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
@@ -51,6 +51,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @MockServerConfig(hostInterface = "localhost")
 class CredentialTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private SecureTokenHelper mockSecureTokenHelper;
@@ -522,6 +525,8 @@ class CredentialTests {
                     "dummyOAuthSessionId",
                     ADDRESS.getId(),
                     "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
                     900);
 
     // We hardcode the VC headers and bodies like this so that it is easy to update them from JSON

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/TokenTests.java
@@ -57,6 +57,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @PactTestFor(providerName = "AddressCriTokenProvider")
 @MockServerConfig(hostInterface = "localhost")
 class TokenTests {
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private CoreSigner mockSigner;
@@ -203,7 +206,13 @@ class TokenTests {
     @NotNull
     private static CriOAuthSessionItem getCriOAuthSessionItem() {
         return new CriOAuthSessionItem(
-                "dummySessionId", "dummyOAuthSessionId", ADDRESS.getId(), "dummyConnection", 900);
+                "dummySessionId",
+                "dummyOAuthSessionId",
+                ADDRESS.getId(),
+                "dummyConnection",
+                MOCK_LOCK,
+                MOCK_PROCESS_RESULT,
+                900);
     }
 
     @NotNull

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/bavCri/ContractTest.java
@@ -70,6 +70,8 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @MockServerConfig(hostInterface = "localhost")
 class ContractTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
 
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
@@ -568,7 +570,13 @@ class ContractTest {
             Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC);
     public static final CriOAuthSessionItem CRI_OAUTH_SESSION_ITEM =
             new CriOAuthSessionItem(
-                    "dummySessionId", "dummyOAuthSessionId", BAV.getId(), "dummyConnection", 900);
+                    "dummySessionId",
+                    "dummyOAuthSessionId",
+                    BAV.getId(),
+                    "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
+                    900);
 
     // These values have come from the CRI team to make the JWT more realistic and match their test
     // environment

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/cicCri/ContractTest.java
@@ -70,6 +70,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @MockServerConfig(hostInterface = "localhost")
 class ContractTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private CoreSigner mockSigner;
@@ -440,6 +443,8 @@ class ContractTest {
                     "dummyOAuthSessionId",
                     CLAIMED_IDENTITY.getId(),
                     "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
                     900);
 
     // These values have come from the CRI team to make the JWT more realistic and match their test

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -74,6 +74,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @MockServerConfig(hostInterface = "localhost")
 class ContractTest {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private CoreSigner mockSigner;
@@ -1810,7 +1813,13 @@ class ContractTest {
             Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC);
     public static final CriOAuthSessionItem CRI_OAUTH_SESSION_ITEM =
             new CriOAuthSessionItem(
-                    "dummySessionId", "dummyOAuthSessionId", DCMAW.getId(), "dummyConnection", 900);
+                    "dummySessionId",
+                    "dummyOAuthSessionId",
+                    DCMAW.getId(),
+                    "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
+                    900);
 
     private static final String CLIENT_ASSERTION_SIGNING_KID = "testKid";
     private static final String CLIENT_ASSERTION_HEADER =

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/CredentialTests.java
@@ -57,6 +57,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @MockServerConfig(hostInterface = "localhost")
 class CredentialTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private SecureTokenHelper mockSecureTokenHelper;
@@ -597,6 +600,8 @@ class CredentialTests {
                     "dummyOAuthSessionId",
                     DRIVING_LICENCE.getId(),
                     "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
                     900);
 
     // We hardcode the VC headers and bodies like this so that it is easy to update them from JSON

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/drivingLicenceCri/TokenTests.java
@@ -56,6 +56,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @PactTestFor(providerName = "DrivingLicenceTokenProvider")
 @MockServerConfig(hostInterface = "localhost")
 class TokenTests {
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private CoreSigner mockSigner;
@@ -243,6 +246,8 @@ class TokenTests {
                     "dummyOAuthSessionId",
                     DRIVING_LICENCE.getId(),
                     "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
                     900);
 
     private static final String CLIENT_ASSERTION_SIGNING_KID = "testKid";

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
@@ -56,6 +56,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @PactTestFor(providerName = "ExperianKbvCriVcProvider")
 @MockServerConfig(hostInterface = "localhost")
 class CredentialTests {
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private SecureTokenHelper mockSecureTokenHelper;
@@ -549,6 +552,8 @@ class CredentialTests {
                 "dummyOAuthSessionId",
                 EXPERIAN_KBV.getId(),
                 "dummyConnection",
+                MOCK_LOCK,
+                MOCK_PROCESS_RESULT,
                 900);
     }
 

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/TokenTests.java
@@ -56,6 +56,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @PactTestFor(providerName = "ExperianKbvCriTokenProvider")
 @MockServerConfig(hostInterface = "localhost")
 class TokenTests {
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private CoreSigner mockSigner;
@@ -205,6 +208,8 @@ class TokenTests {
                 "dummyOAuthSessionId",
                 EXPERIAN_KBV.getId(),
                 "dummyConnection",
+                MOCK_LOCK,
+                MOCK_PROCESS_RESULT,
                 900);
     }
 

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/f2fCri/ContractTest.java
@@ -58,6 +58,8 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @PactTestFor(providerName = "F2fCriProvider")
 @MockServerConfig(hostInterface = "localhost")
 class ContractTest {
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private CoreSigner mockSigner;
@@ -118,6 +120,8 @@ class ContractTest {
                                 "dummyOAuthSessionId",
                                 F2F.getId(),
                                 "dummyConnection",
+                                MOCK_LOCK,
+                                MOCK_PROCESS_RESULT,
                                 900));
 
         assertEquals(
@@ -205,6 +209,8 @@ class ContractTest {
                                 "dummyOAuthSessionId",
                                 F2F.getId(),
                                 "dummyConnection",
+                                MOCK_LOCK,
+                                MOCK_PROCESS_RESULT,
                                 900));
         // Assert
         assertThat(accessToken.getType(), is(AccessTokenType.BEARER));
@@ -286,6 +292,8 @@ class ContractTest {
                                             "dummyOAuthSessionId",
                                             F2F.getId(),
                                             "dummyConnection",
+                                            MOCK_LOCK,
+                                            MOCK_PROCESS_RESULT,
                                             900));
                         });
 

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/CredentialTests.java
@@ -57,6 +57,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @MockServerConfig(hostInterface = "localhost")
 class CredentialTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private SecureTokenHelper mockSecureTokenHelper;
@@ -502,6 +505,8 @@ class CredentialTests {
                     "dummyOAuthSessionId",
                     EXPERIAN_FRAUD.getId(),
                     "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
                     900);
 
     // We hardcode the VC headers and bodies like this so that it is easy to update them from JSON

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/fraudCri/TokenTests.java
@@ -56,6 +56,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @PactTestFor(providerName = "FraudTokenProvider")
 @MockServerConfig(hostInterface = "localhost")
 class TokenTests {
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private CoreSigner mockSigner;
     @Mock private SignerFactory mockSignerFactory;
@@ -243,6 +246,8 @@ class TokenTests {
                     "dummyOAuthSessionId",
                     EXPERIAN_FRAUD.getId(),
                     "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
                     900);
 
     private static final String CLIENT_ASSERTION_SIGNING_KID = "testKid";

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/CredentialTests.java
@@ -59,6 +59,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @MockServerConfig(hostInterface = "localhost")
 class CredentialTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private SecureTokenHelper mockSecureTokenHelper;
@@ -590,7 +593,13 @@ class CredentialTests {
             Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC);
     public static final CriOAuthSessionItem CRI_OAUTH_SESSION_ITEM =
             new CriOAuthSessionItem(
-                    "dummySessionId", "dummyOAuthSessionId", NINO.getId(), "dummyConnection", 900);
+                    "dummySessionId",
+                    "dummyOAuthSessionId",
+                    NINO.getId(),
+                    "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
+                    900);
 
     // We hardcode the VC headers and bodies like this so that it is easy to update them from JSON
     // sent by the CRI team

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/TokenTests.java
@@ -56,6 +56,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @PactTestFor(providerName = "NinoCriTokenProvider")
 @MockServerConfig(hostInterface = "localhost")
 class TokenTests {
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private CoreSigner mockSigner;
@@ -239,7 +242,13 @@ class TokenTests {
             Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC);
     public static final CriOAuthSessionItem CRI_OAUTH_SESSION_ITEM =
             new CriOAuthSessionItem(
-                    "dummySessionId", "dummyOAuthSessionId", NINO.getId(), "dummyConnection", 900);
+                    "dummySessionId",
+                    "dummyOAuthSessionId",
+                    NINO.getId(),
+                    "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
+                    900);
 
     private static final String CLIENT_ASSERTION_SIGNING_KID = "testKid";
     private static final String CLIENT_ASSERTION_HEADER =

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/CredentialTests.java
@@ -59,6 +59,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @MockServerConfig(hostInterface = "localhost")
 class CredentialTests {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private CoreSigner mockSigner;
@@ -465,6 +468,8 @@ class CredentialTests {
                     "dummyOAuthSessionId",
                     PASSPORT.getId(),
                     "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
                     900);
 
     // We hardcode the VC headers and bodies like this so that it is easy to update them from JSON

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/passportCri/TokenTests.java
@@ -55,6 +55,9 @@ import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.RSA_ENCRYPTION_PU
 @PactTestFor(providerName = "PassportTokenProvider")
 @MockServerConfig(hostInterface = "localhost")
 class TokenTests {
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private ConfigService mockConfigService;
     @Mock private SignerFactory mockSignerFactory;
     @Mock private CoreSigner mockSigner;
@@ -246,6 +249,8 @@ class TokenTests {
                     "dummyOAuthSessionId",
                     PASSPORT.getId(),
                     "dummyConnection",
+                    MOCK_LOCK,
+                    MOCK_PROCESS_RESULT,
                     900);
 
     private static final String CLIENT_ASSERTION_SIGNING_KID = "testKid";

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -75,6 +75,7 @@ public class ProcessJourneyEventHandler
         implements RequestHandler<JourneyRequest, Map<String, Object>> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final String CURRENT_PAGE = "currentPage";
+    private static final String CURRENT_CRI = "currentCriId";
     private static final String CORE_SESSION_TIMEOUT_STATE = "CORE_SESSION_TIMEOUT";
     private static final String NEXT_EVENT = "next";
     private static final StepResponse BUILD_CLIENT_OAUTH_RESPONSE =
@@ -158,6 +159,7 @@ public class ProcessJourneyEventHandler
             String ipAddress = RequestHelper.getIpAddress(journeyRequest);
             String deviceInformation = journeyRequest.getDeviceInformation();
             String currentPage = RequestHelper.getJourneyParameter(journeyRequest, CURRENT_PAGE);
+            String currentCri = RequestHelper.getJourneyParameter(journeyRequest, CURRENT_CRI);
             configService.setFeatureSet(RequestHelper.getFeatureSet(journeyRequest));
 
             // Get/ set session items/ config
@@ -185,6 +187,7 @@ public class ProcessJourneyEventHandler
                             auditEventUser,
                             deviceInformation,
                             currentPage,
+                            currentCri,
                             clientOAuthSessionItem);
 
             ipvSessionService.updateIpvSession(ipvSessionItem);
@@ -219,6 +222,7 @@ public class ProcessJourneyEventHandler
             AuditEventUser auditEventUser,
             String deviceInformation,
             String currentPage,
+            String currentCri,
             ClientOAuthSessionItem clientOAuthSessionItem)
             throws JourneyEngineException {
         if (sessionIsNewlyExpired(ipvSessionItem)) {
@@ -235,6 +239,7 @@ public class ProcessJourneyEventHandler
                             ipvSessionItem,
                             journeyEvent,
                             currentPage,
+                            currentCri,
                             auditEventUser,
                             deviceInformation,
                             clientOAuthSessionItem);
@@ -256,6 +261,7 @@ public class ProcessJourneyEventHandler
                                 journeyStateFrom(journeyChangeState),
                                 ipvSessionItem,
                                 NEXT_EVENT,
+                                null,
                                 null,
                                 auditEventUser,
                                 deviceInformation,
@@ -296,12 +302,17 @@ public class ProcessJourneyEventHandler
         }
     }
 
-    @SuppressWarnings("java:S3776") // Cognitive Complexity of methods should not be too high
+    @SuppressWarnings({
+        "java:S3776",
+        "java:S107"
+    }) // // Cognitive Complexity of methods should not be too high, Methods should not have too
+    // many parameters
     private State executeStateTransition(
             JourneyState initialJourneyState,
             IpvSessionItem ipvSessionItem,
             String journeyEvent,
             String currentPage,
+            String currentCri,
             AuditEventUser auditEventUser,
             String deviceInformation,
             ClientOAuthSessionItem clientOAuthSessionItem)
@@ -334,6 +345,7 @@ public class ProcessJourneyEventHandler
                         initialJourneyState.state(),
                         journeyEvent,
                         currentPage,
+                        currentCri,
                         new EventResolveParameters(
                                 ipvSessionItem.getJourneyContext(),
                                 ipvSessionItem,

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
@@ -36,6 +36,7 @@ public class StateMachine {
             String startState,
             String event,
             String currentPage,
+            String currentCri,
             EventResolveParameters eventResolveParameters,
             EventResolver eventResolver)
             throws UnknownEventException, UnknownStateException, JourneyEngineException {
@@ -56,6 +57,14 @@ public class StateMachine {
                                 "Unexpected page event (%s) from page (%s) received in process state (%s)",
                                 event, currentPage, startState));
             }
+        }
+
+        // Check CRI event is allowed
+        if (currentCri != null
+                && state instanceof BasicState basicState
+                && basicState.getResponse() instanceof CriStepResponse criStepResponse
+                && !criStepResponse.getCriId().equals(currentCri)) {
+            return new TransitionResult(state);
         }
 
         var result = state.transition(event, startState, eventResolveParameters, eventResolver);

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.BasicState;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.NestedJourneyDefinition;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.NestedJourneyInvokeState;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.states.State;
+import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.CriStepResponse;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.PageStepResponse;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.ProcessStepResponse;
 
@@ -313,6 +314,32 @@ class StateMachineTest {
                         "event",
                         null,
                         null,
+                        EVENT_RESOLVE_PARAMETERS,
+                        eventResolver);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    void transitionShouldHandleIfCriStateDoesNotMatchExpectedCri() throws Exception {
+        var startingState = mock(BasicState.class);
+        var criStepResponse = new CriStepResponse();
+        criStepResponse.setCriId("notTheRightIssuer");
+        when(startingState.getResponse()).thenReturn(criStepResponse);
+        var expectedResult = new TransitionResult(startingState);
+
+        StateMachineInitializer mockStateMachineInitializer = mock(StateMachineInitializer.class);
+        when(mockStateMachineInitializer.initialize())
+                .thenReturn(Map.of("START_STATE", startingState));
+
+        StateMachine stateMachine = new StateMachine(mockStateMachineInitializer);
+
+        var actualResult =
+                stateMachine.transition(
+                        "START_STATE",
+                        "event",
+                        null,
+                        "exampleIssuer",
                         EVENT_RESOLVE_PARAMETERS,
                         eventResolver);
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineTest.java
@@ -50,7 +50,12 @@ class StateMachineTest {
 
         var actualResult =
                 stateMachine.transition(
-                        "START_STATE", "event", null, EVENT_RESOLVE_PARAMETERS, eventResolver);
+                        "START_STATE",
+                        "event",
+                        null,
+                        null,
+                        EVENT_RESOLVE_PARAMETERS,
+                        eventResolver);
 
         assertEquals(expectedResult, actualResult);
     }
@@ -69,6 +74,7 @@ class StateMachineTest {
                         stateMachine.transition(
                                 "UNKNOWN_STATE",
                                 "event",
+                                null,
                                 null,
                                 EVENT_RESOLVE_PARAMETERS,
                                 eventResolver));
@@ -95,7 +101,12 @@ class StateMachineTest {
 
         var actualResult =
                 stateMachine.transition(
-                        "START_STATE", "event", null, EVENT_RESOLVE_PARAMETERS, eventResolver);
+                        "START_STATE",
+                        "event",
+                        null,
+                        null,
+                        EVENT_RESOLVE_PARAMETERS,
+                        eventResolver);
 
         assertEquals(expectedResult, actualResult);
     }
@@ -129,7 +140,12 @@ class StateMachineTest {
         // Act
         var actualResult =
                 stateMachine.transition(
-                        "START_STATE", "event", null, EVENT_RESOLVE_PARAMETERS, eventResolver);
+                        "START_STATE",
+                        "event",
+                        null,
+                        null,
+                        EVENT_RESOLVE_PARAMETERS,
+                        eventResolver);
 
         // Assert
         var expectedResult =
@@ -170,7 +186,12 @@ class StateMachineTest {
         // Act
         var actualResult =
                 stateMachine.transition(
-                        "START_STATE", "event", null, EVENT_RESOLVE_PARAMETERS, eventResolver);
+                        "START_STATE",
+                        "event",
+                        null,
+                        null,
+                        EVENT_RESOLVE_PARAMETERS,
+                        eventResolver);
 
         // Assert
         var expectedResult =
@@ -216,7 +237,12 @@ class StateMachineTest {
         // Act
         var actualResult =
                 stateMachine.transition(
-                        "START_STATE", "event", null, EVENT_RESOLVE_PARAMETERS, eventResolver);
+                        "START_STATE",
+                        "event",
+                        null,
+                        null,
+                        EVENT_RESOLVE_PARAMETERS,
+                        eventResolver);
 
         // Assert
         var expectedResult =
@@ -258,7 +284,7 @@ class StateMachineTest {
 
         var actualResult =
                 stateMachine.transition(
-                        "START_STATE", event, null, EVENT_RESOLVE_PARAMETERS, eventResolver);
+                        "START_STATE", event, null, null, EVENT_RESOLVE_PARAMETERS, eventResolver);
 
         assertEquals(expectedResult, actualResult);
     }
@@ -285,6 +311,7 @@ class StateMachineTest {
                 stateMachine.transition(
                         "START_STATE/NESTED_JOURNEY",
                         "event",
+                        null,
                         null,
                         EVENT_RESOLVE_PARAMETERS,
                         eventResolver);

--- a/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
+++ b/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
@@ -52,6 +52,9 @@ class ProcessMobileAppCallbackHandlerTest {
     private static final String TEST_CLIENT_OAUTH_SESSION_ID = "test_client_oauth_id";
     private static final String TEST_OAUTH_STATE = "test_oauth_state";
     private static final String TEST_USER_ID = "test_user_id";
+    private static final String MOCK_LOCK = "2025-07-28T10:14:07.494907165Z";
+    private static final String MOCK_PROCESS_RESULT = "/journey/next";
+
     @Mock private Context mockContext;
     @Mock private ConfigService configService;
     @Mock private IpvSessionService ipvSessionService;
@@ -94,6 +97,8 @@ class ProcessMobileAppCallbackHandlerTest {
                         TEST_CLIENT_OAUTH_SESSION_ID,
                         Cri.DCMAW_ASYNC.toString(),
                         "test_connection",
+                        MOCK_LOCK,
+                        MOCK_PROCESS_RESULT,
                         3600);
         when(criOAuthSessionService.getCriOauthSessionItem(TEST_OAUTH_STATE))
                 .thenReturn(criOAuthSessionItem);
@@ -139,6 +144,8 @@ class ProcessMobileAppCallbackHandlerTest {
                         TEST_CLIENT_OAUTH_SESSION_ID,
                         Cri.DCMAW_ASYNC.toString(),
                         "test_connection",
+                        MOCK_LOCK,
+                        MOCK_PROCESS_RESULT,
                         3600);
         when(criOAuthSessionService.getCriOauthSessionItem(TEST_OAUTH_STATE))
                 .thenReturn(criOAuthSessionItem);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -121,7 +121,8 @@ public enum ErrorResponse {
     FAILED_TO_EXTRACT_CIS_FROM_VC(1106, "Failed to extract contra-indicators from VC"),
     MISSING_SECURITY_CHECK_CREDENTIAL(1107, "Missing security check credential"),
     FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS(1108, "Failed to create stored identity for EVCS"),
-    ERROR_CALLING_AIS_API(1109, "Error when calling AIS API");
+    ERROR_CALLING_AIS_API(1109, "Error when calling AIS API"),
+    REPEAT_CRI_CALLBACK(1110, "Repeat CRI callback");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/CriOAuthSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/CriOAuthSessionItem.java
@@ -19,6 +19,8 @@ public class CriOAuthSessionItem implements PersistenceItem {
     private String clientOAuthSessionId;
     private String criId;
     private String connection;
+    private String lockedTimestamp;
+    private String processedResult;
     private long ttl;
 
     @DynamoDbPartitionKey

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionService.java
@@ -14,6 +14,8 @@ import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 import uk.gov.di.ipv.core.library.retry.Retry;
 import uk.gov.di.ipv.core.library.retry.Sleeper;
 
+import java.time.Instant;
+
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CRI_OAUTH_SESSIONS_TABLE_NAME;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_OAUTH_SESSION_ID;
@@ -86,5 +88,15 @@ public class CriOAuthSessionService {
                                 LOG_CRI_OAUTH_SESSION_ID.getFieldName(),
                                 criOAuthSessionItem.getCriOAuthSessionId()));
         return criOAuthSessionItem;
+    }
+
+    public void setLockedTimestamp(CriOAuthSessionItem criOAuthSessionItem) {
+        criOAuthSessionItem.setLockedTimestamp(Instant.now().toString());
+        dataStore.update(criOAuthSessionItem);
+    }
+
+    public void setProcessedResult(CriOAuthSessionItem criOAuthSessionItem, String resultingEvent) {
+        criOAuthSessionItem.setProcessedResult(resultingEvent);
+        dataStore.update(criOAuthSessionItem);
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/CriOAuthSessionServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.service;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.StringUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -12,6 +13,7 @@ import uk.gov.di.ipv.core.library.retry.Sleeper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -105,5 +107,41 @@ class CriOAuthSessionServiceTest {
 
         assertEquals(criOAuthSessionItem.getCriOAuthSessionId(), result.getCriOAuthSessionId());
         assertEquals(criOAuthSessionItem.getCriId(), result.getCriId());
+    }
+
+    @Test
+    void shouldUpdateCriOAuthSessionItemWithLockTimestamp() {
+        var criOAuthSessionItem =
+                CriOAuthSessionItem.builder()
+                        .criOAuthSessionId("testState")
+                        .criId(ADDRESS.getId())
+                        .connection("main")
+                        .build();
+
+        criOauthSessionService.setLockedTimestamp(criOAuthSessionItem);
+
+        var criOAuthSessionItemArgumentCaptor = ArgumentCaptor.forClass(CriOAuthSessionItem.class);
+        verify(mockDataStore, times(1)).update(criOAuthSessionItemArgumentCaptor.capture());
+        assertTrue(
+                StringUtils.isNotBlank(
+                        criOAuthSessionItemArgumentCaptor.getValue().getLockedTimestamp()));
+    }
+
+    @Test
+    void shouldUpdateCriOAuthSessionItemWithJourneyResult() {
+        var criOAuthSessionItem =
+                CriOAuthSessionItem.builder()
+                        .criOAuthSessionId("testState")
+                        .criId(ADDRESS.getId())
+                        .connection("main")
+                        .build();
+
+        criOauthSessionService.setProcessedResult(criOAuthSessionItem, "some-journey-result");
+
+        var criOAuthSessionItemArgumentCaptor = ArgumentCaptor.forClass(CriOAuthSessionItem.class);
+        verify(mockDataStore, times(1)).update(criOAuthSessionItemArgumentCaptor.capture());
+        assertEquals(
+                "some-journey-result",
+                criOAuthSessionItemArgumentCaptor.getValue().getProcessedResult());
     }
 }

--- a/libs/cri-checking-service/src/main/java/uk/gov/di/ipv/core/library/cricheckingservice/CriCheckingService.java
+++ b/libs/cri-checking-service/src/main/java/uk/gov/di/ipv/core/library/cricheckingservice/CriCheckingService.java
@@ -206,8 +206,7 @@ public class CriCheckingService {
         if (StringUtils.isBlank(state)) {
             throw new InvalidCriCallbackRequestException(ErrorResponse.MISSING_OAUTH_STATE);
         }
-        if (criOAuthSessionItem == null
-                || !state.equals(criOAuthSessionItem.getCriOAuthSessionId())) {
+        if (!state.equals(criOAuthSessionItem.getCriOAuthSessionId())) {
             throw new InvalidCriCallbackRequestException(ErrorResponse.INVALID_OAUTH_STATE);
         }
         try {

--- a/openAPI/core-back-internal.yaml
+++ b/openAPI/core-back-internal.yaml
@@ -108,7 +108,7 @@ paths:
             Fn::Sub: >
               {
               "input": "{
-              \"journey\":\"/journey/$util.escapeJavaScript($input.params('journeyStep'))?currentPage=$util.escapeJavaScript($input.params().querystring.get('currentPage'))\",
+              \"journey\":\"/journey/$util.escapeJavaScript($input.params('journeyStep'))?currentPage=$util.escapeJavaScript($input.params().querystring.get('currentPage'))&currentCriId=$util.escapeJavaScript($input.params().querystring.get('currentCriId'))\",
               \"ipAddress\":\"$util.escapeJavaScript($input.params('ip-address'))\",
               \"deviceInformation\":\"$util.escapeJavaScript($input.params('txma-audit-encoded'))\",
               \"featureSet\":\"$util.escapeJavaScript($input.params('feature-set'))\",


### PR DESCRIPTION
## Proposed changes
### What changed

- Adding lock timestamp to CriOauthSessionItem (this expires after 5 minutes) if the callback has not yet been processed.
Processing continues after this and resulting journey saved to CriOauthSessionItem
- If record is locked:
    - Previous callback has finished processing: return journey saved onto CriOauthSessionItem
    - Previous callback still processing: return attempt-recovery page. If previous callback has finished, we recover the user state (e.g. the success screen) otherwise they get redirected back to the previous state (CRI) and have to go through the CRI again. 

I also experimented with trying to check the CriOauthSessionItem again in ProcessJourneyEvent if the `attempt-recovery` event was given AND the current state is a CRI state so that we can check here again if the processing was complete on that oauthState. This could help with lengthening the window to process the callback. However, if still not complete by then, the user would have to go through the CRI again.

I also thought about trying to return the user back to the attempt-recovery screen if the processing wasn't finished (at the point where the user selects continue from the attempt-recovery screen) but this added quite a bit more complexity which I thought wasn't worth it if the CRIs mostly affected are the DCMAW (not really used anymore with V2 app) and CIC (fairly quick and easy to go through) CRIs.

**Testing Results:**
<meta charset="utf-8"><div dir="ltr" style="margin-left:0pt;" align="left">
Scenario | Outcome
-- | --
Request has finished processing once the user selects continue from the attempt recovery screen | Recovers to intended state e.g. successful VC recovers to page-dcmaw-success
Request is still processing when the user continues from attempt-recovery screen | Recovers at DCMAW state so user would have to go through CRI again
More than 2 repeated callbacks First request has finished processing once user continues from attempt-recovery | Recovers to intended state e.g. dcmaw-success page given successful VC
More than 2 repeated callbacks First request is still processing once user continues from attempt-recovery | Recovers to CRI state (DCMAW) and user has to go through CRI again
More than 2 repeat callbacksRecord lock expires before the user selects to continue from attempt-recovery | Recovers to dcmaw-success page
First callback is successfulSecond callback is server_error | Recovers to dcmaw-success page
First callback is successfulSecond callback is access_denied | Recovers to dcmaw-success page
First callback is server_errorSecond callback is successful | Recovers to pyi-technical screen
First callback is access_deniedSecond callback is successful | Recovers to multiple-doc-check page
Pressing back after callback then making another callback | Recovers to dcmaw-success page
Regression check:Single callback results in correct state | Results in dcmaw-success page

</div>

### Why did it change

- When a user makes repeat CRI callbacks, their journey may error e.g. if the second callback is an error which will be processed faster than the first request or the second request fails with invalid oauth state as the auth code was used twice. Hopefully, this ensures that only one request is dealt with at a time and returns the result from the previous request without having to process subsequent ones.

**Impact:**
From 30/06/2025-28/07/2025, the number of repeat callbacks by CRI:
<img width="253" height="135" alt="Screenshot 2025-07-29 at 17 02 16" src="https://github.com/user-attachments/assets/c043717d-a06a-460c-998d-0597256ef8c1" />

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7189](https://govukverify.atlassian.net/browse/PYIC-7189)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code


[PYIC-7189]: https://govukverify.atlassian.net/browse/PYIC-7189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ