### PR TITLE
PYIC-7877: Update ConfigService to correctly refresh parameters

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
@@ -99,7 +99,7 @@ public class AppConfigService extends YamlParametersConfigService {
 
         var retrievedParamsHash = getParamsRawHash(paramsRaw);
         if (!Objects.equals(paramsRawHash, retrievedParamsHash)) {
-            updateParameters(parameters, paramsRaw);
+            setParameters(updateParameters(paramsRaw));
             paramsRawHash = retrievedParamsHash;
         }
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
@@ -99,7 +99,7 @@ public class AppConfigService extends YamlParametersConfigService {
 
         var retrievedParamsHash = getParamsRawHash(paramsRaw);
         if (!Objects.equals(paramsRawHash, retrievedParamsHash)) {
-            setParameters(updateParameters(paramsRaw));
+            setParameters(parseParameters(paramsRaw));
             paramsRawHash = retrievedParamsHash;
         }
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlConfigService.java
@@ -31,14 +31,14 @@ public class YamlConfigService extends YamlParametersConfigService {
     }
 
     public YamlConfigService(File parametersFile, File secretsFile) {
-        setParameters(updateParameters(parametersFile));
-        secrets = updateParameters(secretsFile);
+        setParameters(parseParameters(parametersFile));
+        secrets = parseParameters(secretsFile);
     }
 
-    private Map<String, String> updateParameters(File yamlFile) {
+    private Map<String, String> parseParameters(File yamlFile) {
         try {
             String yamlContent = Files.readString(yamlFile.toPath());
-            return updateParameters(yamlContent);
+            return parseParameters(yamlContent);
         } catch (IOException e) {
             throw new IllegalArgumentException("Could not read parameters yaml file", e);
         }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlConfigService.java
@@ -24,21 +24,21 @@ public class YamlConfigService extends YamlParametersConfigService {
         this.featureSet.remove();
     }
 
-    private final Map<String, String> secrets = new HashMap<>();
+    private Map<String, String> secrets = new HashMap<>();
 
     public YamlConfigService() {
         this(PARAMETERS_FILE, SECRETS_FILE);
     }
 
     public YamlConfigService(File parametersFile, File secretsFile) {
-        updateParameters(parameters, parametersFile);
-        updateParameters(secrets, secretsFile);
+        setParameters(updateParameters(parametersFile));
+        secrets = updateParameters(secretsFile);
     }
 
-    private void updateParameters(Map<String, String> map, File yamlFile) {
+    private Map<String, String> updateParameters(File yamlFile) {
         try {
             String yamlContent = Files.readString(yamlFile.toPath());
-            updateParameters(map, yamlContent);
+            return updateParameters(yamlContent);
         } catch (IOException e) {
             throw new IllegalArgumentException("Could not read parameters yaml file", e);
         }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
@@ -67,7 +67,7 @@ public abstract class YamlParametersConfigService extends ConfigService {
         return lookupParams;
     }
 
-    protected Map<String, String> updateParameters(String yaml) {
+    protected Map<String, String> parseParameters(String yaml) {
         var map = new HashMap<String, String>();
         try {
             var yamlParsed = YAML_OBJECT_MAPPER.readTree(yaml).get(CORE);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
@@ -64,6 +64,7 @@ public abstract class YamlParametersConfigService extends ConfigService {
     }
 
     protected void updateParameters(Map<String, String> map, String yaml) {
+        map.clear();
         try {
             var yamlParsed = YAML_OBJECT_MAPPER.readTree(yaml).get(CORE);
             addJsonConfig(map, yamlParsed, "");

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/YamlParametersConfigService.java
@@ -19,7 +19,11 @@ public abstract class YamlParametersConfigService extends ConfigService {
     public static final ObjectMapper YAML_OBJECT_MAPPER =
             new ObjectMapper(new YAMLFactory()).configure(STRICT_DUPLICATE_DETECTION, true);
 
-    public final Map<String, String> parameters = new HashMap<>();
+    private Map<String, String> parameters = new HashMap<>();
+
+    protected void setParameters(Map<String, String> newParameters) {
+        parameters = newParameters;
+    }
 
     @Override
     public String getParameter(String path) {
@@ -63,11 +67,12 @@ public abstract class YamlParametersConfigService extends ConfigService {
         return lookupParams;
     }
 
-    protected void updateParameters(Map<String, String> map, String yaml) {
-        map.clear();
+    protected Map<String, String> updateParameters(String yaml) {
+        var map = new HashMap<String, String>();
         try {
             var yamlParsed = YAML_OBJECT_MAPPER.readTree(yaml).get(CORE);
             addJsonConfig(map, yamlParsed, "");
+            return map;
         } catch (IOException e) {
             throw new IllegalArgumentException("Could not load parameters yaml", e);
         }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -202,10 +202,12 @@ class AppConfigServiceTest {
     @Test
     void getParameterReturnsUpdatedParameters() {
         // Act
-        var param = configService.getParameter(ConfigurationVariable.COMPONENT_ID);
+        var componentId = configService.getParameter(ConfigurationVariable.COMPONENT_ID);
+        var bearerTokenTtl = configService.getParameter(ConfigurationVariable.BEARER_TOKEN_TTL);
 
         // Assert
-        assertEquals("test-component-id", param);
+        assertEquals("test-component-id", componentId);
+        assertEquals("1800", bearerTokenTtl);
 
         // Arrange
         when(appConfigProvider.get(any()))
@@ -217,10 +219,10 @@ class AppConfigServiceTest {
         """);
 
         // Act
-        param = configService.getParameter(ConfigurationVariable.COMPONENT_ID);
+        componentId = configService.getParameter(ConfigurationVariable.COMPONENT_ID);
 
         // Assert
-        assertEquals("different-component-id", param);
+        assertEquals("different-component-id", componentId);
         assertThrows(
                 ConfigParameterNotFoundException.class,
                 () -> configService.getParameter(ConfigurationVariable.BEARER_TOKEN_TTL));

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -221,6 +221,9 @@ class AppConfigServiceTest {
 
         // Assert
         assertEquals("different-component-id", param);
+        assertThrows(
+                ConfigParameterNotFoundException.class,
+                () -> configService.getParameter(ConfigurationVariable.BEARER_TOKEN_TTL));
     }
 
     // Feature flags


### PR DESCRIPTION
## Proposed changes
### What changed

- Update config service to correctly refresh parameters

### Why did it change

- Parameters were previously being added to a map, instead of replacing it. This meant a Lambda, while it was alive, would just gain attributes. In this case, it failed as we tried to handle an old parameter in a new way:
https://gds.slack.com/archives/C05TJ52FZ8B/p1753883130036029

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7877](https://govukverify.atlassian.net/browse/PYIC-7877)
- https://gds.slack.com/archives/C05TJ52FZ8B/p1753883130036029

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-7877]: https://govukverify.atlassian.net/browse/PYIC-7877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ