### PR TITLE
PYIC-7877 Allow getCriIssuers to receive it for multiple connections

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -24,7 +24,6 @@ public enum ConfigurationVariable {
     CREDENTIAL_ISSUER_ACTIVE_CONNECTION("credentialIssuers/%s/activeConnection"),
     CREDENTIAL_ISSUER_CONNECTION_PREFIX("credentialIssuers/%s/connections"),
     CREDENTIAL_ISSUER_CONFIG("credentialIssuers/%s/connections/%s"),
-    CREDENTIAL_ISSUER_COMPONENT_ID("credentialIssuers/%s/connections/%s/componentId"),
     CREDENTIAL_ISSUER_ENABLED("credentialIssuers/%s/enabled"),
     CREDENTIAL_ISSUER_HISTORIC_SIGNING_KEYS("credentialIssuers/%s/historicSigningKeys"),
     CREDENTIAL_ISSUER_SHARED_ATTRIBUTES("credentialIssuers/%s/allowedSharedAttributes"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -285,15 +285,19 @@ public abstract class ConfigService {
             if (cri.getId().equals(Cri.CIMIT.getId())) {
                 continue;
             }
+
+            var connectionsPath =
+                    String.format(
+                            ConfigurationVariable.CREDENTIAL_ISSUER_CONNECTION_PREFIX.getPath(),
+                            cri.getId());
+
+            var pattern = Pattern.compile("[^/]+/componentId");
             try {
-                var connection = getActiveConnection(cri);
-                var path =
-                        String.format(
-                                ConfigurationVariable.CREDENTIAL_ISSUER_COMPONENT_ID.getPath(),
-                                cri.getId(),
-                                connection);
-                var componentId = getParameter(path);
-                issuerToCri.put(componentId, cri);
+                var connections =
+                        getParametersByPrefixYaml(connectionsPath).entrySet().stream()
+                                .filter(entry -> pattern.matcher(entry.getKey()).find())
+                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                connections.values().forEach(value -> issuerToCri.put(value, cri));
             } catch (ConfigParameterNotFoundException e) {
                 LOGGER.warn(
                         LogHelper.buildLogMessage(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -291,7 +291,7 @@ public abstract class ConfigService {
                             ConfigurationVariable.CREDENTIAL_ISSUER_CONNECTION_PREFIX.getPath(),
                             cri.getId());
 
-            var pattern = Pattern.compile("[^/]+/componentId");
+            var pattern = Pattern.compile("[^/]++/componentId");
             try {
                 var connections =
                         getParametersByPrefixYaml(connectionsPath).entrySet().stream()

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -291,11 +291,10 @@ public abstract class ConfigService {
                             ConfigurationVariable.CREDENTIAL_ISSUER_CONNECTION_PREFIX.getPath(),
                             cri.getId());
 
-            var pattern = Pattern.compile("[^/]++/componentId");
             try {
                 var connections =
                         getParametersByPrefixYaml(connectionsPath).entrySet().stream()
-                                .filter(entry -> pattern.matcher(entry.getKey()).find())
+                                .filter(entry -> entry.getKey().endsWith("/componentId"))
                                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
                 connections.values().forEach(value -> issuerToCri.put(value, cri));
             } catch (ConfigParameterNotFoundException e) {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceYamlTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceYamlTest.java
@@ -141,7 +141,9 @@ class AppConfigServiceYamlTest {
         // Act & Assert
         var config = configService.getIssuerCris();
 
-        assertEquals(Map.of("main-issuer", ADDRESS, "dcmaw-issuer", DCMAW), config);
+        assertEquals(
+                Map.of("stub-issuer", ADDRESS, "main-issuer", ADDRESS, "dcmaw-issuer", DCMAW),
+                config);
     }
 
     // OAuth CRI config

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceTest.java
@@ -81,8 +81,6 @@ class SsmConfigServiceTest {
 
     @Mock SSMProvider ssmProvider;
 
-    @Mock private SSMProvider ssmRecursiveMock;
-
     @Mock SecretsProvider secretsProvider;
 
     private ConfigService configService;

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/SsmConfigServiceYamlTest.java
@@ -320,81 +320,53 @@ class SsmConfigServiceYamlTest {
                             "/test/core/credentialIssuers/address/connections/stub/componentId"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/bav/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/bav/connections/stub/componentId"))
-                    .thenReturn("https://stub-bav-component-id");
+            when(ssmProvider.getMultiple("/test/core/credentialIssuers/bav/connections"))
+                    .thenReturn(
+                            Map.of(
+                                    "stub/componentId", "https://stub-bav-component-id",
+                                    "test/componentId", "https://test-bav-component-id",
+                                    "random/key", "randomValue"));
 
-            when(ssmProvider.get("/test/core/credentialIssuers/dcmaw/activeConnection"))
-                    .thenReturn("stub");
-            when(ssmProvider.get("/test/core/credentialIssuers/dcmaw/connections/stub/componentId"))
-                    .thenReturn("https://stub-dcmaw-component-id");
+            when(ssmProvider.getMultiple("/test/core/credentialIssuers/dcmaw/connections"))
+                    .thenReturn(
+                            Map.of(
+                                    "stub/componentId", "https://stub-dcmaw-component-id",
+                                    "random/key", "randomValue"));
 
-            when(ssmProvider.get("/test/core/credentialIssuers/cimit/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get("/test/core/credentialIssuers/cimit/connections/stub/componentId"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-
-            when(ssmProvider.get("/test/core/credentialIssuers/claimedIdentity/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get(
-                            "/test/core/credentialIssuers/claimedIdentity/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/cimit/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/dcmawAsync/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get(
-                            "/test/core/credentialIssuers/dcmawAsync/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/claimedIdentity/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/drivingLicence/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get(
-                            "/test/core/credentialIssuers/drivingLicence/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/dcmawAsync/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/dwpKbv/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get(
-                            "/test/core/credentialIssuers/dwpKbv/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/drivingLicence/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/fraud/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get("/test/core/credentialIssuers/fraud/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/dwpKbv/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/experianKbv/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get(
-                            "/test/core/credentialIssuers/experianKbv/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/fraud/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/f2f/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get("/test/core/credentialIssuers/f2f/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/experianKbv/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/hmrcMigration/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get(
-                            "/test/core/credentialIssuers/hmrcMigration/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/f2f/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/nino/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get("/test/core/credentialIssuers/nino/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/hmrcMigration/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/activeConnection"))
-                    .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get(
-                            "/test/core/credentialIssuers/ukPassport/connections/stub/componentId"))
+            when(ssmProvider.get("/test/core/credentialIssuers/nino/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
 
-            when(ssmProvider.get("/test/core/credentialIssuers/ticf/activeConnection"))
+            when(ssmProvider.get("/test/core/credentialIssuers/ukPassport/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
-            when(ssmProvider.get("/test/core/credentialIssuers/ticf/connections/stub/componentId"))
+
+            when(ssmProvider.get("/test/core/credentialIssuers/ticf/connections"))
                     .thenThrow(ConfigParameterNotFoundException.class);
         }
 
@@ -404,6 +376,8 @@ class SsmConfigServiceYamlTest {
                     Map.of(
                             "https://stub-dcmaw-component-id",
                             Cri.DCMAW,
+                            "https://test-bav-component-id",
+                            Cri.BAV,
                             "https://stub-bav-component-id",
                             Cri.BAV),
                     configService.getIssuerCris());


### PR DESCRIPTION
## Proposed changes
### What changed

- Allow getIssuersCris in yaml format to return multiple issuers for each connection.

### Why did it change

- Staging environment uses multiple connections for cris

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7877](https://govukverify.atlassian.net/browse/PYIC-7877)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-7877]: https://govukverify.atlassian.net/browse/PYIC-7877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ