### PR TITLE
PYIC-7878: Create Config class

### DIFF
--- a/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/pact/dcmawasynccri/ContractTest.java
+++ b/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/pact/dcmawasynccri/ContractTest.java
@@ -60,6 +60,7 @@ class ContractTest {
             "https://identity.staging.account.gov.uk/app/callback?state=%s";
     private static final String TEST_OAUTH_STATE = "DUMMY_RANDOM_OAUTH_STATE";
     private static final String TEST_ISSUER = "dummyDcmawAsyncComponentId";
+    private static final String TEST_ENCRYPTION_KEY = "dummyDcmawAsyncEncryptionKey";
     private static final String IPV_CORE_CLIENT_ID = "ipv-core";
     private static final Clock CURRENT_TIME =
             Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneOffset.UTC);
@@ -403,6 +404,7 @@ class ContractTest {
                 .authorizeUrl(new URI("http://localhost:" + mockServer.getPort() + "/authorize"))
                 .clientId(IPV_CORE_CLIENT_ID)
                 .componentId(TEST_ISSUER)
+                .encryptionKey(TEST_ENCRYPTION_KEY)
                 .clientCallbackUrl(
                         isMam
                                 ? URI.create(String.format(CALLBACK_URL_TEMPLATE, TEST_OAUTH_STATE))

--- a/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriServiceTest.java
+++ b/lambdas/call-dcmaw-async-cri/src/test/java/uk/gov/di/ipv/core/calldcmawasynccri/service/DcmawAsyncCriServiceTest.java
@@ -46,9 +46,11 @@ class DcmawAsyncCriServiceTest {
     private static final String CRI_OAUTH_STATE = "cri-oauth-state";
     public static final String TEST_SECRET = "test-secret";
     public static final String CRI_CLIENT_ID = "cri-client-id";
+    public static final String AUTHORIZE_URL = "https://example.com/authorize";
     public static final String CREDENTIAL_URL = "https://example.com/credentialbackUrl";
     public static final String TOKEN_URL = "https://example.com/tokenUrl";
     private static final String REDIRECT_URL = "https://example.com/callbackUrl";
+    public static final String TEST_ENCRYPTION = "test-secret";
     public static final String ACCESS_TOKEN = "accessToken";
     public static final String USER_ID = "userId";
     public static final String JOURNEY_ID = "journeyId";
@@ -83,11 +85,13 @@ class DcmawAsyncCriServiceTest {
         var criConfig =
                 OauthCriConfig.builder()
                         .tokenUrl(new URI(TOKEN_URL))
+                        .authorizeUrl(new URI(AUTHORIZE_URL))
                         .credentialUrl(new URI(CREDENTIAL_URL))
                         .clientId(CRI_CLIENT_ID)
                         .clientCallbackUrl(URI.create(REDIRECT_URL))
                         .requiresApiKey(false)
                         .requiresAdditionalEvidence(false)
+                        .encryptionKey(TEST_ENCRYPTION)
                         .build();
 
         var criOAuthSessionItem =

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -66,6 +66,7 @@ class ProcessAsyncCriCredentialHandlerTest {
     private static final String TEST_JOURNEY_ID = "test-journey-id";
     private static final Cri TEST_CRI = Cri.F2F;
     private static final String TEST_COMPONENT_ID = TEST_CRI.getId();
+    private static final String TEST_ENCRYPTION_KEY = "test-encryption-key";
     private static final String TEST_OAUTH_STATE = UUID.randomUUID().toString();
     private static final String TEST_OAUTH_STATE_2 = UUID.randomUUID().toString();
     private static final CriResponseItem TEST_CRI_RESPONSE_ITEM =
@@ -444,7 +445,7 @@ class ProcessAsyncCriCredentialHandlerTest {
                 .authorizeUrl(new URI(""))
                 .clientId("ipv-core")
                 .signingKey(EC_PRIVATE_KEY_JWK)
-                .encryptionKey(null)
+                .encryptionKey(TEST_ENCRYPTION_KEY)
                 .componentId(TEST_COMPONENT_ID)
                 .clientCallbackUrl(new URI(""))
                 .requiresApiKey(false)

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
@@ -40,6 +40,7 @@ import uk.gov.di.ipv.core.library.verifiablecredential.domain.VerifiableCredenti
 import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredentialsService;
 import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCredentialValidator;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -136,7 +137,16 @@ class ProcessCriCallbackHandlerTest {
         when(mockConfigService.getOauthCriConfig(any()))
                 .thenReturn(
                         OauthCriConfig.builder()
+                                .tokenUrl(new URI(""))
+                                .credentialUrl(new URI(""))
+                                .authorizeUrl(new URI(""))
+                                .clientId("ipv-core")
                                 .signingKey(TestFixtures.TEST_EC_PUBLIC_JWK)
+                                .encryptionKey("")
+                                .componentId("")
+                                .clientCallbackUrl(new URI(""))
+                                .requiresApiKey(false)
+                                .requiresAdditionalEvidence(false)
                                 .build());
 
         // Act
@@ -261,7 +271,16 @@ class ProcessCriCallbackHandlerTest {
         when(mockConfigService.getOauthCriConfig(any()))
                 .thenReturn(
                         OauthCriConfig.builder()
+                                .tokenUrl(new URI(""))
+                                .credentialUrl(new URI(""))
+                                .authorizeUrl(new URI(""))
+                                .clientId("ipv-core")
                                 .signingKey(TestFixtures.TEST_EC_PUBLIC_JWK)
+                                .encryptionKey("")
+                                .componentId("")
+                                .clientCallbackUrl(new URI(""))
+                                .requiresApiKey(false)
+                                .requiresAdditionalEvidence(false)
                                 .build());
         when(mockCriCheckingService.checkVcResponse(
                         any(),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/AisConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/AisConfig.java
@@ -1,0 +1,13 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class AisConfig {
+    @NonNull final String apiBaseUrl;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CiRoutingConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CiRoutingConfig.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class CiRoutingConfig {
+    @NonNull final String event;
+    final String document;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CimitConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CimitConfig.java
@@ -1,0 +1,19 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+@Jacksonized
+public class CimitConfig {
+    @NonNull final String componentId;
+    @NonNull final String signingKey;
+    @NonNull final Map<String, @NonNull List<@NonNull CiRoutingConfig>> config;
+    @NonNull final String apiBaseUrl;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
@@ -1,0 +1,18 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class ClientConfig {
+    @NonNull final String id;
+    @NonNull final String issuer;
+    @NonNull final String publicKeyMaterialForCoreToVerify;
+    @NonNull final String validRedirectUrls;
+    @NonNull final String validScopes;
+    final String jwksUrl; // Null for API test client configs
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CoiConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CoiConfig.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class CoiConfig {
+    @NonNull final Integer familyNameChars;
+    @NonNull final Integer givenNameChars;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/Config.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/Config.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.Map;
+
+@Data
+@Builder
+@Jacksonized
+public class Config {
+    @NonNull final InternalOperationsConfig self;
+    @NonNull final Map<String, @NonNull ClientConfig> clients;
+    @NonNull final AisConfig ais;
+    @NonNull final CimitConfig cimit;
+    @NonNull final EvcsConfig evcs;
+    @NonNull final StoredIdentityServiceConfig storedIdentityService;
+    @NonNull final CredentialIssuersConfig credentialIssuers;
+    final Map<String, Map<String, String>> local;
+    final Map<String, @NonNull Boolean> featureFlags;
+    final Map<String, @NonNull Map<String, ?>> features;
+
+    public ClientConfig getClientConfig(String clientId) {
+        return clients.get(clientId);
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CredentialIssuersConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CredentialIssuersConfig.java
@@ -1,0 +1,27 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+import uk.gov.di.ipv.core.library.dto.OauthCriConfig;
+import uk.gov.di.ipv.core.library.dto.RestCriConfig;
+
+@Data
+@Builder
+@Jacksonized
+public class CredentialIssuersConfig {
+    @NonNull final CriConnectionWrapper<OauthCriConfig> address;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> dcmaw;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> dcmawAsync;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> fraud;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> experianKbv;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> ukPassport;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> drivingLicence;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> claimedIdentity;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> f2f;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> nino;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> bav;
+    @NonNull final CriConnectionWrapper<OauthCriConfig> dwpKbv;
+    @NonNull final CriConnectionWrapper<RestCriConfig> ticf;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CriConnectionWrapper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CriConnectionWrapper.java
@@ -1,0 +1,26 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+import uk.gov.di.ipv.core.library.dto.CriConfig;
+
+import java.util.Map;
+
+@Data
+@Builder
+@Jacksonized
+public class CriConnectionWrapper<T extends CriConfig> {
+    @NonNull final String id;
+    @NonNull final String name;
+    @NonNull final String enabled;
+    @NonNull final String unavailable;
+    final String allowedSharedAttributes;
+    @NonNull final String activeConnection;
+    @NonNull final Map<String, @NonNull T> connections;
+
+    public T getActiveConfig() {
+        return connections.get(activeConnection);
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/EvcsConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/EvcsConfig.java
@@ -1,0 +1,13 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class EvcsConfig {
+    @NonNull final String applicationUrl;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
@@ -1,0 +1,39 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+@Jacksonized
+public class InternalOperationsConfig {
+    final String configFormat;
+    @NonNull final String componentId;
+    @NonNull final String signingKeyId;
+    @NonNull final String sisSigningKeyId;
+    @NonNull final String audienceForClients;
+    @NonNull final Integer jwtTtlSeconds;
+    @NonNull final Integer maxAllowedAuthClientTtl;
+    @NonNull final Integer fraudCheckExpiryPeriodHours;
+    @NonNull final Integer dcmawAsyncVcPendingReturnTtl;
+    @NonNull final String clientJarKmsEncryptionKeyAliasPrimary;
+    @NonNull final String clientJarKmsEncryptionKeyAliasSecondary;
+    @NonNull final String coreVtmClaim;
+    @NonNull final Integer backendSessionTimeout;
+    @NonNull final Integer backendSessionTtl;
+    @NonNull final Integer bearerTokenTtl;
+    @NonNull final Integer criResponseTtl;
+    @NonNull final Integer sessionCredentialTtl;
+    @NonNull final Integer authCodeExpirySeconds;
+    @NonNull final Integer oauthKeyCacheDurationMins;
+    @NonNull final List<ContraIndicatorConfig> ciScoringConfig;
+    @NonNull final VotCiThresholdsConfig ciScoringThresholdByVot;
+    @NonNull final Map<String, @NonNull String> returnCodes;
+    @NonNull final CoiConfig coi;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/StoredIdentityServiceConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/StoredIdentityServiceConfig.java
@@ -1,0 +1,13 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class StoredIdentityServiceConfig {
+    @NonNull final String componentId;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/VotCiThresholdsConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/VotCiThresholdsConfig.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class VotCiThresholdsConfig {
+    @NonNull
+    @JsonProperty("P1")
+    final Integer p1;
+
+    @NonNull
+    @JsonProperty("P2")
+    final Integer p2;
+
+    @NonNull
+    @JsonProperty("P3")
+    final Integer p3;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/dto/OauthCriConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/dto/OauthCriConfig.java
@@ -4,6 +4,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -18,9 +19,9 @@ import java.text.ParseException;
 @EqualsAndHashCode(callSuper = true)
 @ExcludeFromGeneratedCoverageReport
 public class OauthCriConfig extends RestCriConfig {
-    private URI tokenUrl;
+    @NonNull private URI tokenUrl;
+    @NonNull private String clientId;
     private URI authorizeUrl;
-    private String clientId;
     private String encryptionKey;
     private URI clientCallbackUrl;
     private boolean requiresAdditionalEvidence;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/dto/RestCriConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/dto/RestCriConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
 
 import java.net.URI;
@@ -17,7 +18,7 @@ public class RestCriConfig extends CriConfig {
     private static final long DEFAULT_REQUEST_TIMEOUT = 30;
 
     private Long requestTimeout;
-    private URI credentialUrl;
+    @NonNull private URI credentialUrl;
     private boolean requiresApiKey;
 
     public long getRequestTimeout() {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -13,6 +13,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.config.EnvironmentVariable;
 import uk.gov.di.ipv.core.library.config.FeatureFlag;
+import uk.gov.di.ipv.core.library.config.domain.Config;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.domain.MitigationRoute;
@@ -268,6 +269,15 @@ public abstract class ConfigService {
             var yamlParsed = YAML_OBJECT_MAPPER.readTree(yaml).get(CORE);
             flattenParameters(map, yamlParsed, "");
             return map;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Could not load parameters yaml", e);
+        }
+    }
+
+    public static Config generateConfiguration(String yaml) {
+        try {
+            var coreConfig = YAML_OBJECT_MAPPER.readTree(yaml).get(CORE);
+            return OBJECT_MAPPER.treeToValue(coreConfig, Config.class);
         } catch (IOException e) {
             throw new IllegalArgumentException("Could not load parameters yaml", e);
         }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -25,6 +25,7 @@ import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -78,6 +79,7 @@ public abstract class ConfigService {
         return Integer.valueOf(value);
     }
 
+    // Get config
     public String getParameter(
             ConfigurationVariable configurationVariable, String... pathProperties) {
         return getParameter(formatPath(configurationVariable.getPath(), pathProperties));
@@ -134,6 +136,10 @@ public abstract class ConfigService {
             ConfigurationVariable configurationVariable, String... pathProperties) {
         return Arrays.asList(getParameter(configurationVariable, pathProperties).split(","));
     }
+
+    public abstract List<String> getFeatureSet();
+
+    protected abstract String getSecret(String path);
 
     public String getSecret(ConfigurationVariable secretVariable, String... pathProperties) {
         return getSecret(formatPath(secretVariable.getPath(), pathProperties));

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -79,7 +79,6 @@ public abstract class ConfigService {
         return Integer.valueOf(value);
     }
 
-    // Get config
     public String getParameter(
             ConfigurationVariable configurationVariable, String... pathProperties) {
         return getParameter(formatPath(configurationVariable.getPath(), pathProperties));
@@ -136,10 +135,6 @@ public abstract class ConfigService {
             ConfigurationVariable configurationVariable, String... pathProperties) {
         return Arrays.asList(getParameter(configurationVariable, pathProperties).split(","));
     }
-
-    public abstract List<String> getFeatureSet();
-
-    protected abstract String getSecret(String path);
 
     public String getSecret(ConfigurationVariable secretVariable, String... pathProperties) {
         return getSecret(formatPath(secretVariable.getPath(), pathProperties));

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -25,7 +25,6 @@ import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/config/domain/ConfigTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/config/domain/ConfigTest.java
@@ -1,0 +1,31 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConfigTest {
+    private static final String TEST_CLIENT_ID = "orchStub";
+
+    @Test
+    void getClientConfigFetchesValidConfig() throws URISyntaxException, IOException {
+        // Arrange
+        String yamlContent =
+                Files.readString(
+                        Paths.get(ConfigTest.class.getResource("/test-parameters.yaml").toURI()));
+
+        // Act
+        var configuration = ConfigService.generateConfiguration(yamlContent);
+
+        // Assert
+        assertEquals(
+                "http://localhost:4500/callback",
+                configuration.getClientConfig(TEST_CLIENT_ID).getValidRedirectUrls());
+    }
+}

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/config/domain/CriConnectionWrapperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/config/domain/CriConnectionWrapperTest.java
@@ -1,0 +1,36 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.core.library.service.ConfigService;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CriConnectionWrapperTest {
+
+    @Test
+    void getActiveConfigFetchesValidConfig() throws URISyntaxException, IOException {
+        // Arrange
+        String yamlContent =
+                Files.readString(
+                        Paths.get(
+                                CriConnectionWrapperTest.class
+                                        .getResource("/test-parameters.yaml")
+                                        .toURI()));
+
+        // Act
+        var criConnectionWrapper =
+                ConfigService.generateConfiguration(yamlContent)
+                        .getCredentialIssuers()
+                        .getAddress();
+
+        // Assert
+        assertEquals(
+                "https://address-cri.stubs.account.gov.uk/authorize",
+                criConnectionWrapper.getActiveConfig().getAuthorizeUrl().toString());
+    }
+}

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -1,0 +1,49 @@
+package uk.gov.di.ipv.core.library.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigServiceTest {
+
+    @Test
+    void generateConfigurationCreatesValidConfig() throws IOException, URISyntaxException {
+        // Arrange
+        String yamlContent =
+                Files.readString(
+                        Paths.get(
+                                ConfigServiceTest.class
+                                        .getResource("/test-parameters.yaml")
+                                        .toURI()));
+
+        // Act
+        var configuration = ConfigService.generateConfiguration(yamlContent);
+
+        // Assert
+        assertEquals(
+                "https://identity.local.account.gov.uk", configuration.getSelf().getComponentId());
+    }
+
+    @Test
+    void generateConfigurationThrowsWhenInvalidConfig() throws IOException, URISyntaxException {
+        // Arrange
+        String yamlContent =
+                Files.readString(
+                        Paths.get(
+                                ConfigServiceTest.class
+                                        .getResource("/test-invalid-parameters.yaml")
+                                        .toURI()));
+
+        // Act & Assert
+        var exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> ConfigService.generateConfiguration(yamlContent));
+        assertEquals("Could not load parameters yaml", exception.getMessage());
+    }
+}

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/LocalConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/LocalConfigServiceTest.java
@@ -7,7 +7,6 @@ import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
 
 import java.io.File;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -27,7 +26,7 @@ class LocalConfigServiceTest {
 
         var param = configService.getParameter(ConfigurationVariable.COMPONENT_ID);
 
-        assertEquals("test-component-id", param);
+        assertEquals("https://identity.local.account.gov.uk", param);
     }
 
     @Test
@@ -48,7 +47,7 @@ class LocalConfigServiceTest {
 
         var param = configService.getParameter(ConfigurationVariable.COMPONENT_ID);
 
-        assertEquals("test-component-id", param);
+        assertEquals("https://identity.local.account.gov.uk", param);
         configService.removeFeatureSet();
     }
 
@@ -58,7 +57,7 @@ class LocalConfigServiceTest {
 
         assertThrows(
                 ConfigParameterNotFoundException.class,
-                () -> configService.getParameter(ConfigurationVariable.EVCS_APPLICATION_URL));
+                () -> configService.getParameter("evcs/invalidPath"));
     }
 
     @Test
@@ -75,8 +74,11 @@ class LocalConfigServiceTest {
         var configService = getConfigService();
 
         assertEquals(
-                Map.of("test-issuer", Cri.ADDRESS, "alternate-issuer", Cri.DCMAW),
-                configService.getIssuerCris());
+                Cri.NINO,
+                configService.getIssuerCris().get("https://nino-cri.stubs.account.gov.uk"));
+        assertEquals(
+                Cri.EXPERIAN_KBV,
+                configService.getIssuerCris().get("https://experian-kbv-cri.stubs.account.gov.uk"));
     }
 
     @Test

--- a/libs/common-services/src/test/resources/test-invalid-parameters.yaml
+++ b/libs/common-services/src/test/resources/test-invalid-parameters.yaml
@@ -1,0 +1,4 @@
+---
+core:
+  self:
+    invalidAttribute: 123

--- a/libs/common-services/src/test/resources/test-parameters.yaml
+++ b/libs/common-services/src/test/resources/test-parameters.yaml
@@ -1,19 +1,416 @@
 ---
 core:
   self:
-    componentId: "test-component-id"
+    configFormat: "yaml"
+    componentId: "https://identity.local.account.gov.uk"
+    signingKeyId: "some-signin-id"
+    audienceForClients: "https://identity.local.account.gov.uk"
+    jwtTtlSeconds: 3600
+    maxAllowedAuthClientTtl: 3600
+    fraudCheckExpiryPeriodHours: 720
+    dcmawAsyncVcPendingReturnTtl: 1800
+    clientJarKmsEncryptionKeyAliasPrimary: "CoreEncryptionKey1"
+    clientJarKmsEncryptionKeyAliasSecondary: "CoreEncryptionKey2"
+    coreVtmClaim: "https://oidc.local.account.gov.uk/trustmark"
+    backendSessionTimeout: 3600
+    backendSessionTtl: 3600
+    bearerTokenTtl: 3600
+    criResponseTtl: 3600
+    sessionCredentialTtl: 3600
+    authCodeExpirySeconds: 3600
+    oauthKeyCacheDurationMins: 5
+    # Test CI scoring values
+    ciScoringThresholdByVot:
+      P1: 5
+      P2: 10
+      P3: 10
+    returnCodes:
+      alwaysRequired: always-required
+      nonCiBreachingP0: non-ci-breaching
+    coi:
+      # Test COI config
+      familyNameChars: 5
+      givenNameChars: 3
+  clients:
+    orchStub:
+      id: orchStub
+      issuer: orchStub
+      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
+      validRedirectUrls: "http://localhost:4500/callback"
+      validScopes: "openid"
+      jwksUrl: "http://host.docker.internal:4500/.well-known/jwks.json"
+    authStub:
+      id: authStub
+      issuer: authStub
+      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
+      validRedirectUrls: "http://localhost:4500/callback"
+      validScopes: "reverification"
+      jwksUrl: "http://host.docker.internal:4500/.well-known/jwks.json"
+    orchApiTest:
+      id: orchApiTest
+      issuer: orchApiTest
+      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
+      validRedirectUrls: "http://localhost:4500/callback"
+      validScopes: "openid"
+    authApiTest:
+      id: authApiTest
+      issuer: authApiTest
+      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
+      validRedirectUrls: "http://localhost:4500/callback"
+      validScopes: "reverification"
+  ais:
+    apiBaseUrl: "https://ais.stubs.account.gov.uk"
+  cimit:
+    componentId: "https://cimit.stubs.account.gov.uk"
+    signingKey: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
+    # Test CIMIT config
+    config:
+      NEEDS-ENHANCED-VERIFICATION:
+        - event: /journey/enhanced-verification
+      NEEDS-ALTERNATE-DOC:
+        - event: /journey/alternate-doc-invalid-dl
+          document: drivingPermit
+        - event: /journey/alternate-doc-invalid-passport
+          document: passport
+    apiBaseUrl: "https://cimit-api.stubs.account.gov.uk"
+  evcs:
+    applicationUrl: "https://evcs.stubs.account.gov.uk"
+  storedIdentityService:
+    componentId: "https://reuse-identity.build.account.gov.uk"
   credentialIssuers:
     address:
-      activeConnection: test
+      id: address
+      name: Address
+      enabled: "true"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
       connections:
-        test:
-          componentId: test-issuer
+        stub:
+          authorizeUrl: https://address-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://address-cri.stubs.account.gov.uk/token
+          credentialUrl: https://address-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://address-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/address
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://address-cri.stubs.account.gov.uk/.well-known/jwks.json
     dcmaw:
-      activeConnection: test
+      id: dcmaw
+      name: "Document Checking - Mobile App and Web"
+      enabled: "true"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
       connections:
-        test:
-          componentId: alternate-issuer
+        stub:
+          authorizeUrl: https://dcmaw-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://dcmaw-cri.stubs.account.gov.uk/token
+          credentialUrl: https://dcmaw-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://dcmaw-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dcmaw
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://dcmaw-cri.stubs.account.gov.uk/.well-known/jwks.json
+    dcmawAsync:
+      id: dcmawAsync
+      name: "Document Checking - Mobile App and Web - Async"
+      enabled: "false"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
+      connections:
+        stub:
+          credentialUrl: https://dcmaw-async.stubs.account.gov.uk/async/credential
+          tokenUrl: https://dcmaw-async.stubs.account.gov.uk/async/token
+          clientId: dummyClientId
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://dcmaw-async.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dcmawAsync
+          requiresApiKey: false
+          jwksUrl: https://dcmaw-async.stubs.account.gov.uk/.well-known/jwks.json
+    fraud:
+      id: fraud
+      name: Fraud
+      enabled: "true"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
+      connections:
+        stub:
+          authorizeUrl: https://fraud-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://fraud-cri.stubs.account.gov.uk/token
+          credentialUrl: https://fraud-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://fraud-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/fraud
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://fraud-cri.stubs.account.gov.uk/.well-known/jwks.json
+    experianKbv:
+      id: experianKbv
+      name: Experian KBV
+      enabled: "true"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
+      connections:
+        stub:
+          authorizeUrl: https://experian-kbv-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://experian-kbv-cri.stubs.account.gov.uk/token
+          credentialUrl: https://experian-kbv-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://experian-kbv-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/kbv
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://experian-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json
+    ukPassport:
+      id: ukPassport
+      name: ukPassport
+      enabled: "true"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
+      connections:
+        stub:
+          authorizeUrl: https://passport-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://passport-cri.stubs.account.gov.uk/token
+          credentialUrl: https://passport-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://passport-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/ukPassport
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://passport-cri.stubs.account.gov.uk/.well-known/jwks.json
+    drivingLicence:
+      id: drivingLicence
+      name: Driving Licence
+      enabled: "true"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address,drivingPermit"
+      activeConnection: "stub"
+      connections:
+        stub:
+          authorizeUrl: https://driving-licence-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://driving-licence-cri.stubs.account.gov.uk/token
+          credentialUrl: https://driving-licence-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://driving-licence-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/drivingLicence
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://driving-licence-cri.stubs.account.gov.uk/.well-known/jwks.json
+    claimedIdentity:
+      id: claimedIdentity
+      name: ClaimedIdentity
+      enabled: "true"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
+      connections:
+        stub:
+          authorizeUrl: https://claimed-identity-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://claimed-identity-cri.stubs.account.gov.uk/token
+          credentialUrl: https://claimed-identity-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://claimed-identity-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/claimedIdentity
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://claimed-identity-cri.stubs.account.gov.uk/.well-known/jwks.json
+    f2f:
+      id: f2f
+      name: Face to Face
+      enabled: "true"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,emailAddress"
+      activeConnection: "stub"
+      connections:
+        stub:
+          authorizeUrl: https://f2f-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://f2f-cri.stubs.account.gov.uk/token
+          credentialUrl: https://f2f-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://f2f-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/f2f
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://f2f-cri.stubs.account.gov.uk/.well-known/jwks.json
+    nino:
+      id: nino
+      name: NINO
+      enabled: "false"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
+      connections:
+        stub:
+          authorizeUrl: https://nino-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://nino-cri.stubs.account.gov.uk/token
+          credentialUrl: https://nino-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://nino-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/nino
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://nino-cri.stubs.account.gov.uk/.well-known/jwks.json
+    bav:
+      id: bav
+      name: Bank account verification
+      enabled: "true"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
+      connections:
+        stub:
+          authorizeUrl: https://bav-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://bav-cri.stubs.account.gov.uk/token
+          credentialUrl: https://bav-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://bav-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/bav
+          requiresApiKey: false
+          requiresAdditionalEvidence: true
+          jwksUrl: https://bav-cri.stubs.account.gov.uk/.well-known/jwks.json
+    dwpKbv:
+      id: dwpKbv
+      name: DWP KBV
+      enabled: "false"
+      unavailable: false # temporarily unavailable
+      allowedSharedAttributes: "name,birthDate,address"
+      activeConnection: "stub"
+      connections:
+        stub:
+          authorizeUrl: https://dwp-kbv-cri.stubs.account.gov.uk/authorize
+          tokenUrl: https://dwp-kbv-cri.stubs.account.gov.uk/token
+          credentialUrl: https://dwp-kbv-cri.stubs.account.gov.uk/credentials/issue
+          clientId: ipv-core-local
+          signingKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
+          componentId: https://dwp-kbv-cri.stubs.account.gov.uk
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dwpKbv
+          requiresApiKey: false
+          requiresAdditionalEvidence: false
+          jwksUrl: https://dwp-kbv-cri.stubs.account.gov.uk/.well-known/jwks.json
+    ticf:
+      id: ticf
+      name: Threat Intelligence and Counter Fraud
+      enabled: "true"
+      unavailable: "false"
+      activeConnection: "stub"
+      connections:
+        stub:
+          credentialUrl: https://ticf.stubs.account.gov.uk/risk-assessment
+          signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}'
+          componentId: https://ticf.stubs.account.gov.uk
+          requiresApiKey: true
+          requestTimeout: 5
+  local:
+    asyncQueue:
+      apiBaseUrl: "https://queue.stubs.account.gov.uk"
+  featureFlags:
+    resetIdentity: false
+    pendingF2FResetEnabled: false
+    strategicAppEnabled: true
+    repeatFraudCheckEnabled: true
+    mfaResetEnabled: true
+    parseVcClasses: true
+    p1JourneysEnabled: true
+    sqsAsync: true
+    kidJarHeaderEnabled: true
+    drivingLicenceAuthCheck: true
+    storedIdentityServiceEnabled: false
+    accountInterventionsEnabled: true
   features:
     testFeature:
       self:
-        componentId: "alternate-component-id"
+        componentId: alternate-component-id
+    accountInterventions:
+      featureFlags:
+        accountInterventionsEnabled: true
+    disableAccountInterventions:
+      featureFlags:
+        accountInterventionsEnabled: false
+    storedIdentityService:
+      featureFlags:
+        storedIdentityServiceEnabled: true
+    mfaReset:
+      featureFlags:
+        mfaResetEnabled: true
+    clearUsersIdentity:
+      featureFlags:
+        resetIdentity: true
+    pendingF2FResetEnabled:
+      featureFlags:
+        pendingF2FResetEnabled: true
+    strategicApp:
+      featureFlags:
+        strategicAppEnabled: true
+    disableStrategicApp:
+      featureFlags:
+        strategicAppEnabled: false
+    zeroHourFraudVcExpiry:
+      self:
+        fraudCheckExpiryPeriodHours: 0
+    p1Journeys:
+      featureFlags:
+        p1JourneysEnabled: true
+    # Disabling CRIs
+    f2fDisabled:
+      credentialIssuers:
+        f2f:
+          enabled: false
+    ticfDisabled:
+      credentialIssuers:
+        ticf:
+          enabled: false
+    bavDisabled:
+      credentialIssuers:
+        bav:
+          enabled: false
+    dwpKbvDisabled:
+      credentialIssuers:
+        dwpKbv:
+          enabled: false
+    drivingLicenceTest:
+      credentialIssuers:
+        drivingLicence:
+          enabled: false
+    dcmawOffTest:
+      credentialIssuers:
+        dcmaw:
+          enabled: false
+    # Enabling CRIs
+    ticfCriBeta:
+      credentialIssuers:
+        ticf:
+          enabled: true
+    # CRI enablement combinations
+    dwpKbvTest:
+      credentialIssuers:
+        dwpKbv:
+          enabled: true

--- a/libs/common-services/src/test/resources/test-parameters.yaml
+++ b/libs/common-services/src/test/resources/test-parameters.yaml
@@ -4,6 +4,7 @@ core:
     configFormat: "yaml"
     componentId: "https://identity.local.account.gov.uk"
     signingKeyId: "some-signin-id"
+    sisSigningKeyId: "dummy-value"
     audienceForClients: "https://identity.local.account.gov.uk"
     jwtTtlSeconds: 3600
     maxAllowedAuthClientTtl: 3600
@@ -24,6 +25,31 @@ core:
       P1: 5
       P2: 10
       P3: 10
+    ciScoringConfig:
+      - ci: "NON-BREACHING"
+        detectedScore: 2
+        checkedScore: -2
+        returnCode: "non-breaching"
+      - ci: "BREACHING"
+        detectedScore: 20
+        checkedScore: -20
+        returnCode: "breaching"
+      - ci: "BREACHING-P1-ONLY"
+        detectedScore: 7
+        checkedScore: -7
+        returnCode: "breaching-p1-only"
+      - ci: "NEEDS-ENHANCED-VERIFICATION"
+        detectedScore: 20
+        checkedScore: -20
+        returnCode: "needs-enhanced-verification"
+      - ci: "NEEDS-ALTERNATE-DOC"
+        detectedScore: 20
+        checkedScore: -20
+        returnCode: "needs-alternate-doc"
+      - ci: "ALWAYS-REQUIRED"
+        detectedScore: 1
+        checkedScore: -1
+        returnCode: "always-required"
     returnCodes:
       alwaysRequired: always-required
       nonCiBreachingP0: non-ci-breaching

--- a/libs/common-services/src/test/resources/test-parameters.yaml
+++ b/libs/common-services/src/test/resources/test-parameters.yaml
@@ -131,7 +131,6 @@ core:
           tokenUrl: https://dcmaw-async.stubs.account.gov.uk/async/token
           clientId: dummyClientId
           signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
-          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
           componentId: https://dcmaw-async.stubs.account.gov.uk
           clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dcmawAsync
           requiresApiKey: false

--- a/libs/oauth-key-service/src/test/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyServiceTest.java
+++ b/libs/oauth-key-service/src/test/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyServiceTest.java
@@ -63,9 +63,17 @@ class OAuthKeyServiceTest {
         static void setUp() throws Exception {
             oauthCriConfig =
                     OauthCriConfig.builder()
+                            .tokenUrl(new URI(""))
+                            .credentialUrl(new URI(""))
+                            .authorizeUrl(new URI(""))
+                            .clientId("ipv-core")
+                            .signingKey("")
                             .jwksUrl(new URI(TEST_JWKS_ENDPOINT))
                             .encryptionKey(TEST_KEY)
                             .componentId(TEST_ISSUER)
+                            .clientCallbackUrl(new URI(""))
+                            .requiresApiKey(false)
+                            .requiresAdditionalEvidence(false)
                             .build();
         }
 
@@ -140,7 +148,19 @@ class OAuthKeyServiceTest {
         @Test
         @MockitoSettings(strictness = LENIENT)
         void getEncryptionKeyShouldReturnKeyFromConfigIfNoJwksUrl() throws Exception {
-            var oauthConfigNoJwksUrl = OauthCriConfig.builder().encryptionKey(TEST_KEY).build();
+            var oauthConfigNoJwksUrl =
+                    OauthCriConfig.builder()
+                            .tokenUrl(new URI(""))
+                            .credentialUrl(new URI(""))
+                            .authorizeUrl(new URI(""))
+                            .clientId("ipv-core")
+                            .signingKey("")
+                            .encryptionKey(TEST_KEY)
+                            .componentId(TEST_ISSUER)
+                            .clientCallbackUrl(new URI(""))
+                            .requiresApiKey(false)
+                            .requiresAdditionalEvidence(false)
+                            .build();
             var key = oAuthKeyService.getEncryptionKey(oauthConfigNoJwksUrl);
 
             assertEquals(RSAKey.parse(TEST_KEY), key);

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -20,7 +20,6 @@ core:
     authCodeExpirySeconds: 3600
     oauthKeyCacheDurationMins: 5
     # Test CI scoring values
-    ciScoringThreshold: 10
     ciScoringConfig:
       - ci: "NON-BREACHING"
         detectedScore: 2

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -4,6 +4,8 @@
 core:
   self:
     componentId: "https://identity.local.account.gov.uk"
+    signingKeyId: "some-signin-id"
+    sisSigningKeyId: "dummy-value"
     audienceForClients: "https://identity.local.account.gov.uk"
     jwtTtlSeconds: 3600
     maxAllowedAuthClientTtl: 3600
@@ -155,7 +157,6 @@ core:
           tokenUrl: https://dcmaw-async.stubs.account.gov.uk/async/token
           clientId: dummyClientId
           signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}'
-          encryptionKey: '{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"vyapkvJXLwpYRJjbkQD99V2gcPEUKrO3dwjcAA9TPkLucQEZvYZvb7-wfSHxlvJlJcdS20r5PKKmqdPeW3Y4ir3WsVVeiht2iOZUreUO5O3V3o7ImvEjPS_2_ZKMHCwUf51a6WGOaDjO87OX_bluV2dp01n-E3kiIl6RmWCVywjn13fX3jsX0LMCM_bt3HofJqiYhhNymEwh39oR_D7EE5sLUii2XvpTYPa6L_uPwdKa4vRl4h4owrWEJaJifMorGcvqhCK1JOHqgknN_3cb_ns9Px6ynQCeFXvBDJy4q71clkBq_EZs5227Y1S222wXIwUYN8w5YORQe3M-pCIh1Q\"}'
           componentId: https://dcmaw-async.stubs.account.gov.uk
           clientCallbackUrl: http://localhost:4501/credential-issuer/callback/dcmawAsync
           requiresApiKey: false


### PR DESCRIPTION
## Proposed changes
### What changed

1. Update existing tests to use valid Cri configs
2. Update Cri config classes to be strict
3. Add Config class

### Why did it change

- Config is consumed using first-class accessors, rather than parameterised paths
- Keeps the config as a single object which is easier to pass around, cache etc. in code
- Makes the config a single, validatable object.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7878](https://govukverify.atlassian.net/browse/PYIC-7878)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
- [ ] Check Cri config `NON_NULL` assertions. It has only been based on what we've seen.
- [ ] IF it is not true in production, Production will break if it tries to use this Config

[PYIC-7878]: https://govukverify.atlassian.net/browse/PYIC-7878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ