### PR TITLE
PYIC-8570: use new sis signing key to sign stored identity JWTs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2994,6 +2994,12 @@ Resources:
                 - 'kms:sign'
               Resource:
                 - !ImportValue SigningKeyArn
+            - Sid: kmsSisSigningKeyPermission
+              Effect: Allow
+              Action:
+                - 'kms:sign'
+              Resource:
+                - !ImportValue StoredIdentitySigningKeyArn
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBCrudPolicy:

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -47,6 +47,7 @@ public enum ConfigurationVariable {
     SESSION_CREDENTIALS_TTL("self/sessionCredentialTtl"),
     SIGNING_KEY_ID("self/signingKeyId"),
     SIGNING_KEY_JWK("self/signingKey"),
+    SIS_SIGNING_KEY_ID("self/sisSigningKeyId"),
     STORED_IDENTITY_SERVICE_COMPONENT_ID("storedIdentityService/componentId"),
     DCMAW_ASYNC_VC_PENDING_RETURN_TTL("self/dcmawAsyncVcPendingReturnTtl");
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/signing/SignerFactory.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/signing/SignerFactory.java
@@ -5,6 +5,7 @@ import com.nimbusds.jose.jwk.ECKey;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import java.text.ParseException;
@@ -12,6 +13,7 @@ import java.text.ParseException;
 import static software.amazon.awssdk.regions.Region.EU_WEST_2;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.SIGNING_KEY_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.SIGNING_KEY_JWK;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.SIS_SIGNING_KEY_ID;
 
 @ExcludeFromGeneratedCoverageReport
 public class SignerFactory {
@@ -29,6 +31,14 @@ public class SignerFactory {
     }
 
     public CoreSigner getSigner() {
+        return getSigner(SIGNING_KEY_ID);
+    }
+
+    public CoreSigner getSisSigner() {
+        return getSigner(SIS_SIGNING_KEY_ID);
+    }
+
+    private CoreSigner getSigner(ConfigurationVariable signingKeyConfig) {
         if (ConfigService.isLocal()) {
             try {
                 return new LocalECDSASigner(ECKey.parse(configService.getSecret(SIGNING_KEY_JWK)));
@@ -36,6 +46,6 @@ public class SignerFactory {
                 throw new IllegalArgumentException("Could not parse signing key", e);
             }
         }
-        return new KmsEs256Signer(kmsClient, configService.getParameter(SIGNING_KEY_ID));
+        return new KmsEs256Signer(kmsClient, configService.getParameter(signingKeyConfig));
     }
 }

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityService.java
@@ -92,13 +92,13 @@ public class StoredIdentityService {
         try {
             var storedIdentity = createStoredIdentityJwt(userId, vcs, achievedVot);
 
-            return createSignedJwt(storedIdentity, signerFactory.getSigner()).serialize();
+            return createSignedJwt(storedIdentity, signerFactory.getSisSigner()).serialize();
         } catch (HttpResponseExceptionWithErrorBody e) {
             LOGGER.error(LogHelper.buildLogMessage(e.getErrorResponse().getMessage()));
             throw new FailedToCreateStoredIdentityForEvcsException(
                     e.getErrorResponse().getMessage());
         } catch (JOSEException e) {
-            LOGGER.error(LogHelper.buildLogMessage("Failed to create signed JWT"));
+            LOGGER.error(LogHelper.buildErrorMessage("Failed to create signed JWT", e));
             throw new FailedToCreateStoredIdentityForEvcsException("Failed to create signed JWT");
         }
     }

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/StoredIdentityServiceTest.java
@@ -83,7 +83,7 @@ class StoredIdentityServiceTest {
         var userClaims =
                 UserClaims.builder().passportClaim(List.of(PASSPORT_CLAIM, PASSPORT_CLAIM)).build();
 
-        when(mockSignerFactory.getSigner()).thenReturn(signer);
+        when(mockSignerFactory.getSisSigner()).thenReturn(signer);
         when(mockConfigService.getParameter(COMPONENT_ID)).thenReturn(MOCK_COMPONENT_ID);
         when(mockConfigService.getParameter(STORED_IDENTITY_SERVICE_COMPONENT_ID))
                 .thenReturn(MOCK_SIS_COMPONENT_ID);


### PR DESCRIPTION
## Proposed changes
### What changed

- update SignerFactory to use new SIS signing key
- updated cloudformation template to allow ProcessCandidateIdentity to use new sis signing key

I have tested the following in my dev environment:
- The kid is successfully passed into the header of the JWT and matches the hashed key id stored in config
- the JWT signature is successfully verified with the public key stored in SSM

### Why did it change

- The stored identity JWT was being signed with the signing key we use for CRIs which is inappropriate so we needed a new one specifically for signing SI JWTs.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8570](https://govukverify.atlassian.net/browse/PYIC-8570)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code


[PYIC-8570]: https://govukverify.atlassian.net/browse/PYIC-8570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ