### PR TITLE
PYIC-7900: update getContraIndicatorConfigMap to get from param store/appConfig instead of secrets manager

### DIFF
--- a/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/service/CimitService.java
+++ b/libs/cimit-service/src/main/java/uk/gov/di/ipv/core/library/cimit/service/CimitService.java
@@ -53,7 +53,6 @@ public class CimitService {
     public static final String POST_CI_ENDPOINT = "/contra-indicators/detect";
     public static final String POST_MITIGATIONS_ENDPOINT = "/contra-indicators/mitigate";
     public static final String GET_VCS_ENDPOINT = "/contra-indicators";
-    private static final String NOT_REQUIRED = "notRequired";
 
     public static final String FAILED_RESPONSE = "fail";
 
@@ -231,15 +230,16 @@ public class CimitService {
                         .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
 
         var apiKey = configService.getSecret(CIMIT_API_KEY);
-        if (apiKey != null && !apiKey.equals(NOT_REQUIRED)) {
+
+        if (StringUtils.isNotBlank(apiKey)) {
             requestBuilder.header(X_API_KEY_HEADER, configService.getSecret(CIMIT_API_KEY));
         }
 
-        if (govukSigninJourneyId != null) {
+        if (StringUtils.isNotBlank(govukSigninJourneyId)) {
             requestBuilder.header(GOVUK_SIGNIN_JOURNEY_ID_HEADER, govukSigninJourneyId);
         }
 
-        if (ipAddress != null) {
+        if (StringUtils.isNotBlank(ipAddress)) {
             requestBuilder.header(IP_ADDRESS_HEADER, ipAddress);
         }
         return requestBuilder;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -11,7 +11,7 @@ public enum ConfigurationVariable {
     CIMIT_SIGNING_KEY("cimit/signingKey"),
     CIMIT_API_BASE_URL("cimit/apiBaseUrl"),
     CIMIT_API_KEY("cimitApi/apiKey"),
-    CI_CONFIG("self/ciConfig"),
+    CI_SCORING_CONFIG("self/ciScoringConfig"),
     CI_SCORING_THRESHOLD("self/ciScoringThresholdByVot/%s"),
     CLIENT_ISSUER("clients/%s/issuer"),
     CLIENT_JWKS_URL("clients/%s/jwksUrl"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -190,7 +190,7 @@ public abstract class ConfigService {
 
     public Map<String, ContraIndicatorConfig> getContraIndicatorConfigMap() {
         try {
-            String secretValue = getSecret(ConfigurationVariable.CI_CONFIG);
+            var secretValue = getParameter(ConfigurationVariable.CI_CONFIG);
             List<ContraIndicatorConfig> configList =
                     OBJECT_MAPPER.readValue(secretValue, new TypeReference<>() {});
             Map<String, ContraIndicatorConfig> configMap = new HashMap<>();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -190,7 +190,7 @@ public abstract class ConfigService {
 
     public Map<String, ContraIndicatorConfig> getContraIndicatorConfigMap() {
         try {
-            var secretValue = getParameter(ConfigurationVariable.CI_CONFIG);
+            var secretValue = getParameter(ConfigurationVariable.CI_SCORING_CONFIG);
             List<ContraIndicatorConfig> configList =
                     OBJECT_MAPPER.readValue(secretValue, new TypeReference<>() {});
             Map<String, ContraIndicatorConfig> configMap = new HashMap<>();

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -292,9 +292,21 @@ class AppConfigServiceTest {
     @Test
     void shouldGetContraIndicatorConfigMap() {
         // Arrange
-        when(secretsProvider.get(any()))
-                .thenReturn(
-                        "[{\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"returnCode\":\"1\"},{\"ci\":\"Z03\",\"detectedScore\":5,\"checkedScore\":-3,\"returnCode\":\"1\"}]");
+        var testRawParametersCiConfig =
+                """
+            core:
+              self:
+                  ciConfig:
+                    - ci: "X01"
+                      detectedScore: 3
+                      checkedScore: -3
+                      returnCode: "1"
+                    - ci: "Z03"
+                      detectedScore: 5
+                      checkedScore: -3
+                      returnCode: "1"
+        """;
+        when(appConfigProvider.get(any())).thenReturn(testRawParametersCiConfig);
 
         // Act
         var configMap = configService.getContraIndicatorConfigMap();
@@ -312,9 +324,15 @@ class AppConfigServiceTest {
     @Test
     void shouldReturnEmptyCollectionOnInvalidContraIndicatorConfigsMap() {
         // Arrange
-        when(secretsProvider.get(any()))
-                .thenReturn(
-                        "[\"ci\":\"X01\",\"detectedScore\":3,\"checkedScore\":-3,\"returnCode\":\"1\"}]");
+        var testRawParametersInvalidCiConfig =
+                """
+            core:
+              self:
+                  ciConfig:
+                    - ci: "SomeCi"
+                      invalidKey: "invalidValue"
+        """;
+        when(appConfigProvider.get(any())).thenReturn(testRawParametersInvalidCiConfig);
 
         // Act
         var configMap = configService.getContraIndicatorConfigMap();

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -296,7 +296,7 @@ class AppConfigServiceTest {
                 """
             core:
               self:
-                  ciConfig:
+                  ciScoringConfig:
                     - ci: "X01"
                       detectedScore: 3
                       checkedScore: -3
@@ -328,7 +328,7 @@ class AppConfigServiceTest {
                 """
             core:
               self:
-                  ciConfig:
+                  ciScoringConfig:
                     - ci: "SomeCi"
                       invalidKey: "invalidValue"
         """;

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -3,6 +3,31 @@
 ---
 core:
   self:
+    ciConfig:
+      - ci: "NON-BREACHING"
+        detectedScore: 2
+        checkedScore: -2
+        returnCode: "non-breaching"
+      - ci: "BREACHING"
+        detectedScore: 20
+        checkedScore: -20
+        returnCode: "breaching"
+      - ci: "BREACHING-P1-ONLY"
+        detectedScore: 7
+        checkedScore: -7
+        returnCode: "breaching-p1-only"
+      - ci: "NEEDS-ENHANCED-VERIFICATION"
+        detectedScore: 20
+        checkedScore: -20
+        returnCode: "needs-enhanced-verification"
+      - ci: "NEEDS-ALTERNATE-DOC"
+        detectedScore: 20
+        checkedScore: -20
+        returnCode: "needs-alternate-doc"
+      - ci: "ALWAYS-REQUIRED"
+        detectedScore: 1
+        checkedScore: -1
+        returnCode: "always-required"
     componentId: "https://identity.local.account.gov.uk"
     audienceForClients: "https://identity.local.account.gov.uk"
     jwtTtlSeconds: 3600

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -3,7 +3,23 @@
 ---
 core:
   self:
-    ciConfig:
+    componentId: "https://identity.local.account.gov.uk"
+    audienceForClients: "https://identity.local.account.gov.uk"
+    jwtTtlSeconds: 3600
+    maxAllowedAuthClientTtl: 3600
+    fraudCheckExpiryPeriodHours: 720
+    dcmawAsyncVcPendingReturnTtl: 1800
+    coreVtmClaim: "https://oidc.local.account.gov.uk/trustmark"
+    backendSessionTimeout: 3600
+    backendSessionTtl: 3600
+    bearerTokenTtl: 3600
+    criResponseTtl: 3600
+    sessionCredentialTtl: 3600
+    authCodeExpirySeconds: 3600
+    oauthKeyCacheDurationMins: 5
+    # Test CI scoring values
+    ciScoringThreshold: 10
+    ciScoringConfig:
       - ci: "NON-BREACHING"
         detectedScore: 2
         checkedScore: -2
@@ -28,22 +44,6 @@ core:
         detectedScore: 1
         checkedScore: -1
         returnCode: "always-required"
-    componentId: "https://identity.local.account.gov.uk"
-    audienceForClients: "https://identity.local.account.gov.uk"
-    jwtTtlSeconds: 3600
-    maxAllowedAuthClientTtl: 3600
-    fraudCheckExpiryPeriodHours: 720
-    dcmawAsyncVcPendingReturnTtl: 1800
-    coreVtmClaim: "https://oidc.local.account.gov.uk/trustmark"
-    backendSessionTimeout: 3600
-    backendSessionTtl: 3600
-    bearerTokenTtl: 3600
-    criResponseTtl: 3600
-    sessionCredentialTtl: 3600
-    authCodeExpirySeconds: 3600
-    oauthKeyCacheDurationMins: 5
-    # Test CI scoring values
-    ciScoringThreshold: 10
     ciScoringThresholdByVot:
       P1: 5
       P2: 10

--- a/local-running/core.local.secrets.template.yaml
+++ b/local-running/core.local.secrets.template.yaml
@@ -29,15 +29,6 @@ core:
       "qi": "27L2sofeonh_IZ3G2YEEti-udMK55hc-38asC8_Y1WcK2LupegpwaLNYFa7ZmQQ9lj-0RVv8vn4LkMkgf8_FGbmK4mv9-ul9aTS7y8tkfGDTcvGjUb4LMyvNnd3iZzKuDB-A5ZbvGzXQOq70kvlPetPHfyzuZyU9ZyU_rr5P3H0",
       "alg": "RS256"
     }'
-    # Test CI config
-    ciConfig: '[
-      {"ci":"NON-BREACHING","detectedScore":2,"checkedScore":-2,"returnCode":"non-breaching"},
-      {"ci":"BREACHING","detectedScore":20,"checkedScore":-20,"returnCode":"breaching"},
-      {"ci":"BREACHING-P1-ONLY","detectedScore":7,"checkedScore":-7,"returnCode":"breaching-p1-only"},
-      {"ci":"NEEDS-ENHANCED-VERIFICATION","detectedScore":20,"checkedScore":-20,"returnCode":"needs-enhanced-verification"},
-      {"ci":"NEEDS-ALTERNATE-DOC","detectedScore":20,"checkedScore":-20,"returnCode":"needs-alternate-doc"},
-      {"ci":"ALWAYS-REQUIRED","detectedScore":1,"checkedScore":-1,"returnCode":"always-required"}
-    ]'
   evcs:
     apiKey: "EVCS_API_KEY" # pragma: allowlist secret
   cimitApi:


### PR DESCRIPTION
## Proposed changes
### What changed

- update getContraIndicatorConfigMap to get from param store/appConfig instead of secrets manager
- tidy checks for values in CimitService when sending a cimit request

Tested in dev 🍏 

### Why did it change

- We're moving the CI config to appConfog/param store instead of secrets manager

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7900](https://govukverify.atlassian.net/browse/PYIC-7900)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-7900]: https://govukverify.atlassian.net/browse/PYIC-7900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ