### PR TITLE
PYIC-8513 Bump cosign-release

### DIFF
--- a/.github/workflows/secure-pipeline-api-tests-image.yml
+++ b/.github/workflows/secure-pipeline-api-tests-image.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         with:
-          cosign-release: 'v1.9.0'
+          cosign-release: 'v2.4.0'
 
       - name: Set up build AWS creds
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Proposed changes
### What changed

- secure-pipeline-api-tests-image pipeline - cosign-release bumped from 1.9.0 to 2.4.0

### Why did it change

- As reacent dependabot update bumped cosign installer to 3.9.2, this workflow require cosign release at least 2.4.0

This should unblock the workflow in core-back

Please, look for any breaking changes related to it.
cosign sign --key
cosign sign --key
Above should work

Issue:
https://github.com/govuk-one-login/ipv-core-back/actions/runs/16725235244/job/47347918702#step:3:215

Breaking PR:
https://github.com/govuk-one-login/ipv-core-back/pull/3341

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8513](https://govukverify.atlassian.net/browse/PYIC-8513)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8513]: https://govukverify.atlassian.net/browse/PYIC-8513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ