### PR TITLE
BAU: update local running to pass query params to processJourneyEvent…

### DIFF
--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -148,10 +148,7 @@ public class JourneyEngineHandler {
                 .deviceInformation(ctx.header(ENCODED_DEVICE_INFORMATION))
                 .clientOAuthSessionId(ctx.header(CLIENT_SESSION_ID))
                 .featureSet(ctx.header(FEATURE_SET))
-                .journey(
-                        !journeyEvent.startsWith("/journey/")
-                                ? "/journey/" + journeyWithQuery
-                                : journeyWithQuery)
+                .journey(journeyWithQuery)
                 .build();
     }
 

--- a/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
+++ b/local-running/src/main/java/uk/gov/di/ipv/coreback/handlers/JourneyEngineHandler.java
@@ -2,8 +2,6 @@ package uk.gov.di.ipv.coreback.handlers;
 
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import io.javalin.http.Context;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.buildclientoauthresponse.BuildClientOauthResponseHandler;
 import uk.gov.di.ipv.core.buildcrioauthrequest.BuildCriOauthRequestHandler;
 import uk.gov.di.ipv.core.calldcmawasynccri.CallDcmawAsyncCriHandler;
@@ -33,7 +31,6 @@ import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_RESET_SESS
 
 public class JourneyEngineHandler {
     public static final CoreContext EMPTY_CONTEXT = new CoreContext();
-    private static final Logger LOGGER = LogManager.getLogger();
 
     public static final String JOURNEY = "journey";
     public static final String IPV_SESSION_ID = "ipv-session-id";
@@ -145,7 +142,6 @@ public class JourneyEngineHandler {
 
         var journeyWithQuery = journeyEvent + currentPage;
 
-        LOGGER.warn(journeyWithQuery);
         return JourneyRequest.builder()
                 .ipvSessionId(ctx.header(IPV_SESSION_ID))
                 .ipAddress(ctx.header(IP_ADDRESS))


### PR DESCRIPTION
… handler

## Proposed changes
### What changed

- allow query params to be passed to the process-journey-event lambda when the `/journey/{event}` endpoint is hit running locally

### Why did it change

- there's some extra validation to check we aren't dealing with mismatching page states by passing back a `currentPage` query param to core-back from the FE. This wasn't working when running locally so I've added in mapping similar to that in the core-back-internal.yaml openAPI spec

