### PR TITLE
Pyic 8306 Fix suffix for dynamodb table name in manual f2f reset lambda

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -118,10 +118,6 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
-  IsBuildStagingProd: !Or
-    - !Equals [ !Ref Environment, build ]
-    - !Equals [ !Ref Environment, staging ]
-    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -803,7 +799,6 @@ Resources:
 
   ManualF2fPendingResetFunctionManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
-    Condition: IsBuildStagingProd
     Properties:
       ManagedPolicyName: ManualF2fPendingResetManagedPolicy
       Description: Allows invoking the ManualF2f Lambda
@@ -817,10 +812,16 @@ Resources:
               - lambda:GetFunction
             Resource:
               - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:manual-f2f-pending-reset-${Environment}
+          - Sid: AllowGetDeleteCriResponseDynamoDbTable
+            Effect: Allow
+            Action:
+              - 'dynamodb:GetItem'
+              - 'dynamodb:DeleteItem'
+            Resource:
+              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/cri-response
 
   ManualF2fPendingResetFunctionInvokeRole:
     Type: AWS::IAM::Role
-    Condition: IsBuildStagingProd
     Properties:
       RoleName: !Sub ${AWS::StackName}-RunbookF2fResetRole
       Description: "This role allows approved support team to perform pending F2F reset"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -118,6 +118,10 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsBuildStagingProd: !Or
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, production ]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -765,7 +769,7 @@ Resources:
                 - 'dynamodb:GetItem'
                 - 'dynamodb:DeleteItem'
               Resource:
-                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/cri-response
+                - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/cri-response-${Environment}
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - SSMParameterReadPolicy:
@@ -799,6 +803,7 @@ Resources:
 
   ManualF2fPendingResetFunctionManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
+    Condition: IsBuildStagingProd
     Properties:
       ManagedPolicyName: ManualF2fPendingResetManagedPolicy
       Description: Allows invoking the ManualF2f Lambda
@@ -812,16 +817,10 @@ Resources:
               - lambda:GetFunction
             Resource:
               - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:manual-f2f-pending-reset-${Environment}
-          - Sid: AllowGetDeleteCriResponseDynamoDbTable
-            Effect: Allow
-            Action:
-              - 'dynamodb:GetItem'
-              - 'dynamodb:DeleteItem'
-            Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/cri-response
 
   ManualF2fPendingResetFunctionInvokeRole:
     Type: AWS::IAM::Role
+    Condition: IsBuildStagingProd
     Properties:
       RoleName: !Sub ${AWS::StackName}-RunbookF2fResetRole
       Description: "This role allows approved support team to perform pending F2F reset"


### PR DESCRIPTION
## Proposed changes
### What changed

- Add missing suffix for dynamodb table to correctly match the resource name.

### Why did it change

- cri-response table does not exist.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8306](https://govukverify.atlassian.net/browse/PYIC-8306)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8306]: https://govukverify.atlassian.net/browse/PYIC-8306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ