### PR TITLE
PYIC-8547: Add test to check that multiple app callbacks don't skip through the journey

### DIFF
--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -350,6 +350,22 @@ Feature: M2B Strategic App Journeys
       When I submit a 'back' event
       Then I get a 'page-ipv-identity-document-start' page response
 
+    Scenario: Multiple callbacks do not incorrectly progress the journey
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+
+      # Repeat callback
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+
   Rule: No photo ID
     Scenario: Strategic app no photo ID goes to F2F
       Given I activate the 'strategicApp' feature set


### PR DESCRIPTION

## Proposed changes
### What changed

Added new API test to simulate multiple app callbacks
Updated app callback test code to match new core-front behaviour in https://github.com/govuk-one-login/ipv-core-front/pull/2173

### Why did it change

To check that the bug is fixed and prevent regressions

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8547](https://govukverify.atlassian.net/browse/PYIC-8547)



[PYIC-8547]: https://govukverify.atlassian.net/browse/PYIC-8547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ