### PR TITLE
PYIC-8567: Update Cosign and installer

### DIFF
--- a/.github/workflows/secure-pipeline-api-tests-image.yml
+++ b/.github/workflows/secure-pipeline-api-tests-image.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         with:
-          cosign-release: 'v1.9.0'
+          cosign-release: 'v2.5.1'
 
       - name: Set up build AWS creds
         uses: aws-actions/configure-aws-credentials@v4
@@ -51,5 +51,5 @@ jobs:
           docker push "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:latest"
           docker push "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:${SHA}"
 
-          cosign sign --key "awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY}" "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:latest"
-          cosign sign --key "awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY}" "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:${SHA}"
+          cosign sign --yes --tlog-upload=false --key "awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY}" "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:latest"
+          cosign sign --yes --tlog-upload=false --key "awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY}" "${BUILD_ECR_REG}/${BUILD_API_TESTS_ECR_REPO}:${SHA}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Update Cosign and installer
Cosign v2 defaults to uploading signatures to Rekor (tlog); disable with --tlog-upload=false

### Why did it change

v3.9.2 of the installer no longer supports Cosign below v2.0.0 so we should take this opportunity to update Cosign to its most recent version along with the installer.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PYIC-8567](https://govukverify.atlassian.net/browse/PYIC-8567)

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8567]: https://govukverify.atlassian.net/browse/PYIC-8567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ