### PR TITLE
BAU: Add gradle setup to workflow and change kid to its hashed version in pact tests

### DIFF
--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -29,10 +29,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Setup gradle from wrapper
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: wrapper
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -29,6 +29,10 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Setup gradle from wrapper
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -180,6 +180,11 @@ jobs:
           distribution: 'corretto'
           cache: gradle
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+        with:
+          gradle-version: "8.13"
+
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java
@@ -141,7 +141,7 @@ class IssueClientAccessTokenHandlerTest {
             "the JWT is signed with {\"kty\":\"EC\",\"d\":\"A2cfN3vYKgOQ_r1S6PhGHCLLiVEqUshFYExrxMwkq_A\",\"crv\":\"P-256\",\"kid\":\"14342354354353\",\"x\":\"BMyQQqr3NEFYgb9sEo4hRBje_HHEsy87PbNIBGL4Uiw\",\"y\":\"qoXdkYVomy6HWT6yNLqjHSmYoICs6ioUF565Btx0apw\",\"alg\":\"ES256\"}") // pragma: allowlist secret
     public void setOrchSigningKey() throws Exception {
         var signingKey =
-                "{\"kty\":\"EC\",\"d\":\"A2cfN3vYKgOQ_r1S6PhGHCLLiVEqUshFYExrxMwkq_A\",\"crv\":\"P-256\",\"kid\":\"14342354354353\",\"x\":\"BMyQQqr3NEFYgb9sEo4hRBje_HHEsy87PbNIBGL4Uiw\",\"y\":\"qoXdkYVomy6HWT6yNLqjHSmYoICs6ioUF565Btx0apw\",\"alg\":\"ES256\"}"; // pragma: allowlist secret
+                "{\"kty\":\"EC\",\"d\":\"A2cfN3vYKgOQ_r1S6PhGHCLLiVEqUshFYExrxMwkq_A\",\"crv\":\"P-256\",\"kid\":\"f17da8669a951afc3fb499e901186d77e99af23b5d1962d3ce85e9d6c82d3a69\",\"x\":\"BMyQQqr3NEFYgb9sEo4hRBje_HHEsy87PbNIBGL4Uiw\",\"y\":\"qoXdkYVomy6HWT6yNLqjHSmYoICs6ioUF565Btx0apw\",\"alg\":\"ES256\"}"; // pragma: allowlist secret
 
         when(mockOauthKeyService.getClientSigningKey(eq(TEST_CLIENT_ID), any()))
                 .thenReturn(ECKey.parse(signingKey));
@@ -151,7 +151,7 @@ class IssueClientAccessTokenHandlerTest {
             "the JWT is signed with {\"kty\":\"EC\",\"d\":\"4NLo4B5Oj5E_ga6-eYjTSehss85p_mL799NRQqmll64\",\"crv\":\"P-256\",\"kid\":\"14342354354353\",\"x\":\"emDeRQ0KISC_TdfkoAZdd4lWm2Nk5UOtmmboLEab850\",\"y\":\"-Ua4zzSzMG5lgpMyZoURg6Au60mHSxgnnf9pDtJmE2w\",\"alg\":\"ES256\"}") // pragma: allowlist secret
     public void setAuthSigningKey() throws Exception {
         var signingKey =
-                "{\"kty\":\"EC\",\"d\":\"4NLo4B5Oj5E_ga6-eYjTSehss85p_mL799NRQqmll64\",\"crv\":\"P-256\",\"kid\":\"14342354354353\",\"x\":\"emDeRQ0KISC_TdfkoAZdd4lWm2Nk5UOtmmboLEab850\",\"y\":\"-Ua4zzSzMG5lgpMyZoURg6Au60mHSxgnnf9pDtJmE2w\",\"alg\":\"ES256\"}"; // pragma: allowlist secret
+                "{\"kty\":\"EC\",\"d\":\"4NLo4B5Oj5E_ga6-eYjTSehss85p_mL799NRQqmll64\",\"crv\":\"P-256\",\"kid\":\"f17da8669a951afc3fb499e901186d77e99af23b5d1962d3ce85e9d6c82d3a69\",\"x\":\"emDeRQ0KISC_TdfkoAZdd4lWm2Nk5UOtmmboLEab850\",\"y\":\"-Ua4zzSzMG5lgpMyZoURg6Au60mHSxgnnf9pDtJmE2w\",\"alg\":\"ES256\"}"; // pragma: allowlist secret
 
         when(mockOauthKeyService.getClientSigningKey(eq(TEST_CLIENT_ID), any()))
                 .thenReturn(ECKey.parse(signingKey));

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java
@@ -148,7 +148,7 @@ class IssueClientAccessTokenHandlerTest {
     }
 
     @State(
-            "the JWT is signed with {\"kty\":\"EC\",\"d\":\"4NLo4B5Oj5E_ga6-eYjTSehss85p_mL799NRQqmll64\",\"crv\":\"P-256\",\"kid\":\"14342354354353\",\"x\":\"emDeRQ0KISC_TdfkoAZdd4lWm2Nk5UOtmmboLEab850\",\"y\":\"-Ua4zzSzMG5lgpMyZoURg6Au60mHSxgnnf9pDtJmE2w\",\"alg\":\"ES256\"}") // pragma: allowlist secret
+            "the JWT is signed with {\"kty\":\"EC\",\"d\":\"4NLo4B5Oj5E_ga6-eYjTSehss85p_mL799NRQqmll64\",\"crv\":\"P-256\",\"kid\":\"f17da8669a951afc3fb499e901186d77e99af23b5d1962d3ce85e9d6c82d3a69\",\"x\":\"emDeRQ0KISC_TdfkoAZdd4lWm2Nk5UOtmmboLEab850\",\"y\":\"-Ua4zzSzMG5lgpMyZoURg6Au60mHSxgnnf9pDtJmE2w\",\"alg\":\"ES256\"}") // pragma: allowlist secret
     public void setAuthSigningKey() throws Exception {
         var signingKey =
                 "{\"kty\":\"EC\",\"d\":\"4NLo4B5Oj5E_ga6-eYjTSehss85p_mL799NRQqmll64\",\"crv\":\"P-256\",\"kid\":\"f17da8669a951afc3fb499e901186d77e99af23b5d1962d3ce85e9d6c82d3a69\",\"x\":\"emDeRQ0KISC_TdfkoAZdd4lWm2Nk5UOtmmboLEab850\",\"y\":\"-Ua4zzSzMG5lgpMyZoURg6Au60mHSxgnnf9pDtJmE2w\",\"alg\":\"ES256\"}"; // pragma: allowlist secret

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java
@@ -141,7 +141,7 @@ class IssueClientAccessTokenHandlerTest {
             "the JWT is signed with {\"kty\":\"EC\",\"d\":\"A2cfN3vYKgOQ_r1S6PhGHCLLiVEqUshFYExrxMwkq_A\",\"crv\":\"P-256\",\"kid\":\"14342354354353\",\"x\":\"BMyQQqr3NEFYgb9sEo4hRBje_HHEsy87PbNIBGL4Uiw\",\"y\":\"qoXdkYVomy6HWT6yNLqjHSmYoICs6ioUF565Btx0apw\",\"alg\":\"ES256\"}") // pragma: allowlist secret
     public void setOrchSigningKey() throws Exception {
         var signingKey =
-                "{\"kty\":\"EC\",\"d\":\"A2cfN3vYKgOQ_r1S6PhGHCLLiVEqUshFYExrxMwkq_A\",\"crv\":\"P-256\",\"kid\":\"f17da8669a951afc3fb499e901186d77e99af23b5d1962d3ce85e9d6c82d3a69\",\"x\":\"BMyQQqr3NEFYgb9sEo4hRBje_HHEsy87PbNIBGL4Uiw\",\"y\":\"qoXdkYVomy6HWT6yNLqjHSmYoICs6ioUF565Btx0apw\",\"alg\":\"ES256\"}"; // pragma: allowlist secret
+                "{\"kty\":\"EC\",\"d\":\"A2cfN3vYKgOQ_r1S6PhGHCLLiVEqUshFYExrxMwkq_A\",\"crv\":\"P-256\",\"kid\":\"14342354354353\",\"x\":\"BMyQQqr3NEFYgb9sEo4hRBje_HHEsy87PbNIBGL4Uiw\",\"y\":\"qoXdkYVomy6HWT6yNLqjHSmYoICs6ioUF565Btx0apw\",\"alg\":\"ES256\"}"; // pragma: allowlist secret
 
         when(mockOauthKeyService.getClientSigningKey(eq(TEST_CLIENT_ID), any()))
                 .thenReturn(ECKey.parse(signingKey));


### PR DESCRIPTION
## Proposed changes
### What changed

- There are incompatibilities between aws-sam-cli and gradle 9.x version. Added gradle setup to workflow to resolve this issue.

### Why did it change

- To resolve GitHub actions issues


## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
