### PR TITLE
PYIC-8098: fix journey-map auth not working in aws

### DIFF
--- a/journey-map/server/app.ts
+++ b/journey-map/server/app.ts
@@ -6,9 +6,6 @@ const isDevelopment = process.env.NODE_ENV === "development";
 
 const app = express();
 
-app.use(express.static("public"));
-app.use(express.static("journey-maps"));
-
 app.get("/healthcheck", (req, res) => {
   res.status(200).send("OK");
 });
@@ -16,6 +13,9 @@ app.get("/healthcheck", (req, res) => {
 if (!isDevelopment) {
   app.use(authorise);
 }
+
+app.use(express.static("public"));
+app.use(express.static("journey-maps"));
 
 // In dev we load journey maps directly
 if (isDevelopment) {


### PR DESCRIPTION
## Proposed changes
### What changed

- moving the auth near the top of the app.ts file

Can test in my dev env: https://dev-theab-journey-map.02.core.dev.stubs.account.gov.uk/ (username and pwd in config)

### Why did it change

- the auth on the journey-map wasn't working when deployed to AWS 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8098](https://govukverify.atlassian.net/browse/PYIC-8098)



[PYIC-8098]: https://govukverify.atlassian.net/browse/PYIC-8098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ