### PR TITLE
PYIC-8585: Discard async CRI queue message if no pending record

### DIFF
--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -223,8 +223,9 @@ public class ProcessAsyncCriCredentialHandler
         var criResponseItem = criResponseService.getCriResponseItemWithState(userId, state);
         if (criResponseItem.isEmpty()) {
             LOGGER.error(
-                    LogHelper.buildLogMessage("No response item found given user id and state"));
-            throw new AsyncVerifiableCredentialException(UNEXPECTED_ASYNC_VERIFIABLE_CREDENTIAL);
+                    LogHelper.buildLogMessage(
+                            "No pending CRI response item found for given user id and state; discarding message"));
+            return;
         }
 
         var cri = Cri.fromId(criResponseItem.get().getCredentialIssuer());

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -41,7 +41,6 @@ import uk.gov.di.ipv.core.library.verifiablecredential.validator.VerifiableCrede
 import uk.gov.di.ipv.core.processasynccricredential.domain.BaseAsyncCriResponse;
 import uk.gov.di.ipv.core.processasynccricredential.domain.ErrorAsyncCriResponse;
 import uk.gov.di.ipv.core.processasynccricredential.domain.SuccessAsyncCriResponse;
-import uk.gov.di.ipv.core.processasynccricredential.exceptions.AsyncVerifiableCredentialException;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -52,7 +51,6 @@ import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAudit;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAuditWithCriId;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForAsync;
-import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNEXPECTED_ASYNC_VERIFIABLE_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_CODE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
@@ -138,19 +136,12 @@ public class ProcessAsyncCriCredentialHandler
         } catch (JsonProcessingException
                 | ParseException
                 | CiPutException
-                | AsyncVerifiableCredentialException
                 | UnrecognisedVotException
                 | CiPostMitigationsException
                 | CredentialParseException
                 | EvcsServiceException
                 | HttpResponseExceptionWithErrorBody e) {
             LOGGER.error(LogHelper.buildErrorMessage("Failed to process VC response message.", e));
-            if (e instanceof AsyncVerifiableCredentialException asyncVcException
-                    && asyncVcException
-                            .getErrorResponse()
-                            .equals(UNEXPECTED_ASYNC_VERIFIABLE_CREDENTIAL)) {
-                EmbeddedMetricHelper.asyncCriResponseUnexpected(extractQueueName(message));
-            }
             return List.of(new SQSBatchResponse.BatchItemFailure(message.getMessageId()));
         } catch (VerifiableCredentialException e) {
             LOGGER.error(
@@ -210,7 +201,6 @@ public class ProcessAsyncCriCredentialHandler
     private void processSuccessAsyncCriResponse(SuccessAsyncCriResponse successAsyncCriResponse)
             throws ParseException,
                     CiPutException,
-                    AsyncVerifiableCredentialException,
                     CiPostMitigationsException,
                     VerifiableCredentialException,
                     UnrecognisedVotException,

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -181,7 +181,7 @@ class ProcessAsyncCriCredentialHandlerTest {
     }
 
     @Test
-    void shouldRejectValidUnexpectedVerifiableCredential() throws Exception {
+    void shouldDiscardValidUnexpectedVerifiableCredentialWithoutRetry() throws Exception {
         final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE_2);
 
         when(criResponseService.getCriResponseItemWithState(TEST_USER_ID, TEST_OAUTH_STATE_2))
@@ -190,11 +190,11 @@ class ProcessAsyncCriCredentialHandlerTest {
         final SQSBatchResponse batchResponse = handler.handleRequest(testEvent, null);
 
         verifyVerifiableCredentialNotProcessedFurther();
-        verifyBatchResponseFailures(testEvent, batchResponse);
+        assertEquals(0, batchResponse.getBatchItemFailures().size());
     }
 
     @Test
-    void shouldRejectValidUnsolicitedVerifiableCredential() throws Exception {
+    void shouldDiscardValidUnsolicitedVerifiableCredentialWithoutRetry() throws Exception {
         final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE);
 
         when(criResponseService.getCriResponseItemWithState(TEST_USER_ID, TEST_OAUTH_STATE))
@@ -204,7 +204,7 @@ class ProcessAsyncCriCredentialHandlerTest {
 
         verifyVerifiableCredentialNotProcessedFurther();
 
-        verifyBatchResponseFailures(testEvent, batchResponse);
+        assertEquals(0, batchResponse.getBatchItemFailures().size());
     }
 
     @Test

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -68,7 +68,6 @@ class ProcessAsyncCriCredentialHandlerTest {
     private static final String TEST_COMPONENT_ID = TEST_CRI.getId();
     private static final String TEST_ENCRYPTION_KEY = "test-encryption-key";
     private static final String TEST_OAUTH_STATE = UUID.randomUUID().toString();
-    private static final String TEST_OAUTH_STATE_2 = UUID.randomUUID().toString();
     private static final CriResponseItem TEST_CRI_RESPONSE_ITEM =
             new CriResponseItem(
                     TEST_USER_ID,
@@ -178,19 +177,6 @@ class ProcessAsyncCriCredentialHandlerTest {
         assertEquals(AuditEventTypes.IPV_F2F_CRI_VC_ERROR, auditEvents.get(0).getEventName());
         assertEquals(AuditEventTypes.IPV_ASYNC_CRI_VC_ERROR, auditEvents.get(1).getEventName());
         assertEquals(CriResponseService.STATUS_ABANDON, TEST_CRI_RESPONSE_ITEM.getStatus());
-    }
-
-    @Test
-    void shouldDiscardValidUnexpectedVerifiableCredentialWithoutRetry() throws Exception {
-        final SQSEvent testEvent = createSuccessTestEvent(TEST_OAUTH_STATE_2);
-
-        when(criResponseService.getCriResponseItemWithState(TEST_USER_ID, TEST_OAUTH_STATE_2))
-                .thenReturn(Optional.empty());
-
-        final SQSBatchResponse batchResponse = handler.handleRequest(testEvent, null);
-
-        verifyVerifiableCredentialNotProcessedFurther();
-        assertEquals(0, batchResponse.getBatchItemFailures().size());
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -60,7 +60,6 @@ public enum ErrorResponse {
     FAILED_TO_CONSTRUCT_REDIRECT_URI(1047, "Failed to construct redirect uri"),
     FAILED_TO_PARSE_JSON_MESSAGE(1048, "Failed to parse JSON message"),
     FAILED_UNHANDLED_EXCEPTION(1049, "Unhandled exception"),
-    UNEXPECTED_ASYNC_VERIFIABLE_CREDENTIAL(1050, "Unexpected async verifiable credential"),
     PENDING_VERIFICATION_EXCEPTION(1051, "Pending face to face verification exception"),
     FAILED_TO_FIND_VISITED_CRI(1052, "Failed to find a visited CRI"),
     FAILED_TO_PARSE_CIMIT_SIGNING_KEY(1053, "Failed to parse CIMIT signing key"),


### PR DESCRIPTION
## Proposed changes
### What changed

-  Discard async CRI messages with no pending record instead of retrying; update tests accordingly

Before:
<img width="600" height="778" alt="Screenshot 2025-08-20 at 11 18 20" src="https://github.com/user-attachments/assets/0e750e85-6094-4dea-a0d0-ea47eb969bd4" />

After:
<img width="600" height="565" alt="Screenshot 2025-08-20 at 11 18 03" src="https://github.com/user-attachments/assets/fc344909-7c97-46a9-9df6-e438477b3d6b" />

Expanded new log:
<img width="600" height="783" alt="Screenshot 2025-08-20 at 11 19 58" src="https://github.com/user-attachments/assets/64320924-2e32-4ea3-bdc0-954a9519da1c" />

### Why did it change

-  The retries are causing unnecessary processing, noise in logs and are filling up mobile’s DLQ, making it hard to identify genuine issues.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8585](https://govukverify.atlassian.net/browse/PYIC-8585)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8585]: https://govukverify.atlassian.net/browse/PYIC-8585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ