### PR TITLE
PYIC-8595: Add VOT info to IPV_IDENTITY_REUSE_COMPLETE event

### DIFF
--- a/api-tests/data/audit-events/new-identity-f2f-journey.json
+++ b/api-tests/data/audit-events/new-identity-f2f-journey.json
@@ -356,6 +356,9 @@
   {
     "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
     "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "previous_achieved_vot": "P2"
+    },
     "restricted": {
       "device_information": {}
     }

--- a/api-tests/data/audit-events/reuse-journey-identity-stored.json
+++ b/api-tests/data/audit-events/reuse-journey-identity-stored.json
@@ -12,6 +12,9 @@
   {
     "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
     "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "previous_achieved_vot": "P2"
+    },
     "restricted": {
       "device_information": {}
     }

--- a/api-tests/data/audit-events/reuse-journey.json
+++ b/api-tests/data/audit-events/reuse-journey.json
@@ -12,6 +12,9 @@
   {
     "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
     "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "previous_achieved_vot": "P2"
+    },
     "restricted": {
       "device_information": {}
     }

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -12,6 +12,9 @@
   {
     "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
     "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "previous_achieved_vot": "P2"
+    },
     "restricted": {
       "device_information": {}
     }
@@ -109,6 +112,9 @@
   {
     "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
     "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "previous_achieved_vot": "P2"
+    },
     "restricted": {
       "device_information": {}
     }

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -751,7 +751,10 @@ public class CheckExistingIdentityHandler
             boolean correlated = userIdentityService.areVcsCorrelated(credentials);
             var result =
                     votMatcher.findStrongestMatches(
-                            List.of(Vot.P2, Vot.P1), credentials, List.of(), correlated);
+                            Vot.SUPPORTED_VOTS_BY_DESCENDING_STRENGTH,
+                            credentials,
+                            List.of(),
+                            correlated);
             return result.strongestMatch().map(m -> m.vot()).orElse(null);
         } catch (Exception e) {
             LOGGER.warn(LogHelper.buildLogMessage("Failed to compute previous_achieved_vot"), e);

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -990,7 +990,10 @@ class CheckExistingIdentityHandlerTest {
                             List.of(P2), List.of(gpg45Vc), List.of(), true))
                     .thenReturn(buildMatchResultFor(P2, matchedProfile));
             when(mockVotMatcher.findStrongestMatches(
-                            List.of(P2, P1), List.of(gpg45Vc), List.of(), true))
+                            Vot.SUPPORTED_VOTS_BY_DESCENDING_STRENGTH,
+                            List.of(gpg45Vc),
+                            List.of(),
+                            true))
                     .thenReturn(buildMatchResultFor(P2, matchedProfile));
             when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
 
@@ -1034,7 +1037,10 @@ class CheckExistingIdentityHandlerTest {
                             List.of(P2), List.of(gpg45Vc), List.of(), true))
                     .thenReturn(buildMatchResultFor(P2, M1A));
             when(mockVotMatcher.findStrongestMatches(
-                            List.of(P2, P1), List.of(gpg45Vc), List.of(), true))
+                            Vot.SUPPORTED_VOTS_BY_DESCENDING_STRENGTH,
+                            List.of(gpg45Vc),
+                            List.of(),
+                            true))
                     .thenThrow(new RuntimeException("boom"));
 
             var journeyResponse =
@@ -1070,7 +1076,8 @@ class CheckExistingIdentityHandlerTest {
                     .thenReturn(emptyAsyncCriStatus);
             when(mockVotMatcher.findStrongestMatches(List.of(P2), vcs, List.of(), true))
                     .thenReturn(buildMatchResultFor(P2, M1A));
-            when(mockVotMatcher.findStrongestMatches(List.of(P2, P1), vcs, List.of(), true))
+            when(mockVotMatcher.findStrongestMatches(
+                            Vot.SUPPORTED_VOTS_BY_DESCENDING_STRENGTH, vcs, List.of(), true))
                     .thenReturn(buildMatchResultFor(P2, M1A));
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
 

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionPreviousAchievedVot.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionPreviousAchievedVot.java
@@ -1,0 +1,22 @@
+package uk.gov.di.ipv.core.library.auditing.extension;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.core.library.enums.Vot;
+
+@ExcludeFromGeneratedCoverageReport
+@Getter
+public class AuditExtensionPreviousAchievedVot implements AuditExtensions {
+
+    @JsonProperty("previous_achieved_vot")
+    private final Vot previousAchievedVot;
+
+    @JsonCreator
+    public AuditExtensionPreviousAchievedVot(
+            @JsonProperty(value = "previous_achieved_vot", required = true)
+                    Vot previousAchievedVot) {
+        this.previousAchievedVot = previousAchievedVot;
+    }
+}


### PR DESCRIPTION
## Proposed changes
### What changed

- Add VOT info to IPV_IDENTITY_REUSE_COMPLETE event

### Why did it change

- Existing event data contains the VTR, the returned VOT and the technically achieved VOT in the stored identity for the current journey. But the data team would like to track whether stored identities change between P2 and P3 during reuse, so we need to emit extra data

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8595](https://govukverify.atlassian.net/browse/PYIC-8595)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8595]: https://govukverify.atlassian.net/browse/PYIC-8595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ