### PR TITLE
PYIC-7895: Add URI and UUID in Config class

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/AisConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/AisConfig.java
@@ -5,9 +5,11 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
 
+import java.net.URI;
+
 @Data
 @Builder
 @Jacksonized
 public class AisConfig {
-    @NonNull final String apiBaseUrl;
+    @NonNull final URI apiBaseUrl;
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CimitConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/CimitConfig.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -12,8 +13,8 @@ import java.util.Map;
 @Builder
 @Jacksonized
 public class CimitConfig {
-    @NonNull final String componentId;
+    @NonNull final URI componentId;
     @NonNull final String signingKey;
     @NonNull final Map<String, @NonNull List<@NonNull CiRoutingConfig>> config;
-    @NonNull final String apiBaseUrl;
+    @NonNull final URI apiBaseUrl;
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
@@ -5,6 +5,8 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
 
+import java.net.URI;
+
 @Data
 @Builder
 @Jacksonized
@@ -14,5 +16,5 @@ public class ClientConfig {
     @NonNull final String publicKeyMaterialForCoreToVerify;
     @NonNull final String validRedirectUrls;
     @NonNull final String validScopes;
-    final String jwksUrl; // Null for API test client configs
+    final URI jwksUrl; // Null for API test client configs
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/EvcsConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/EvcsConfig.java
@@ -5,9 +5,11 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
 
+import java.net.URI;
+
 @Data
 @Builder
 @Jacksonized
 public class EvcsConfig {
-    @NonNull final String applicationUrl;
+    @NonNull final URI applicationUrl;
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
@@ -6,25 +6,27 @@ import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
 import uk.gov.di.ipv.core.library.domain.ContraIndicatorConfig;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Data
 @Builder
 @Jacksonized
 public class InternalOperationsConfig {
     final String configFormat;
-    @NonNull final String componentId;
-    @NonNull final String signingKeyId;
-    @NonNull final String sisSigningKeyId;
-    @NonNull final String audienceForClients;
+    @NonNull final URI componentId;
+    @NonNull final UUID signingKeyId;
+    @NonNull final UUID sisSigningKeyId;
+    @NonNull final URI audienceForClients;
     @NonNull final Integer jwtTtlSeconds;
     @NonNull final Integer maxAllowedAuthClientTtl;
     @NonNull final Integer fraudCheckExpiryPeriodHours;
     @NonNull final Integer dcmawAsyncVcPendingReturnTtl;
     @NonNull final String clientJarKmsEncryptionKeyAliasPrimary;
     @NonNull final String clientJarKmsEncryptionKeyAliasSecondary;
-    @NonNull final String coreVtmClaim;
+    @NonNull final URI coreVtmClaim;
     @NonNull final Integer backendSessionTimeout;
     @NonNull final Integer backendSessionTtl;
     @NonNull final Integer bearerTokenTtl;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/StoredIdentityServiceConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/StoredIdentityServiceConfig.java
@@ -5,9 +5,11 @@ import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
 
+import java.net.URI;
+
 @Data
 @Builder
 @Jacksonized
 public class StoredIdentityServiceConfig {
-    @NonNull final String componentId;
+    @NonNull final URI componentId;
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/ConfigServiceTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.ipv.core.library.testdata.CommonData;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ConfigServiceTest {
 
     @Test
-    void generateConfigurationCreatesValidConfig() throws IOException {
+    void generateConfigurationCreatesValidConfig() throws IOException, URISyntaxException {
         // Arrange
         String yamlContent =
                 new String(
@@ -25,7 +27,8 @@ class ConfigServiceTest {
 
         // Assert
         assertEquals(
-                "https://identity.local.account.gov.uk", configuration.getSelf().getComponentId());
+                new URI("https://identity.local.account.gov.uk"),
+                configuration.getSelf().getComponentId());
     }
 
     @Test

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -3,8 +3,8 @@ core:
   self:
     configFormat: "yaml"
     componentId: "https://identity.local.account.gov.uk"
-    signingKeyId: "some-signin-id"
-    sisSigningKeyId: "dummy-value"
+    signingKeyId: "0faa6b9e-f148-4de9-afd0-445de70334ef"
+    sisSigningKeyId: "383e1fda-574b-4de5-b066-0fd020d282f0"
     audienceForClients: "https://identity.local.account.gov.uk"
     jwtTtlSeconds: 3600
     maxAllowedAuthClientTtl: 3600


### PR DESCRIPTION
## Proposed changes
### What changed

- Add URI and UUID in Config class

### Why did it change

- To make the Config class stricter

### Issue tracking

- [PYIC-7895](https://govukverify.atlassian.net/browse/PYIC-7895)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-7895]: https://govukverify.atlassian.net/browse/PYIC-7895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ