### PR TITLE
PYIC-8612: Route unexpected OAuth errors from DWP KBV to Experian KBV

### DIFF
--- a/api-tests/features/p1-web-journey.feature
+++ b/api-tests/features/p1-web-journey.feature
@@ -282,11 +282,7 @@ Feature: P1 Web Journeys
       When I call the CRI stub with attributes and get an '<error>' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-      Then I get a 'pyi-technical' page response
-      When I submit a 'next' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
+      Then I get a 'page-pre-experian-kbv-transition' page response
 
       Examples:
         | error                     |

--- a/api-tests/features/p1-web-journey.feature
+++ b/api-tests/features/p1-web-journey.feature
@@ -282,9 +282,12 @@ Feature: P1 Web Journeys
       When I call the CRI stub with attributes and get an '<error>' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'pyi-technical' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
 
       Examples:
         | error                     |
-        | server_error              |
         | temporarily_unavailable   |

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -429,7 +429,6 @@ Feature: P2 Web document journey
 
       Examples:
         | error                     |
-        | server_error              |
         | temporarily_unavailable   |
 
   Rule: P2 VTR only - User drops out of KBV CRI via thin file or failed checks

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -382,7 +382,7 @@ Feature: P2 Web document journey
       Then I get a 'page-pre-dwp-kbv-transition' page response
       When I submit a 'next' event
       Then I get a 'dwpKbv' CRI response
-      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+      When I call the CRI stub with attributes and get an '<oauth_error>' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response
@@ -398,38 +398,13 @@ Feature: P2 Web document journey
       Then I get a 'P2' identity
 
       Examples:
-        | cri            | details                      |
-        | drivingLicence | kenneth-driving-permit-valid |
-        | ukPassport     | kenneth-passport-valid       |
-
-    Scenario Outline: User drops out of DWP KBV due to a <error> error
-      When I submit a 'ukPassport' event
-      Then I get a 'ukPassport' CRI response
-      When I submit 'kenneth-passport-valid' details to the CRI stub
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'next' event
-      Then I get a 'page-pre-dwp-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'dwpKbv' CRI response
-      When I call the CRI stub with attributes and get an '<error>' OAuth error
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-technical' page response
-      When I submit a 'next' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-
-      Examples:
-        | error                     |
-        | server_error              |
-        | temporarily_unavailable   |
+        | cri            | details                      | oauth_error             |
+        | drivingLicence | kenneth-driving-permit-valid | access_denied           |
+        | ukPassport     | kenneth-passport-valid       | access_denied           |
+        | ukPassport     | kenneth-passport-valid       | server_error            |
+        | ukPassport     | kenneth-passport-valid       | temporarily_unavailable |
+        | ukPassport     | kenneth-passport-valid       | invalid_scope           |
+        | ukPassport     | kenneth-passport-valid       | unauthorized_client     |
 
   Rule: P2 VTR only - User drops out of KBV CRI via thin file or failed checks
     Background: Navigate to KBV CRI

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -25,6 +25,18 @@ nestedJourneyStates:
           - IPV_DWP_KBV_CRI_THIN_FILE_ENCOUNTERED
       access-denied:
         targetState: PRE_EXPERIAN_PAGE
+      not-found:
+        targetState: PRE_EXPERIAN_PAGE
+      fail-with-no-ci:
+        targetState: PRE_EXPERIAN_PAGE
+      vcs-not-correlated:
+        targetState: PRE_EXPERIAN_PAGE
+      error:
+        targetState: PRE_EXPERIAN_PAGE
+      temporarily-unavailable:
+        targetState: PRE_EXPERIAN_PAGE
+      dl-auth-source-check:
+        targetState: PRE_EXPERIAN_PAGE
       fail-with-ci:
         exitEventToEmit: fail-with-ci
   EXPERIAN_KBV_CRI:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -25,17 +25,7 @@ nestedJourneyStates:
           - IPV_DWP_KBV_CRI_THIN_FILE_ENCOUNTERED
       access-denied:
         targetState: PRE_EXPERIAN_PAGE
-      not-found:
-        targetState: PRE_EXPERIAN_PAGE
-      fail-with-no-ci:
-        targetState: PRE_EXPERIAN_PAGE
-      vcs-not-correlated:
-        targetState: PRE_EXPERIAN_PAGE
       error:
-        targetState: PRE_EXPERIAN_PAGE
-      temporarily-unavailable:
-        targetState: PRE_EXPERIAN_PAGE
-      dl-auth-source-check:
         targetState: PRE_EXPERIAN_PAGE
       fail-with-ci:
         exitEventToEmit: fail-with-ci


### PR DESCRIPTION
## Proposed changes
### What changed

- Route unexpected OAuth errors from DWP KBV to Experian KBV

Before:
<img width="1419" height="474" alt="Screenshot 2025-08-28 at 11 16 31" src="https://github.com/user-attachments/assets/852cc091-9385-4fd9-9483-b2fecd1c9c1b" />

After:
<img width="1409" height="469" alt="Screenshot 2025-08-28 at 11 16 27" src="https://github.com/user-attachments/assets/35690080-84ea-445b-9b91-05f84a0cb760" />

### Why did it change

- Experian KBVs should be a fallback for DWP KBV failures

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8612](https://govukverify.atlassian.net/browse/PYIC-8612)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out



[PYIC-8612]: https://govukverify.atlassian.net/browse/PYIC-8612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ