### PR TITLE
PYIC-8609: Add DwpKbvCriReturnRateAlarm

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3741,7 +3741,7 @@ Resources:
         - Id: redirect
           MetricStat:
             Metric:
-              Namespace: CoreBackEmbeddedMetrics-build
+              Namespace: !Sub "CoreBackEmbeddedMetrics-${Environment}"
               MetricName: criRedirect
               Dimensions:
                 - Name: cri
@@ -3751,7 +3751,7 @@ Resources:
         - Id: returned
           MetricStat:
             Metric:
-              Namespace: CoreBackEmbeddedMetrics-build
+              Namespace: !Sub "CoreBackEmbeddedMetrics-${Environment}"
               MetricName: criReturn
               Dimensions:
                 - Name: cri

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3748,6 +3748,7 @@ Resources:
                   Value: dwpKbv
             Period: 300
             Stat: Sum
+          ReturnData: false
         - Id: returned
           MetricStat:
             Metric:
@@ -3758,6 +3759,7 @@ Resources:
                   Value: dwpKbv
             Period: 300
             Stat: Sum
+          ReturnData: false
         - Id: returnRate
           Expression: "returned / redirect"
           Label: "DWP KBV CRI Return Rate"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3725,6 +3725,44 @@ Resources:
             Period: 60
             Stat: Sum
 
+  DwpKbvCriReturnRateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-DwpKbvCriReturnRateAlarm
+      AlarmDescription: "Alarm if DWP KBV CRI return rate is 0 for 3 consecutive 5-minute windows"
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue alarm-alerts-topic
+      EvaluationPeriods: 3
+      Threshold: 0
+      ComparisonOperator: LessThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: redirect
+          MetricStat:
+            Metric:
+              Namespace: CoreBackEmbeddedMetrics-build
+              MetricName: criRedirect
+              Dimensions:
+                - Name: cri
+                  Value: dwpKbv
+            Period: 300
+            Stat: Sum
+        - Id: returned
+          MetricStat:
+            Metric:
+              Namespace: CoreBackEmbeddedMetrics-build
+              MetricName: criReturn
+              Dimensions:
+                - Name: cri
+                  Value: dwpKbv
+            Period: 300
+            Stat: Sum
+        - Id: returnRate
+          Expression: "returned / redirect"
+          Label: "DWP KBV CRI Return Rate"
+          ReturnData: true
+
   IssueClientAccessTokenFunctionIOExceptionMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:


### PR DESCRIPTION
## Proposed changes
### What changed

- Add DwpKbvCriReturnRateAlarm

### Why did it change

- To monitor the external CRI's success rate

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8609](https://govukverify.atlassian.net/browse/PYIC-8609)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8609]: https://govukverify.atlassian.net/browse/PYIC-8609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ