### PR TITLE
PYIC-8381: add sis applicationUrl to config for validation

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/Config.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/Config.java
@@ -16,6 +16,7 @@ public class Config {
     @NonNull final AisConfig ais;
     @NonNull final CimitConfig cimit;
     @NonNull final EvcsConfig evcs;
+    final SisConfig sis;
     @NonNull final StoredIdentityServiceConfig storedIdentityService;
     @NonNull final CredentialIssuersConfig credentialIssuers;
     final Map<String, Map<String, String>> local;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/SisConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/SisConfig.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.core.library.config.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
+
+import java.net.URI;
+
+@Data
+@Builder
+@Jacksonized
+public class SisConfig {
+    @NonNull final URI applicationUrl;
+}

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -100,6 +100,8 @@ core:
     apiBaseUrl: "https://cimit-api.stubs.account.gov.uk"
   evcs:
     applicationUrl: "https://evcs.stubs.account.gov.uk"
+  sis:
+    applicationUrl: "https://sis.stubs.account.gov.uk"
   storedIdentityService:
     componentId: "https://reuse-identity.build.account.gov.uk"
   credentialIssuers:


### PR DESCRIPTION
## Proposed changes
### What changed

- add sis applicationUrl to config for validation

### Why did it change

- so that we can add new sis config to the config files and it can deploy successfully

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8381](https://govukverify.atlassian.net/browse/PYIC-8381)



[PYIC-8381]: https://govukverify.atlassian.net/browse/PYIC-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ