### PR TITLE
PYIC-8582: switch to AWS CRT-based http client

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ awsSdkDynamodb = { module = "software.amazon.awssdk:dynamodb" }
 awsSdkDynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
 awsSdkKms = { module = "software.amazon.awssdk:kms" }
 awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
-awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
+awsSdkCrtClient = { module = "software.amazon.awssdk:aws-crt-client" }
 awsSdkAppConfigData = { module = "software.amazon.awssdk:appconfigdata" }
 commonsCodec = "commons-codec:commons-codec:1.19.0"
 commonsCollections = "org.apache.commons:commons-collections4:4.5.0-M2"

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation libs.bundles.awsLambda,
 			libs.awsSdkKms,
 			libs.powertoolsParameters,
+			libs.awsSdkCrtClient,
 			project(":libs:ais-service"),
 			project(":libs:audit-service"),
 			project(":libs:common-services"),

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -12,7 +12,7 @@ import com.nimbusds.jose.util.Base64URL;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import software.amazon.awssdk.services.kms.model.DecryptResponse;
@@ -47,7 +47,7 @@ public class KmsRsaDecrypter implements JWEDecrypter {
         this.kmsClient =
                 KmsClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .httpClientBuilder(AwsCrtHttpClient.builder())
                         .build();
     }
 

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsSdkUrlConnectionClient,
+			libs.awsSdkCrtClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -8,7 +8,7 @@ plugins {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.apacheHttpCore,
-			libs.awsSdkUrlConnectionClient,
+			libs.awsSdkCrtClient,
 			libs.jacksonDatabind,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 			libs.awsSdkDynamodbEnhanced,
 			libs.awsSdkKms,
 			libs.awsSdkAppConfigData,
+			libs.awsSdkCrtClient,
 			libs.commonsCodec,
 			libs.commonsCollections,
 			libs.jacksonDatabind,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStore.java
@@ -15,7 +15,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
@@ -57,7 +57,7 @@ public class DynamoDataStore<T extends PersistenceItem> implements DataStore<T> 
         var client =
                 DynamoDbClient.builder()
                         .region(EU_WEST_2)
-                        .httpClient(UrlConnectionHttpClient.create())
+                        .httpClient(AwsCrtHttpClient.create())
                         .build();
 
         return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.DecryptionFailureException;
@@ -55,7 +55,7 @@ public class AppConfigService extends ConfigService {
         appConfigProvider =
                 ParamManager.getAppConfigProvider(
                                 AppConfigDataClient.builder()
-                                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                                        .httpClientBuilder(AwsCrtHttpClient.builder())
                                         .build(),
                                 environmentId,
                                 applicationId)
@@ -64,7 +64,7 @@ public class AppConfigService extends ConfigService {
         secretsProvider =
                 ParamManager.getSecretsProvider(
                                 SecretsManagerClient.builder()
-                                        .httpClient(UrlConnectionHttpClient.create())
+                                        .httpClient(AwsCrtHttpClient.create())
                                         .build())
                         .defaultMaxAge(cacheDuration, MINUTES);
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/signing/SignerFactory.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/signing/SignerFactory.java
@@ -2,7 +2,7 @@ package uk.gov.di.ipv.core.library.signing;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.ECKey;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
@@ -26,7 +26,7 @@ public class SignerFactory {
         this.kmsClient =
                 KmsClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(UrlConnectionHttpClient.builder())
+                        .httpClientBuilder(AwsCrtHttpClient.builder())
                         .build();
     }
 

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -7,7 +7,7 @@ plugins {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkSqs,
-			libs.awsSdkUrlConnectionClient,
+			libs.awsSdkCrtClient,
 			libs.bundles.awsLambda,
 			libs.bundles.log4j,
 			libs.jacksonDatabind,


### PR DESCRIPTION
## Proposed changes
### What changed

- switch to AWS CRT-based http client
- Have checked this works in local-running

### Why did it change

- AWS documentation now recommends using the AWS common-runtime client by default on lambda. There was a [previous attempt](https://github.com/govuk-one-login/ipv-core-back/pull/2049) but it didn't work with dynatrace but now that we have switched over to open telemetry, we're giving it another go.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8582](https://govukverify.atlassian.net/browse/PYIC-8582)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8582]: https://govukverify.atlassian.net/browse/PYIC-8582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ