### PR TITLE
Pyic 8627 - Set sis feature flag to true in local env.

### DIFF
--- a/api-tests/data/audit-events/dwp-kbv-successful-journey.json
+++ b/api-tests/data/audit-events/dwp-kbv-successful-journey.json
@@ -376,7 +376,7 @@
     "extensions": {
       "identity_type": "new",
       "vot": "P2",
-      "sis_record_created": false
+      "sis_record_created": true
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/new-identity-f2f-journey.json
+++ b/api-tests/data/audit-events/new-identity-f2f-journey.json
@@ -480,7 +480,7 @@
     "extensions": {
       "identity_type": "new",
       "vot": "P2",
-      "sis_record_created": false
+      "sis_record_created": true
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/reprove-identity-journey.json
+++ b/api-tests/data/audit-events/reprove-identity-journey.json
@@ -305,7 +305,7 @@
     "extensions": {
       "identity_type": "new",
       "vot": "P3",
-      "sis_record_created": false
+      "sis_record_created": true
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/reuse-journey.json
+++ b/api-tests/data/audit-events/reuse-journey.json
@@ -79,6 +79,18 @@
     }
   },
   {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "existing",
+      "sis_record_created": true,
+      "vot": "P2"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_JOURNEY_END",
     "component_id": "https://identity.local.account.gov.uk",
     "restricted": {

--- a/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
+++ b/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
@@ -308,7 +308,7 @@
     "extensions": {
       "identity_type": "new",
       "vot": "P3",
-      "sis_record_created": false
+      "sis_record_created": true
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -79,6 +79,18 @@
     }
   },
   {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "existing",
+      "sis_record_created": true,
+      "vot": "P2"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_USER_DETAILS_UPDATE_START",
     "component_id": "https://identity.local.account.gov.uk",
     "restricted": {
@@ -173,6 +185,18 @@
     "extensions": {
       "cri": "ticf",
       "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "identity_type": "existing",
+      "sis_record_created": true,
+      "vot": "P2"
     },
     "restricted": {
       "device_information": {}
@@ -529,7 +553,7 @@
     "extensions": {
       "identity_type": "update",
       "vot": "P2",
-      "sis_record_created": false
+      "sis_record_created": true
     },
     "restricted": {
       "device_information": {}

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -369,7 +369,7 @@ core:
     sqsAsync: true
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: true
-    storedIdentityServiceEnabled: false
+    storedIdentityServiceEnabled: true
     accountInterventionsEnabled: true
 
   features:


### PR DESCRIPTION
## Proposed changes
### What changed

-  Changed sis feature flag to true in local environment
-  Adjusted audit event data files

### Why did it change

- Stored identity feature flag is enabled in all environments apart from local env, which make our api test in accurate when run in GH or pipelines.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8627](https://govukverify.atlassian.net/browse/PYIC-8627)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8627]: https://govukverify.atlassian.net/browse/PYIC-8627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ