### PR TITLE
PYIC-8235: Fix Journey map SSM parameter namings & API GW references

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -855,7 +855,7 @@ Resources:
           ResourcePath: '/*'
           HttpMethod: '*'
           MetricsEnabled: true
-      StageName: !Sub ${Environment}
+      StageName: !Sub "${Environment}-analytics"
       TracingEnabled: true
       DefinitionBody:
         'Fn::Transform':
@@ -906,7 +906,7 @@ Resources:
     Type: AWS::ApiGateway::Deployment
     Properties:
       RestApiId: !Ref IPVCoreAnalyticsAPI
-      StageName: !Sub ${Environment}
+      StageName: !Ref IPVCoreAnalyticsAPI.Stage
 
   IPVCoreAnalyticsUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
@@ -915,7 +915,7 @@ Resources:
       UsagePlanName: !Sub IPVCoreAnalyticsUsagePlan-${Environment}
       ApiStages:
         - ApiId: !Ref IPVCoreAnalyticsAPI
-          Stage: !Sub ${Environment}
+          Stage: !Ref IPVCoreAnalyticsAPI.Stage
       Throttle:
         RateLimit: 10
         BurstLimit: 2
@@ -979,7 +979,7 @@ Resources:
     Properties:
       DomainName: !Ref IPVCoreAnalyticsDomain
       RestApiId: !Ref IPVCoreAnalyticsAPI
-      Stage: !Sub ${Environment}
+      Stage: !Ref IPVCoreAnalyticsAPI.Stage
       BasePath: ""
 
   IPVCoreAnalyticsDNSRecord:

--- a/journey-map/deploy/template.yaml
+++ b/journey-map/deploy/template.yaml
@@ -319,9 +319,9 @@ Resources:
             - Name: JOURNEY_MAP_PASSWORD
               Value: '{{resolve:ssm:/journey-map/JOURNEY_MAP_PASSWORD}}'
             - Name: JOURNEY_TRANSITIONS_ENDPOINT
-              Value: '{{resolve:ssm:/journeyMap/JOURNEY_TRANSITIONS_ENDPOINT}}'
+              Value: '{{resolve:ssm:/journey-map/JOURNEY_TRANSITIONS_ENDPOINT}}'
             - Name: ANALYTICS_API_KEY
-              Value: '{{resolve:ssm:/journeyMap/ANALYTICS_API_KEY}}'
+              Value: '{{resolve:ssm:/journey-map/ANALYTICS_API_KEY}}'
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp


### PR DESCRIPTION
## Proposed changes
### What changed

- Fix Journey map SSM parameter namings
- Fix stagename references to avoid overlap

### Why did it change

- The reference uses journeyMap, not the. correct "journey-map"
- Stage name overlap preventing deployment

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8235](https://govukverify.atlassian.net/browse/PYIC-8235)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8235]: https://govukverify.atlassian.net/browse/PYIC-8235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ