### PR TITLE
PYIC-8235: Fix log group to be dynamic

### DIFF
--- a/lambdas/fetch-journey-transitions/src/main/java/uk/gov/di/ipv/core/fetchjourneytransitions/FetchJourneyTransitionsHandler.java
+++ b/lambdas/fetch-journey-transitions/src/main/java/uk/gov/di/ipv/core/fetchjourneytransitions/FetchJourneyTransitionsHandler.java
@@ -26,7 +26,10 @@ public class FetchJourneyTransitionsHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final String LOG_GROUP = "/aws/lambda/process-journey-event-dev";
+    private static final String ENVIRONMENT =
+            Optional.ofNullable(System.getenv("ENVIRONMENT")).orElse("build");
+    private static final String LOG_GROUP =
+            String.format("/aws/lambda/process-journey-event-%s", ENVIRONMENT);
     private static final int MAX_ATTEMPTS = 10;
     private static final Pattern JOURNEY_ID_PATTERN = Pattern.compile("^[A-Za-z0-9_-]{43}$");
     private static final Map<String, String> CORS_HEADERS =


### PR DESCRIPTION
## Proposed changes
### What changed

- Fix log group to be dynamic

### Why did it change

- Log group must be dynamic

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8235](https://govukverify.atlassian.net/browse/PYIC-8235)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8235]: https://govukverify.atlassian.net/browse/PYIC-8235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ