### PR TITLE
PYIC-8614: remove old journeyContext from IpvSessionItem

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.library.persistence.item;
 
-import com.nimbusds.oauth2.sdk.util.StringUtils;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -53,7 +52,6 @@ public class IpvSessionItem implements PersistenceItem {
      * @see uk.gov.di.ipv.core.processjourneyevent.statemachine.events.BasicEvent#TransitionResult
      */
     @Builder.Default private List<String> journeyContexts = new ArrayList<>();
-    private String journeyContext;
 
     // Only for passing the featureSet to the external API lambdas at the end of the user journey.
     // Not for general use.
@@ -119,22 +117,13 @@ public class IpvSessionItem implements PersistenceItem {
         if (!this.journeyContexts.contains(journeyContext)) {
             this.journeyContexts.add(journeyContext);
         }
-        this.journeyContext = journeyContext;
     }
 
     public void unsetJourneyContext(String journeyContext) {
         this.journeyContexts.remove(journeyContext);
-        this.journeyContext = null;
     }
 
     public List<String> getActiveJourneyContexts() {
-        // This needs to add the existing journey context to the
-        // journeyContexts set in case a user uses a mix
-        // of old and new version of the process-journey-event lambda
-        if (StringUtils.isNotBlank(journeyContext)
-                && !this.journeyContexts.contains(journeyContext)) {
-            this.journeyContexts.add(journeyContext);
-        }
         return this.journeyContexts;
     }
 }


### PR DESCRIPTION
## Proposed changes
### What changed

- remove old journeyContext from IpvSessionItem

### Why did it change

- Since we have journeyContexts which allows it to be multi-valued, we can clean up the old journeyContext

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8614](https://govukverify.atlassian.net/browse/PYIC-8614)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8614]: https://govukverify.atlassian.net/browse/PYIC-8614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ