### PR TITLE
BAU Mark switched-on CRIs 'enabled' across all envs

### DIFF
--- a/journey-map/public/index.html
+++ b/journey-map/public/index.html
@@ -39,7 +39,7 @@
           <div id="checkbox-controls">
             <fieldset id="disabledInput">
               <legend>Turn off a CRI</legend>
-              <p>See what happens when you turn off a service.</p>
+              <p>Note not all CRIs have disabled routing configured.</p>
             </fieldset>
             <fieldset id="featureFlagInput">
               <legend>Turn on a feature flag</legend>

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -148,7 +148,7 @@ core:
     dcmawAsync:
       id: dcmawAsync
       name: "Document Checking - Mobile App and Web - Async"
-      enabled: "false"
+      enabled: "true"
       unavailable: false # temporarily unavailable
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
@@ -285,7 +285,7 @@ core:
     nino:
       id: nino
       name: NINO
-      enabled: "false"
+      enabled: "true"
       unavailable: false # temporarily unavailable
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"


### PR DESCRIPTION
## Proposed changes
### What changed

Mark switched-on CRIs 'enabled' across all envs and also add clarifying note in journey map tool

### Why did it change

DCMAW Async and NINO CRIs are in use in routes switched on up to prod but their CRI 'enabled' flag has no effect (their routes are controlled by other flags) - set to true anyway to avoid any confusion, especially in the journey map tool

## Checklists

- [x] READMEs and documentation up-to-date
- [x] No risk of exposure: PII, credentials, etc through logs
- [x] Understand 1) config updates are immediately deployed 2) config-management Lambda updates are deployed via a pipeline