### PR TITLE
Revert "PYIC-8582: switch to AWS CRT-based http client"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ awsSdkDynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced" }
 awsSdkKms = { module = "software.amazon.awssdk:kms" }
 awsSdkSqs = { module = "software.amazon.awssdk:sqs" }
 awsSdkLogs = "com.amazonaws:aws-java-sdk-logs:1.12.664"
-awsSdkCrtClient = { module = "software.amazon.awssdk:aws-crt-client" }
+awsSdkUrlConnectionClient = { module = "software.amazon.awssdk:url-connection-client" }
 awsSdkAppConfigData = { module = "software.amazon.awssdk:appconfigdata" }
 commonsCodec = "commons-codec:commons-codec:1.19.0"
 commonsCollections = "org.apache.commons:commons-collections4:4.5.0-M2"

--- a/lambdas/initialise-ipv-session/build.gradle
+++ b/lambdas/initialise-ipv-session/build.gradle
@@ -10,7 +10,6 @@ dependencies {
 	implementation libs.bundles.awsLambda,
 			libs.awsSdkKms,
 			libs.powertoolsParameters,
-			libs.awsSdkCrtClient,
 			project(":libs:ais-service"),
 			project(":libs:audit-service"),
 			project(":libs:common-services"),

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/service/KmsRsaDecrypter.java
@@ -12,7 +12,7 @@ import com.nimbusds.jose.util.Base64URL;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import software.amazon.awssdk.services.kms.model.DecryptResponse;
@@ -47,7 +47,7 @@ public class KmsRsaDecrypter implements JWEDecrypter {
         this.kmsClient =
                 KmsClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(AwsCrtHttpClient.builder())
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
                         .build();
     }
 

--- a/libs/audit-service/build.gradle
+++ b/libs/audit-service/build.gradle
@@ -11,7 +11,7 @@ configurations {
 
 dependencies {
 	implementation platform(libs.awsSdkBom),
-			libs.awsSdkCrtClient,
+			libs.awsSdkUrlConnectionClient,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,
 			project(":libs:common-services"),

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -12,7 +12,7 @@ configurations {
 dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.apacheHttpCore,
-			libs.awsSdkCrtClient,
+			libs.awsSdkUrlConnectionClient,
 			libs.jacksonDatabind,
 			libs.powertoolsLogging,
 			libs.powertoolsParameters,

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -19,7 +19,6 @@ dependencies {
 			libs.awsSdkDynamodbEnhanced,
 			libs.awsSdkKms,
 			libs.awsSdkAppConfigData,
-			libs.awsSdkCrtClient,
 			libs.commonsCodec,
 			libs.commonsCollections,
 			libs.jacksonDatabind,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStore.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/DynamoDataStore.java
@@ -15,7 +15,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
@@ -57,7 +57,7 @@ public class DynamoDataStore<T extends PersistenceItem> implements DataStore<T> 
         var client =
                 DynamoDbClient.builder()
                         .region(EU_WEST_2)
-                        .httpClient(AwsCrtHttpClient.create())
+                        .httpClient(UrlConnectionHttpClient.create())
                         .build();
 
         return DynamoDbEnhancedClient.builder().dynamoDbClient(client).build();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/AppConfigService.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.DecryptionFailureException;
@@ -55,7 +55,7 @@ public class AppConfigService extends ConfigService {
         appConfigProvider =
                 ParamManager.getAppConfigProvider(
                                 AppConfigDataClient.builder()
-                                        .httpClientBuilder(AwsCrtHttpClient.builder())
+                                        .httpClientBuilder(UrlConnectionHttpClient.builder())
                                         .build(),
                                 environmentId,
                                 applicationId)
@@ -64,7 +64,7 @@ public class AppConfigService extends ConfigService {
         secretsProvider =
                 ParamManager.getSecretsProvider(
                                 SecretsManagerClient.builder()
-                                        .httpClient(AwsCrtHttpClient.create())
+                                        .httpClient(UrlConnectionHttpClient.create())
                                         .build())
                         .defaultMaxAge(cacheDuration, MINUTES);
     }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/signing/SignerFactory.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/signing/SignerFactory.java
@@ -2,7 +2,7 @@ package uk.gov.di.ipv.core.library.signing;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.ECKey;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
@@ -26,7 +26,7 @@ public class SignerFactory {
         this.kmsClient =
                 KmsClient.builder()
                         .region(EU_WEST_2)
-                        .httpClientBuilder(AwsCrtHttpClient.builder())
+                        .httpClientBuilder(UrlConnectionHttpClient.builder())
                         .build();
     }
 

--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	implementation platform(libs.awsSdkBom),
 			libs.awsSdkSqs,
 			libs.lombok,
-			libs.awsSdkCrtClient,
+			libs.awsSdkUrlConnectionClient,
 			libs.bundles.awsLambda,
 			libs.bundles.log4j,
 			libs.jacksonDatabind,


### PR DESCRIPTION
This reverts commit 87cb15cebbd9c09594ce4ab4437a3d4653a7f55e.

## Proposed changes
### What changed

Revert back to the Url Connection Client for use with the AWS SDK instead of the CRT Http Client. If it fixes the issue, we need to document the problem and decision somewhere. If it doesn't fix the issue, we can try profiling/generating a heap dump

### Why did it change

**Seems** to cause a memory leak but only for one Lambda and only in production. The change had a very minor impact on performance anyway.

See Jira ticket for details.

### Issue tracking

- [PYIC-8582](https://govukverify.atlassian.net/browse/PYIC-8582)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8582]: https://govukverify.atlassian.net/browse/PYIC-8582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ