### PR TITLE
PYIC-8649: Clean up P1 journeys feature flag

### DIFF
--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/pact/BuildUserIdentityHandlerTest.java
@@ -95,7 +95,7 @@ class BuildUserIdentityHandlerTest {
         var userIdentityService = new UserIdentityService(mockConfigService);
         var ipvSessionService = new IpvSessionService(mockIpvSessionDataStore, mockSleeper);
         var clientOAuthSessionDetailsService =
-                new ClientOAuthSessionDetailsService(mockOAuthSessionStore, mockConfigService);
+                new ClientOAuthSessionDetailsService(mockOAuthSessionStore);
 
         // Configure CIMIT service to return VC and no CIs
         var jwtBuilder =

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -18,7 +18,6 @@ import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.http.HttpStatusCode;
@@ -99,7 +98,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.COMPONENT_ID;
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.FRAUD_CHECK_EXPIRY_PERIOD_HOURS;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.AIS_ENABLED;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.P1_JOURNEYS_ENABLED;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.REPEAT_FRAUD_CHECK;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.RESET_IDENTITY;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SIS_VERIFICATION;
@@ -385,7 +383,6 @@ class CheckExistingIdentityHandlerTest {
                                     false,
                                     true,
                                     false));
-            Mockito.lenient().when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
             when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, false, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
@@ -500,7 +497,6 @@ class CheckExistingIdentityHandlerTest {
                                     false,
                                     true,
                                     false));
-            Mockito.lenient().when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
             when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, false, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(PENDING_RETURN, vcs));
@@ -1287,7 +1283,6 @@ class CheckExistingIdentityHandlerTest {
         void shouldReturnReproveP1JourneyIfReproveIdentityFlagSet() {
             clientOAuthSessionItem.setReproveIdentity(Boolean.TRUE);
             clientOAuthSessionItem.setVtr(List.of(P2.name(), P1.name()));
-            lenient().when(configService.enabled(P1_JOURNEYS_ENABLED)).thenReturn(true);
             when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                     .thenReturn(emptyAsyncCriStatus);
 

--- a/lambdas/fetch-system-settings/src/test/java/uk/gov/di/ipv/core/fetchsystemsettings/FetchSystemSettingsHandlerTest.java
+++ b/lambdas/fetch-system-settings/src/test/java/uk/gov/di/ipv/core/fetchsystemsettings/FetchSystemSettingsHandlerTest.java
@@ -65,7 +65,6 @@ class FetchSystemSettingsHandlerTest {
                             "drivingLicenceAuthCheck": true,
                             "sisVerificationEnabled": false,
                             "repeatFraudCheckEnabled": true,
-                            "p1JourneysEnabled": true,
                             "storedIdentityServiceEnabled": false,
                             "accountInterventionsEnabled": true,
                             "pendingF2FResetEnabled": false

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/pact/IssueClientAccessTokenHandlerTest.java
@@ -86,8 +86,7 @@ class IssueClientAccessTokenHandlerTest {
 
         var accessTokenService = new AccessTokenService(configService);
         var sessionService = new IpvSessionService(ipvSessionDataStore, mockSleeper);
-        var clientOAuthSessionService =
-                new ClientOAuthSessionDetailsService(oAuthDataStore, configService);
+        var clientOAuthSessionService = new ClientOAuthSessionDetailsService(oAuthDataStore);
         var clientAuthJwtIdService = new ClientAuthJwtIdService(jwtIdStore);
         var tokenRequestValidator =
                 new TokenRequestValidator(

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/pact/UserReverificationHandlerTest.java
@@ -77,7 +77,7 @@ public class UserReverificationHandlerTest {
     void pactSetup(PactVerificationContext context) throws IOException {
         var ipvSessionService = new IpvSessionService(mockIpvSessionDataStore, mockSleeper);
         var clientOAuthSessionDetailsService =
-                new ClientOAuthSessionDetailsService(mockOAuthSessionStore, mockConfigService);
+                new ClientOAuthSessionDetailsService(mockOAuthSessionStore);
 
         var handler =
                 new UserReverificationHandler(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -5,7 +5,6 @@ public enum CoreFeatureFlag implements FeatureFlag {
     RESET_IDENTITY("resetIdentity"),
     REPEAT_FRAUD_CHECK("repeatFraudCheckEnabled"),
     MFA_RESET("mfaResetEnabled"),
-    P1_JOURNEYS_ENABLED("p1JourneysEnabled"),
     SQS_ASYNC("sqsAsync"),
     DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
     STORED_IDENTITY_SERVICE("storedIdentityServiceEnabled"),

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ClientOAuthSessionDetailsService.java
@@ -1,32 +1,21 @@
 package uk.gov.di.ipv.core.library.service;
 
 import com.nimbusds.jwt.JWTClaimsSet;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
-import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.exceptions.ClientOauthSessionNotFoundException;
-import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 
 import java.text.ParseException;
-import java.util.List;
 
 import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.BACKEND_SESSION_TTL;
 import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.CLIENT_OAUTH_SESSIONS_TABLE_NAME;
 
 public class ClientOAuthSessionDetailsService {
-    private static final Logger LOGGER = LogManager.getLogger();
-
     private final DataStore<ClientOAuthSessionItem> dataStore;
-    private final ConfigService configService;
 
-    public ClientOAuthSessionDetailsService(
-            DataStore<ClientOAuthSessionItem> dataStore, ConfigService configService) {
+    public ClientOAuthSessionDetailsService(DataStore<ClientOAuthSessionItem> dataStore) {
         this.dataStore = dataStore;
-        this.configService = configService;
     }
 
     @ExcludeFromGeneratedCoverageReport
@@ -35,8 +24,7 @@ public class ClientOAuthSessionDetailsService {
                 DataStore.create(
                         CLIENT_OAUTH_SESSIONS_TABLE_NAME,
                         ClientOAuthSessionItem.class,
-                        configService),
-                configService);
+                        configService));
     }
 
     public ClientOAuthSessionItem getClientOAuthSession(String clientOAuthSessionId)
@@ -64,7 +52,7 @@ public class ClientOAuthSessionDetailsService {
         clientOAuthSessionItem.setUserId(claimsSet.getSubject());
         clientOAuthSessionItem.setGovukSigninJourneyId(
                 claimsSet.getStringClaim("govuk_signin_journey_id"));
-        clientOAuthSessionItem.setVtr(getEnabledVtr(claimsSet.getStringListClaim("vtr")));
+        clientOAuthSessionItem.setVtr(claimsSet.getStringListClaim("vtr"));
         clientOAuthSessionItem.setScope(claimsSet.getStringClaim("scope"));
         clientOAuthSessionItem.setReproveIdentity(claimsSet.getBooleanClaim("reprove_identity"));
         clientOAuthSessionItem.setEvcsAccessToken(evcsAccessToken);
@@ -98,15 +86,5 @@ public class ClientOAuthSessionDetailsService {
 
     public void updateClientSessionDetails(ClientOAuthSessionItem clientOAuthSessionItem) {
         dataStore.update(clientOAuthSessionItem);
-    }
-
-    private List<String> getEnabledVtr(List<String> vtr) {
-        if (!configService.enabled(CoreFeatureFlag.P1_JOURNEYS_ENABLED)
-                && vtr.contains(Vot.P1.name())) {
-            LOGGER.warn(
-                    LogHelper.buildLogMessage("Received P1 VTR, but P1 journeys are not enabled"));
-            return vtr.stream().filter(vot -> !Vot.P1.name().equals(vot)).toList();
-        }
-        return vtr;
     }
 }

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -364,7 +364,6 @@ core:
     repeatFraudCheckEnabled: true
     mfaResetEnabled: true
     parseVcClasses: true
-    p1JourneysEnabled: true
     sqsAsync: true
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: true
@@ -405,9 +404,6 @@ core:
     zeroHourFraudVcExpiry:
       self:
         fraudCheckExpiryPeriodHours: 0
-    p1Journeys:
-      featureFlags:
-        p1JourneysEnabled: true
     # Disabling CRIs
     f2fDisabled:
       credentialIssuers:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -365,7 +365,6 @@ core:
     repeatFraudCheckEnabled: true
     mfaResetEnabled: true
     parseVcClasses: true
-    p1JourneysEnabled: true
     sqsAsync: true
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: true
@@ -404,9 +403,6 @@ core:
     zeroHourFraudVcExpiry:
       self:
         fraudCheckExpiryPeriodHours: 0
-    p1Journeys:
-      featureFlags:
-        p1JourneysEnabled: true
     # Disabling CRIs
     f2fDisabled:
       credentialIssuers:


### PR DESCRIPTION

## Proposed changes
### What changed

- Clean up P1 journeys feature flag

### Why did it change

- For all intents and purposes Low Confidence is now live (even if we aren’t receiving any P1 requests from Orch yet) and our feature flag p1JourneysEnabled is switched on up to prod. Orch controls which RPs can make P1 requests so we no longer need this flag.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8649](https://govukverify.atlassian.net/browse/PYIC-8649)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8649]: https://govukverify.atlassian.net/browse/PYIC-8649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ