### PR TITLE
PYIC-7655 Tidy up CRI API request headers

### DIFF
--- a/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
+++ b/libs/cri-api-service/src/main/java/uk/gov/di/ipv/core/library/criapiservice/CriApiService.java
@@ -52,9 +52,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Objects;
 
-import static uk.gov.di.ipv.core.library.config.EnvironmentVariable.ENVIRONMENT;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
-import static uk.gov.di.ipv.core.library.domain.Cri.DWP_KBV;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_CRI_ID;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_RESPONSE_CONTENT_TYPE;
@@ -65,6 +63,7 @@ public class CriApiService {
     private static final String HEADER_CONTENT_TYPE = "Content-Type";
     private static final String HEADER_ACCEPT = "Accept";
     private static final String MIME_TYPE_APPLICATION_JSON = "application/json";
+    private static final String MIME_TYPE_APPLICATION_JWT = "application/jwt";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final ConfigService configService;
     private final SignerFactory signerFactory;
@@ -340,22 +339,14 @@ public class CriApiService {
         var apiKey = getApiKey(criConfig, criOAuthSessionItem);
 
         var request = new HTTPRequest(HTTPRequest.Method.POST, criConfig.getCredentialUrl());
+        request.setHeader(
+                HEADER_ACCEPT,
+                String.join(", ", MIME_TYPE_APPLICATION_JWT, MIME_TYPE_APPLICATION_JSON));
 
         if (requestBody != null) {
             var bodyString = OBJECT_MAPPER.writeValueAsString(requestBody);
             request.setBody(bodyString);
             request.setHeader(HEADER_CONTENT_TYPE, MIME_TYPE_APPLICATION_JSON);
-        } else {
-            // Temporary for DWP integration testing
-            if (configService.getEnvironmentVariable(ENVIRONMENT) != null
-                    && configService.getEnvironmentVariable(ENVIRONMENT).equals("staging")
-                    && cri.equals(DWP_KBV)) {
-                request.setHeader(HEADER_ACCEPT, "application/jwt");
-            } else {
-                request.setHeader(
-                        HEADER_CONTENT_TYPE,
-                        ""); // remove the default, no request body so we don't need a content type
-            }
         }
 
         if (apiKey != null) {


### PR DESCRIPTION
## Proposed changes
### What changed

Remove workarounds for Content-Type header and set correct Accept header for CRI API requests

### Why did it change

While testing the integration with DWP KBV CRI last year it was discovered that for the synchronous CRI credential request we were explicitly setting the `Content-Type` header with value empty string. This was seemingly introduced because NINO CRI rejected our requests with an "Unsupported media type" error because the nimbus lib set a Content-Type header `application/x-www-form-urlencoded` by default in its underlying HTTP request even with no request body. However, DWP KBV CRI was found to be rejecting the `Content-Type` header empty string, understandably because empty string is not a valid content type.

Ideally we wouldn't be sending a `Content-Type` at all in these requests (since we aren't providing a body) but there didn't seem to be a way to omit this header through nimbus. However, earlier in the year we switched the underlying HTTP client for these requests to our own tracing client, which means we can now do away with these header workarounds (Content-Type header won't be set at all now).

Also we should make sure we're setting the correct `Accept` header: `application/jwt, application/json` because we support both responses - JWT for a synchronous CRI response and JSON for asynchronous.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7655](https://govukverify.atlassian.net/browse/PYIC-7655)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-7655]: https://govukverify.atlassian.net/browse/PYIC-7655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ