### PR TITLE
PYIC-8298: Allow InitialiseIpvSession to decrypt with any KMS key

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1345,7 +1345,7 @@ Resources:
                 - 'kms:Decrypt'
                 - 'kms:GenerateDataKey'
               Resource:
-                - !ImportValue CoreEncryptionKeyArn
+                - !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*"
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:


### PR DESCRIPTION
## Proposed changes
### What changed

- Allow InitialiseIpvSession to decrypt with any KMS key

### Why did it change

- So we can rotate keys in future. At the moment we don't allow decryption with different keys, which means this would have to be updated exactly when we update the key, which we cannot do.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8298](https://govukverify.atlassian.net/browse/PYIC-8298)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8298]: https://govukverify.atlassian.net/browse/PYIC-8298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ