### PR TITLE
BAU improve api-tests readme to make TDD easier

### DIFF
--- a/api-tests/README.md
+++ b/api-tests/README.md
@@ -23,7 +23,7 @@ There are 3 presets that can be used:
 - `npm run test:dev` - runs against a dev environment
 - `npm run test:ci` - starts a new local instance of core-back and tests against it
 
-Additional arguments can be passed to cucumber, e.g. to include specific tests: `npm run test:local -- --name 'F2F'`
+To run a subset of the tests, add a tag before the feature(s)/scenario(s) you want to run (like in `p2-app-journey.feature`) and run them like this: `npm run test:local -- --tags @YourTag`
 
 If you are using custom configuration, then you can use `npm test` to invoke cucumber without any presets.
 


### PR DESCRIPTION
## Proposed changes
### What changed

One line of the api-test readme
- 

### Why did it change
The previous line wasn't helpful in facilitating use of the api-tests for TDD in working on routing.
- 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

- [x] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
