### PR TITLE
PYIC-8593: Reduce default time window to 10 days.

### DIFF
--- a/journey-map/server/config.ts
+++ b/journey-map/server/config.ts
@@ -4,7 +4,7 @@ const sharedDevSystemSettingsEndpoint =
   "https://analytics-api-dev.01.dev.identity.account.gov.uk/system-settings";
 
 export default {
-  maximumTimeRangeMs: process.env.MAXIMUM_TIME_RANGE_MS ?? 1209600000, // 14 days
+  maximumTimeRangeMs: process.env.MAXIMUM_TIME_RANGE_MS ?? 864000000, // 10 days
   environment: {
     production: {
       journeyTransitionsEndpoint:

--- a/journey-map/src/render.ts
+++ b/journey-map/src/render.ts
@@ -255,10 +255,10 @@ function alphaFromCount(count: number, maxCount: number) {
   if (maxCount === 0) return "00";
   const ratio = count / maxCount;
 
-  const exponent = 0.3;
+  const exponent = 0.8;
   const powerScaled = Math.pow(ratio, exponent);
 
-  const minAlpha = 0.1;
+  const minAlpha = 0.8;
   const scaled = minAlpha + (1 - minAlpha) * powerScaled;
 
   const alpha = Math.round(scaled * 255);


### PR DESCRIPTION
## Proposed changes
### What changed

- Reduced default time window for fetching transitions in journey map to 10 days
- Bumped minimum alpha for edges to 0.8.

### Why did it change

- Lambda sometimes explode within the 14 days range. 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8593](https://govukverify.atlassian.net/browse/PYIC-8593)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8593]: https://govukverify.atlassian.net/browse/PYIC-8593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ