### PR TITLE
PYIC-7696: Allow core-back to use new signing keys

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1499,7 +1499,7 @@ Resources:
               Action:
                 - 'kms:sign'
               Resource:
-                - !ImportValue SigningKeyArn
+                - !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*"
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:
@@ -1634,7 +1634,7 @@ Resources:
               Action:
                 - 'kms:sign'
               Resource:
-                - !ImportValue SigningKeyArn
+                - !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*"
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:
@@ -2758,7 +2758,7 @@ Resources:
               Action:
                 - 'kms:sign'
               Resource:
-                - !ImportValue SigningKeyArn
+                - !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*"
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:
@@ -3431,7 +3431,7 @@ Resources:
               Action:
                 - 'kms:sign'
               Resource:
-                - !ImportValue SigningKeyArn
+                - !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*"
             - Sid: kmsSisSigningKeyPermission
               Effect: Allow
               Action:


### PR DESCRIPTION
## Proposed changes
### What changed

- Allow core-back to use new signing keys

### Why did it change

- Coreback needs perms to use new/ >1 signing keys

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7696](https://govukverify.atlassian.net/browse/PYIC-7696)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-7696]: https://govukverify.atlassian.net/browse/PYIC-7696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ