### PR TITLE
BAU: Update PACT version to try to address dependency on vulnerable version of Netty

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ awsSdk = "2.34.6"
 jackson = "2.20.0"
 log4j = "2.25.0"
 mockito = "5.19.0"
-pact = "4.6.5"
+pact = "4.6.17"
 powertools = "1.20.0"
 
 [libraries]


### PR DESCRIPTION


## Proposed changes
### What changed

Update PACT library

### Why did it change

The current PACT library version depends on a vulnerable version of Netty

