### PR TITLE
PYIC-8648: Add additional context to the DAD & MAM download page

### DIFF
--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
@@ -180,7 +180,7 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I submit a 'smartphone' event
       Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
       When I submit an 'iphone' event
-      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -203,7 +203,7 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I submit a 'smartphone' event
       Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
       When I submit an 'iphone' event
-      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -437,7 +437,7 @@ Feature: M2B Strategic App Journeys
       Then I get a 'non-uk-no-app-options' page response
       # Change their mind and go back
       When I submit a 'useApp' event
-      Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone'
+      Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone-appOnly'
       # Decide to abandon again
       When I submit a 'preferNoApp' event
       Then I get a 'non-uk-no-app-options' page response

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -376,7 +376,7 @@ Feature: M2B Strategic App Journeys
       When I submit a 'smartphone' event
       Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
       When I submit an 'iphone' event
-      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -432,7 +432,7 @@ Feature: M2B Strategic App Journeys
       When I submit a 'computer-or-tablet' event
       Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
       When I submit a 'iphone' event
-      Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone'
+      Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone-appOnly'
       When I submit a 'preferNoApp' event
       Then I get a 'non-uk-no-app-options' page response
       # Change their mind and go back

--- a/api-tests/features/strategic-app/strategic-app-dl-auth-source-check-reuse-update-details.feature
+++ b/api-tests/features/strategic-app/strategic-app-dl-auth-source-check-reuse-update-details.feature
@@ -23,7 +23,7 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'smartphone' event
             Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
             When I submit an 'iphone' event
-            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces a '<details>' VC
             # And the user returns from the app to core-front
             And I pass on the DCMAW callback
@@ -64,7 +64,7 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'smartphone' event
             Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
             When I submit an 'iphone' event
-            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
             # And the user returns from the app to core-front
             And I pass on the DCMAW callback
@@ -102,7 +102,7 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'smartphone' event
             Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
             When I submit an 'iphone' event
-            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
             # And the user returns from the app to core-front
             And I pass on the DCMAW callback
@@ -155,7 +155,7 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'smartphone' event
             Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
             When I submit an 'iphone' event
-            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
             # And the user returns from the app to core-front
             And I pass on the DCMAW callback
@@ -175,7 +175,7 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'smartphone' event
             Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
             When I submit an 'iphone' event
-            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
             # And the user returns from the app to core-front
             And I pass on the DCMAW callback
@@ -197,7 +197,7 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'smartphone' event
             Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
             When I submit an 'iphone' event
-            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
             # And the user returns from the app to core-front
             And I pass on the DCMAW callback
@@ -230,7 +230,7 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'smartphone' event
             Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
             When I submit an 'iphone' event
-            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When I submit an 'anotherWay' event
             Then I get an 'update-details-failed' page response
             When I submit a 'continue' event
@@ -254,7 +254,7 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'smartphone' event
             Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
             When I submit an 'iphone' event
-            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
             # And the user returns from the app to core-front
             And I pass on the DCMAW callback
@@ -287,7 +287,7 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'smartphone' event
             Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
             When I submit an 'iphone' event
-            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces an 'access_denied' error response
             # This will probably need to change once the polling is working
             And I pass on the DCMAW callback

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -41,6 +41,7 @@ nestedJourneyStates:
         exitEventToEmit: next
       fail-with-ci:
         exitEventToEmit: fail-with-ci
+
   PRE_EXPERIAN_PAGE:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -108,6 +108,40 @@ nestedJourneyStates:
       anotherWay:
         exitEventToEmit: anotherWay
 
+  DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE:
+    response:
+      type: page
+      pageId: pyi-triage-desktop-download-app
+      context: iphone-appOnly
+    events:
+      next:
+        exitEventToEmit: next
+      abandon:
+        exitEventToEmit: anotherWay
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-no-ci:
+        exitEventToEmit: anotherWay
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      enhanced-verification:
+        exitEventToEmit: anotherWay
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+      dl-auth-source-check:
+        targetState: STRATEGIC_APP_HANDLE_RESULT
+        targetEntryEvent: dl-auth-source-check
+      preferNoApp:
+        targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkJourneyContext:
+          internationalAddress:
+            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+      anotherWay:
+        exitEventToEmit: anotherWay
+
   DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER:
     response:
       type: page
@@ -133,6 +167,38 @@ nestedJourneyStates:
       type: page
       pageId: pyi-triage-desktop-download-app
       context: android
+    events:
+      next:
+        exitEventToEmit: next
+      abandon:
+        exitEventToEmit: anotherWay
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-no-ci:
+        exitEventToEmit: anotherWay
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+      dl-auth-source-check:
+        targetState: STRATEGIC_APP_HANDLE_RESULT
+        targetEntryEvent: dl-auth-source-check
+      preferNoApp:
+        targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkJourneyContext:
+          internationalAddress:
+            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+      anotherWay:
+        exitEventToEmit: anotherWay
+
+  DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE:
+    response:
+      type: page
+      pageId: pyi-triage-desktop-download-app
+      context: android-appOnly
     events:
       next:
         exitEventToEmit: next
@@ -219,24 +285,28 @@ nestedJourneyStates:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
 
-  MOBILE_ANDROID_START_SESSION:
-    response:
-      type: process
-      lambda: call-dcmaw-async-cri
-      lambdaInput:
-        mobileAppJourneyType: mam
-    events:
-      next:
-        targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
-
   MOBILE_IPHONE_DOWNLOAD_PAGE:
     response:
       type: page
       pageId: pyi-triage-mobile-download-app
       context: iphone
+    events:
+      next:
+        targetState: STRATEGIC_APP_HANDLE_RESULT
+        targetEntryEvent: check-mobile-app-result
+      preferNoApp:
+        targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkJourneyContext:
+          internationalAddress:
+            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+      anotherWay:
+        exitEventToEmit: anotherWay
+
+  MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE:
+    response:
+      type: page
+      pageId: pyi-triage-mobile-download-app
+      context: iphone-appOnly
     events:
       next:
         targetState: STRATEGIC_APP_HANDLE_RESULT
@@ -259,11 +329,41 @@ nestedJourneyStates:
       back:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
 
+  MOBILE_ANDROID_START_SESSION:
+    response:
+      type: process
+      lambda: call-dcmaw-async-cri
+      lambdaInput:
+        mobileAppJourneyType: mam
+    events:
+      next:
+        targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
   MOBILE_ANDROID_DOWNLOAD_PAGE:
     response:
       type: page
       pageId: pyi-triage-mobile-download-app
       context: android
+    events:
+      next:
+        targetState: STRATEGIC_APP_HANDLE_RESULT
+        targetEntryEvent: check-mobile-app-result
+      preferNoApp:
+        targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkJourneyContext:
+          internationalAddress:
+            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+      anotherWay:
+        exitEventToEmit: anotherWay
+
+  MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE:
+    response:
+      type: page
+      pageId: pyi-triage-mobile-download-app
+      context: android-appOnly
     events:
       next:
         targetState: STRATEGIC_APP_HANDLE_RESULT

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -70,6 +70,9 @@ nestedJourneyStates:
     events:
       next:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE
+        checkJourneyContext:
+          appOnly:
+            targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -255,6 +258,9 @@ nestedJourneyStates:
     events:
       next:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE
+        checkJourneyContext:
+          appOnly:
+            targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -281,6 +287,9 @@ nestedJourneyStates:
     events:
       next:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
+        checkJourneyContext:
+          appOnly:
+            targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -338,6 +347,9 @@ nestedJourneyStates:
     events:
       next:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
+        checkJourneyContext:
+          appOnly:
+            targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -163,7 +163,7 @@ nestedJourneyStates:
       returnToRp:
         exitEventToEmit: returnToRp
       useApp:
-        targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE
+        targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
 
   DESKTOP_ANDROID_DOWNLOAD_PAGE:
     response:
@@ -247,7 +247,7 @@ nestedJourneyStates:
       returnToRp:
         exitEventToEmit: returnToRp
       useApp:
-        targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE
+        targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
 
   DAD_ANDROID_START_SESSION:
     response:
@@ -416,7 +416,7 @@ nestedJourneyStates:
       returnToRp:
         exitEventToEmit: returnToRp
       useApp:
-        targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
+        targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
 
   MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
     response:
@@ -426,7 +426,7 @@ nestedJourneyStates:
       returnToRp:
         exitEventToEmit: returnToRp
       useApp:
-        targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
+        targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
 
   STRATEGIC_APP_HANDLE_RESULT:
     nestedJourney: STRATEGIC_APP_HANDLE_RESULT

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -168,8 +168,10 @@ states:
     exitEvents:
       next:
         targetState: POST_APP_DOC_CHECK_SUCCESS_PAGE
+        journeyContextToUnset: appOnly
       anotherWay:
         targetState: MULTIPLE_DOC_CHECK_PAGE
+        journeyContextToUnset: appOnly
         checkMitigation:
           enhanced-verification:
             targetState: MITIGATION_01_PYI_POST_OFFICE
@@ -179,9 +181,11 @@ states:
                 targetState: INELIGIBLE
       incompleteDlAuthCheckInvalidDl:
         targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK
+        journeyContextToUnset: appOnly
       failedDlAuthCheckInvalidDl:
         targetState: WEB_DL_OR_PASSPORT
         targetEntryEvent: alternate-doc-invalid-dl-another-way
+        journeyContextToUnset: appOnly
         checkMitigation:
           enhanced-verification:
             targetJourney: FAILED
@@ -192,6 +196,7 @@ states:
           mitigationType: invalid-dl
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
+        journeyContextToUnset: appOnly
 
   STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK:
     response:
@@ -769,6 +774,7 @@ states:
       next:
         targetState: STRATEGIC_APP_TRIAGE_INTERNATIONAL_ADDRESS
         targetEntryEvent: appTriage
+        journeyContextToSet: appOnly
         auditEvents:
           - IPV_INTERNATIONAL_ADDRESS_START
       abandon:
@@ -840,6 +846,7 @@ states:
       next:
         targetState: STRATEGIC_APP_TRIAGE_INTERNATIONAL_ADDRESS
         targetEntryEvent: appTriage
+        journeyContextToSet: appOnly
       end:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -88,6 +88,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_NAMES_ONLY
             targetEntryEvent: appTriage
+            journeyContextToSet: appOnly
 
   APP_DOC_CHECK_NAMES_ONLY:
     nestedJourney: APP_DOC_CHECK
@@ -120,16 +121,20 @@ states:
     exitEvents:
       next:
         targetState: POST_APP_DOC_CHECK_NAMES_ONLY
+        journeyContextToUnset: appOnly
       anotherWay:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
+        journeyContextToUnset: appOnly
       incompleteDlAuthCheckInvalidDl:
         targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_ONLY
       failedDlAuthCheckInvalidDl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+        journeyContextToUnset: appOnly
       returnToRp:
         targetState: RETURN_TO_RP
+        journeyContextToUnset: appOnly
 
   STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_ONLY:
     response:
@@ -140,6 +145,7 @@ states:
       anotherTypePhotoId:
         targetState: STRATEGIC_APP_TRIAGE_NAMES_ONLY
         targetEntryEvent: appTriage
+        journeyContextToSet: appOnly
       returnToRp:
         targetState: RETURN_TO_RP
 
@@ -229,6 +235,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_NAMES_WITH_ADDRESS
             targetEntryEvent: appTriage
+            journeyContextToSet: appOnly
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -238,16 +245,21 @@ states:
     exitEvents:
       next:
         targetState: POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS
+        journeyContextToUnset: appOnly
       anotherWay:
         targetJourney: FAILED
         targetState: FAILED_UPDATE_DETAILS
+        journeyContextToUnset: appOnly
       incompleteDlAuthCheckInvalidDl:
         targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_WITH_ADDRESS
       failedDlAuthCheckInvalidDl:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+        journeyContextToUnset: appOnly
       returnToRp:
         targetState: RETURN_TO_RP
+        journeyContextToUnset: appOnly
+
 
   STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_WITH_ADDRESS:
     response:
@@ -258,6 +270,7 @@ states:
       anotherTypePhotoId:
         targetState: STRATEGIC_APP_TRIAGE_NAMES_WITH_ADDRESS
         targetEntryEvent: appTriage
+        journeyContextToSet: appOnly
       returnToRp:
         targetState: RETURN_TO_RP
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -260,7 +260,6 @@ states:
         targetState: RETURN_TO_RP
         journeyContextToUnset: appOnly
 
-
   STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_WITH_ADDRESS:
     response:
       type: page


### PR DESCRIPTION
## Proposed changes
### What changed

- Placeholder steps
- Currently, the app download flow includes content suggesting that users can "prove their identity another way" if they choose not to use the app.
- For regular ID proving journeys, this is correct – users may be able to continue via an alternative path.
- For app-only routes (e.g. COI, 6MFC, international addresses), this content is misleading because no alternative route exists.

- The `iphone` and `android` contexts determine which QR code to display. A quick win for adding another context is to append the new context to the existing one and search for keywords instead of matching the context exactly.

### Why did it change

- This creates user frustration and failure, as some users leave the journey assuming an alternative path exists, only to find they cannot complete their task.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8648](https://govukverify.atlassian.net/browse/PYIC-8648)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8648]: https://govukverify.atlassian.net/browse/PYIC-8648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ