### PR TITLE
PYIC-8702: use api key when making a request to SIS

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/ConfigurationVariable.java
@@ -5,6 +5,7 @@ public enum ConfigurationVariable {
     CREDENTIAL_ISSUER_CLIENT_OAUTH_SECRET("credentialIssuers/%s/connections/%s/oAuthClientSecret"),
     CREDENTIAL_ISSUER_API_KEY("credentialIssuers/%s/connections/%s/apiKey"),
     EVCS_API_KEY("evcs/apiKey"),
+    SIS_API_KEY("sis/apiKey"),
     JAR_ENCRYPTION_KEY_JWK("self/jarEncryptionKey"),
     SIGNING_KEY_JWK("self/signingKey");
 

--- a/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/client/SisClient.java
+++ b/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/client/SisClient.java
@@ -34,10 +34,12 @@ import java.util.Optional;
 
 import static org.apache.hc.core5.http.HttpHeaders.AUTHORIZATION;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
+import static uk.gov.di.ipv.core.library.config.ConfigurationVariable.SIS_API_KEY;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_RESPONSE_MESSAGE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_STATUS_CODE;
 
 public class SisClient {
+    public static final String X_API_KEY_HEADER = "x-api-key";
     private static final String USER_IDENTITY_SUB_PATH = "user-identity";
     private static final Logger LOGGER = LogManager.getLogger();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -76,7 +78,8 @@ public class SisClient {
                                     HttpRequest.BodyPublishers.ofString(
                                             OBJECT_MAPPER.writeValueAsString(requestBody)))
                             .header(AUTHORIZATION, "Bearer " + accessToken)
-                            .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
+                            .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString())
+                            .header(X_API_KEY_HEADER, configService.getSecret(SIS_API_KEY));
 
             var httpResponse = sendHttpRequest(httpRequestBuilder.build());
 

--- a/libs/sis-service/src/test/java/uk/gov/di/ipv/core/library/sis/client/SisClientTest.java
+++ b/libs/sis-service/src/test/java/uk/gov/di/ipv/core/library/sis/client/SisClientTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.http.HttpStatusCode;
+import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.retry.Sleeper;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -41,6 +42,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class SisClientTest {
     private static final String SIS_APPLICATION_URL = "http://localhost/v1";
+    private static final String SIS_API_KEY = "some-api-key"; // pragma: allowlist secret
     private static final String TEST_JOURNEY_ID = "TEST_JOURNEY_ID";
     private static final List<Vot> TEST_VOTS = List.of(Vot.P1, Vot.P2);
     public static final String TEST_ACCESS_TOKEN = "dummy_access_token";
@@ -50,7 +52,6 @@ class SisClientTest {
     @Mock private HttpResponse<String> mockHttpResponse;
     @Mock private Sleeper mockSleeper;
     @Captor ArgumentCaptor<HttpRequest> httpRequestCaptor;
-    @Captor private ArgumentCaptor<String> stringCaptor;
     @InjectMocks private SisClient sisClient;
     @Mock private URI badUri;
 
@@ -76,6 +77,8 @@ class SisClientTest {
     @Test
     void getStoredIdentity_retriesRequest_ifSisReturnsErrorCode() throws Exception {
         // Arrange
+        when(mockConfigService.getSecret(ConfigurationVariable.SIS_API_KEY))
+                .thenReturn(SIS_API_KEY);
         when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
 
         when(mockHttpResponse.body())
@@ -99,6 +102,8 @@ class SisClientTest {
     @Test
     void getStoredIdentity_returnsEmptyResult_ifRetryRequestLimitExceeded() throws Exception {
         // Arrange
+        when(mockConfigService.getSecret(ConfigurationVariable.SIS_API_KEY))
+                .thenReturn(SIS_API_KEY);
         when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.body()).thenReturn("{\"message\":\"throttled\"}");
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.THROTTLING);
@@ -121,6 +126,8 @@ class SisClientTest {
     @Test
     void getStoredIdentity_sendsCorrectRequest() throws Exception {
         // Arrange
+        when(mockConfigService.getSecret(ConfigurationVariable.SIS_API_KEY))
+                .thenReturn(SIS_API_KEY);
         when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.NOT_FOUND);
 
@@ -152,6 +159,8 @@ class SisClientTest {
     void getStoredIdentity_shouldParseResponseCorrectly(
             String responseJson, SisGetStoredIdentityResult expectedResult) throws Exception {
         // Arrange
+        when(mockConfigService.getSecret(ConfigurationVariable.SIS_API_KEY))
+                .thenReturn(SIS_API_KEY);
         when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.OK);
         when(mockHttpResponse.body()).thenReturn(responseJson);
@@ -188,6 +197,8 @@ class SisClientTest {
     @Test
     void getStoredIdentity_returnsFailure_whenJsonIsInvalid() throws Exception {
         // Arrange
+        when(mockConfigService.getSecret(ConfigurationVariable.SIS_API_KEY))
+                .thenReturn(SIS_API_KEY);
         when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.OK);
         when(mockHttpResponse.body()).thenReturn("not valid json");
@@ -202,6 +213,8 @@ class SisClientTest {
     @Test
     void getStoredIdentity_returnsFailure_whenHttpErrorReceived() throws Exception {
         // Arrange
+        when(mockConfigService.getSecret(ConfigurationVariable.SIS_API_KEY))
+                .thenReturn(SIS_API_KEY);
         when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.INTERNAL_SERVER_ERROR);
 
@@ -215,6 +228,8 @@ class SisClientTest {
     @Test
     void getStoredIdentity_returnsNotFound_when404Received() throws Exception {
         // Arrange
+        when(mockConfigService.getSecret(ConfigurationVariable.SIS_API_KEY))
+                .thenReturn(SIS_API_KEY);
         when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.NOT_FOUND);
 

--- a/local-running/core.local.secrets.template.yaml
+++ b/local-running/core.local.secrets.template.yaml
@@ -31,6 +31,8 @@ core:
     }'
   evcs:
     apiKey: "EVCS_API_KEY" # pragma: allowlist secret
+  sis:
+    apiKey: "SIS_API_KEY" # pragma: allowlist secret
   cimitApi:
     apiKey: "CIMIT_API_KEY" # pragma: allowlist secret
   credentialIssuers:


### PR DESCRIPTION
## Proposed changes
### What changed

- sending api key to SIS
- update local-running secrets template to include new SIS api key

### Why did it change

- Real SIS needs an api key so we need to send an api key and update our stub to match

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8702](https://govukverify.atlassian.net/browse/PYIC-8702)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8702]: https://govukverify.atlassian.net/browse/PYIC-8702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ