### PR TITLE
BAU: remove unused event from DESKTOP_IPHONE_DOWNLOAD_PAGE

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -92,8 +92,6 @@ nestedJourneyStates:
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
-      enhanced-verification:
-        exitEventToEmit: anotherWay
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED


### PR DESCRIPTION
## Proposed changes
### What changed

Remove unused `enhanced-verification` event from DESKTOP_IPHONE_DOWNLOAD_PAGE state.

### Why did it change

It was already removed from DESKTOP_ANDROID_DOWNLOAD_PAGE as part of this https://govukverify.atlassian.net/browse/PYIC-7983 but the iphone version was missed.

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
