### PR TITLE
BAU: add pactConsumerTests gradle task to lib:sis-service

### DIFF
--- a/libs/sis-service/build.gradle
+++ b/libs/sis-service/build.gradle
@@ -61,6 +61,12 @@ test {
 	jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
 }
 
+task pactConsumerTests (type: Test) {
+	useJUnitPlatform()
+	include 'uk/gov/di/ipv/core/library/sis/pact/**'
+	systemProperties['pact.rootDir'] = "$rootDir/build/pacts"
+}
+
 jacocoTestReport {
 	dependsOn test
 	reports {


### PR DESCRIPTION
## Proposed changes
### What changed

- adds pactConsumerTests gradle task to lib:sis-service

### Why did it change

- The SIS consumer tests weren't being uploaded to the pact broker because the tests weren't being ran when GA runs gradle pactConsumerTests
