### PR TITLE
Pyic 8682 name normalisation

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/NameHelper.java
@@ -30,7 +30,7 @@ public class NameHelper {
         return names.stream()
                 .filter(
                         name -> {
-                            var normalisedName = normaliseNameForComparison(NameHelper.getFullName(name));
+                            var normalisedName = getNormalisedFullNameForComparison(name);
 
                             if (!normalisedNames.contains(normalisedName)) {
                                 normalisedNames.add(normalisedName);
@@ -41,7 +41,7 @@ public class NameHelper {
                 .collect(Collectors.toSet());
     }
 
-    public static String getFullName(Name name) {
+    public static String getNormalisedFullNameForComparison(Name name) {
         var nameParts = name.getNameParts();
 
         String givenNames =
@@ -50,7 +50,8 @@ public class NameHelper {
                                 namePart ->
                                         NamePart.NamePartType.GIVEN_NAME.equals(namePart.getType()))
                         .map(NamePart::getValue)
-                        .collect(Collectors.joining(" "));
+                        .collect(Collectors.joining(" "))
+                        .trim();
 
         String familyNames =
                 nameParts.stream()
@@ -59,9 +60,12 @@ public class NameHelper {
                                         NamePart.NamePartType.FAMILY_NAME.equals(
                                                 namePart.getType()))
                         .map(NamePart::getValue)
-                        .collect(Collectors.joining(" "));
+                        .collect(Collectors.joining(" "))
+                        .trim();
 
-        return (givenNames + " " + familyNames).trim();
+        return (normaliseNameForComparison(givenNames)
+                + " "
+                + normaliseNameForComparison(familyNames));
     }
 
     public static String normaliseNameForComparison(String name) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -112,8 +112,8 @@ public abstract class ConfigService {
         return getConfiguration().getSelf().getBackendSessionTtl();
     }
 
-    public String getDcmawAsyncVcPendingReturnTtl() {
-        return getConfiguration().getSelf().getDcmawAsyncVcPendingReturnTtl().toString();
+    public long getDcmawAsyncVcPendingReturnTtl() {
+        return getConfiguration().getSelf().getDcmawAsyncVcPendingReturnTtl();
     }
 
     public long getCriResponseTtl() {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/NameHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/NameHelperTest.java
@@ -24,17 +24,17 @@ class NameHelperTest {
     }
 
     @Test
-    void shouldDeduplicateAcrossGivenAndFamilyNames() {
+    void shouldNotDeduplicateAcrossGivenAndFamilyNames() {
         // Arrange
-        var name1 = createName(new String[] { "Martin", "John" }, new String[] { "Smith" });
-        var name2 = createName(new String[] { "Martin" }, new String[] { "John", "Smith" });
+        var name1 = createName(new String[] {"Martin", "John"}, new String[] {"Smith"});
+        var name2 = createName(new String[] {"Martin"}, new String[] {"John", "Smith"});
         var names = Set.of(name1, name2);
 
         // Act
         var deduplicateNames = NameHelper.deduplicateNames(names);
 
         // Assert
-        assertEquals(1, deduplicateNames.size());
+        assertEquals(2, deduplicateNames.size());
     }
 
     @Test

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/NameHelperTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/NameHelperTest.java
@@ -5,24 +5,100 @@ import org.junit.jupiter.api.Test;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.helpers.vocab.NameGenerator.createName;
 
 class NameHelperTest {
     @Test
-    void shouldDeduplicateNamesWithCaseInsensitivity() {
+    void shouldNotDeduplicateDifferentNames() {
         // Arrange
         var name1 = createName("martin", "smith");
-        var name2 = createName("Martin", "smith");
-        var name3 = createName("MARTIN", "smith");
-        var name4 = createName("Harry", "smith");
+        var name2 = createName("martin", "jones");
+        var name3 = createName("john", "smith");
+        var names = Set.of(name1, name2, name3);
+
+        // Act
+        var deduplicateNames = NameHelper.deduplicateNames(names);
+
+        // Assert
+        assertEquals(3, deduplicateNames.size());
+    }
+
+    @Test
+    void shouldDeduplicateAcrossGivenAndFamilyNames() {
+        // Arrange
+        var name1 = createName(new String[] { "Martin", "John" }, new String[] { "Smith" });
+        var name2 = createName(new String[] { "Martin" }, new String[] { "John", "Smith" });
+        var names = Set.of(name1, name2);
+
+        // Act
+        var deduplicateNames = NameHelper.deduplicateNames(names);
+
+        // Assert
+        assertEquals(1, deduplicateNames.size());
+    }
+
+    @Test
+    void shouldDeduplicateNamesWithDifferentCases() {
+        // Arrange
+        var name1 = createName("martin", "smith");
+        var name2 = createName("MARTIN", "smith");
+        var name3 = createName("martin", "SMITH");
+        var name4 = createName("MARTIN", "SMITH");
         var names = Set.of(name1, name2, name3, name4);
 
         // Act
         var deduplicateNames = NameHelper.deduplicateNames(names);
 
         // Assert
-        assertEquals(2, deduplicateNames.size());
-        assertTrue(deduplicateNames.contains(name4));
+        assertEquals(1, deduplicateNames.size());
+    }
+
+    @Test
+    void shouldDeduplicateNamesWithApostrophes() {
+        // Arrange
+        var name1 = createName("Martin", "O'Toole");
+        var name2 = createName("Martin", "O’Toole");
+        var name3 = createName("Martin", "OToole");
+        var name4 = createName("M'artin", "OToole");
+        var name5 = createName("M’artin", "OToole");
+        var names = Set.of(name1, name2, name3, name4, name5);
+
+        // Act
+        var deduplicateNames = NameHelper.deduplicateNames(names);
+
+        // Assert
+        assertEquals(1, deduplicateNames.size());
+    }
+
+    @Test
+    void shouldDeduplicateNamesWithAccents() {
+        // Arrange
+        var name1 = createName("José", "Mourinho");
+        var name2 = createName("Jose", "Mourinho");
+        var name3 = createName("Jose", "Mourinhó");
+        var names = Set.of(name1, name2, name3);
+
+        // Act
+        var deduplicateNames = NameHelper.deduplicateNames(names);
+
+        // Assert
+        assertEquals(1, deduplicateNames.size());
+    }
+
+    @Test
+    void shouldDeduplicateHyphenatedNames() {
+        // Arrange
+        var name1 = createName("Anne-Marie", "Alicia-Lopez");
+        var name2 = createName("Anne-Marie", "Alicia Lopez");
+        var name3 = createName("Anne-Marie", new String[] {"Alicia", "Lopez"});
+        var name4 = createName("Anne Marie", "Alicia-Lopez");
+        var name5 = createName(new String[] {"Anne", "Marie"}, "Alicia-Lopez");
+        var names = Set.of(name1, name2, name3, name4, name5);
+
+        // Act
+        var deduplicateNames = NameHelper.deduplicateNames(names);
+
+        // Assert
+        assertEquals(1, deduplicateNames.size());
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/vocab/NameGenerator.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/vocab/NameGenerator.java
@@ -3,7 +3,9 @@ package uk.gov.di.ipv.core.library.helpers.vocab;
 import uk.gov.di.model.Name;
 import uk.gov.di.model.NamePart;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class NameGenerator {
     private NameGenerator() {}
@@ -13,12 +15,33 @@ public class NameGenerator {
     }
 
     public static Name createName(String givenName, String familyName) {
-        return createName(
-                List.of(
-                        NamePartGenerator.createNamePart(
-                                givenName, NamePart.NamePartType.GIVEN_NAME),
-                        NamePartGenerator.createNamePart(
-                                familyName, NamePart.NamePartType.FAMILY_NAME)));
+        return createName(new String[] {givenName}, new String[] {familyName});
+    }
+
+    public static Name createName(String[] givenNames, String[] familyNames) {
+        var givenNameParts =
+                Arrays.stream(givenNames)
+                        .map(
+                                gn ->
+                                        NamePartGenerator.createNamePart(
+                                                gn, NamePart.NamePartType.GIVEN_NAME));
+        var familyNameParts =
+                Arrays.stream(familyNames)
+                        .map(
+                                fn ->
+                                        NamePartGenerator.createNamePart(
+                                                fn, NamePart.NamePartType.FAMILY_NAME));
+        var allNameParts = Stream.concat(givenNameParts, familyNameParts).toList();
+
+        return createName(allNameParts);
+    }
+
+    public static Name createName(String givenName, String[] familyNames) {
+        return createName(new String[] {givenName}, familyNames);
+    }
+
+    public static Name createName(String[] givenNames, String familyName) {
+        return createName(givenNames, new String[] {familyName});
     }
 
     public static class NamePartGenerator {

--- a/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseService.java
+++ b/libs/cri-response-service/src/main/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseService.java
@@ -117,7 +117,7 @@ public class CriResponseService {
                 var now = DateUtils.toSecondsSinceEpoch(new Date());
                 var expiry =
                         DateUtils.toSecondsSinceEpoch(issuedAt)
-                                + Integer.parseInt(configService.getDcmawAsyncVcPendingReturnTtl());
+                                + configService.getDcmawAsyncVcPendingReturnTtl();
                 if (now < expiry) {
                     var criResponse = getCriResponseItem(userId, DCMAW_ASYNC);
                     return new AsyncCriStatus(

--- a/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseServiceTest.java
+++ b/libs/cri-response-service/src/test/java/uk/gov/di/ipv/core/library/criresponse/service/CriResponseServiceTest.java
@@ -221,7 +221,7 @@ class CriResponseServiceTest {
 
     @Test
     void getDcmawAsyncResponseStatusShouldGetCorrectStatusForExistingDcmawAsyncVc() {
-        when(mockConfigService.getDcmawAsyncVcPendingReturnTtl()).thenReturn("1000000000");
+        when(mockConfigService.getDcmawAsyncVcPendingReturnTtl()).thenReturn(1000000000L);
         when(criResponseService.getCriResponseItem(USER_ID_1, DCMAW_ASYNC))
                 .thenReturn(new CriResponseItem());
         var vcs = List.of(vcDcmawAsyncDrivingPermitDva(), vcAddressTwo());
@@ -236,7 +236,7 @@ class CriResponseServiceTest {
     @Test
     void getAsyncResponseStatusShouldReturnEmptyWhenDcmawAsyncVcExpired() {
         // Arrange
-        when(mockConfigService.getDcmawAsyncVcPendingReturnTtl()).thenReturn("-1");
+        when(mockConfigService.getDcmawAsyncVcPendingReturnTtl()).thenReturn(-1L);
 
         // Act
         var asyncCriStatus =

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -345,13 +345,7 @@ public class UserIdentityService {
             List<IdentityClaim> identityClaims) {
         return getShortenedNamesForCoiCheck(
                 identityClaims,
-                Integer.parseInt(
-                        configService
-                                .getConfiguration()
-                                .getSelf()
-                                .getCoi()
-                                .getFamilyNameChars()
-                                .toString()),
+                configService.getConfiguration().getSelf().getCoi().getFamilyNameChars(),
                 NamePart.NamePartType.FAMILY_NAME);
     }
 
@@ -359,13 +353,7 @@ public class UserIdentityService {
             List<IdentityClaim> identityClaims) {
         return getShortenedNamesForCoiCheck(
                 identityClaims,
-                Integer.parseInt(
-                        configService
-                                .getConfiguration()
-                                .getSelf()
-                                .getCoi()
-                                .getGivenNameChars()
-                                .toString()),
+                configService.getConfiguration().getSelf().getCoi().getGivenNameChars(),
                 NamePart.NamePartType.GIVEN_NAME);
     }
 

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -269,7 +269,8 @@ public class UserIdentityService {
     private boolean checkNameAndFamilyNameCorrelationInCredentials(List<VerifiableCredential> vcs)
             throws HttpResponseExceptionWithErrorBody {
         List<IdentityClaim> identityClaims = getIdentityClaimsForNameCorrelation(vcs);
-        return checkNamesForCorrelation(getFullNamesFromCredentials(identityClaims));
+        var normalisedNames = getNormalisedFullNamesFromCredentials(identityClaims);
+        return normalisedNames.stream().distinct().count() <= 1;
     }
 
     private boolean checkBirthDateCorrelationInCredentials(List<VerifiableCredential> vcs)
@@ -285,10 +286,7 @@ public class UserIdentityService {
     }
 
     public boolean checkNamesForCorrelation(List<String> userFullNames) {
-        return userFullNames.stream()
-                        .map(NameHelper::normaliseNameForComparison)
-                        .distinct()
-                        .count()
+        return userFullNames.stream().map(NameHelper::normaliseNameForComparison).distinct().count()
                 <= 1;
     }
 
@@ -329,10 +327,10 @@ public class UserIdentityService {
         return identityClaims;
     }
 
-    private List<String> getFullNamesFromCredentials(List<IdentityClaim> identityClaims) {
+    private List<String> getNormalisedFullNamesFromCredentials(List<IdentityClaim> identityClaims) {
         return identityClaims.stream()
                 .flatMap(claim -> claim.getName().stream())
-                .map(NameHelper::getFullName)
+                .map(NameHelper::getNormalisedFullNameForComparison)
                 .toList();
     }
 

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
@@ -259,6 +259,26 @@ class UserIdentityServiceTest {
     }
 
     @Test
+    void areVCsCorrelatedReturnFalseWhenNamesConcatenateToTheSameString() throws Exception {
+        // Arrange
+        var vcs =
+                List.of(
+                        generateVerifiableCredential(
+                                USER_ID_1,
+                                PASSPORT,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01")),
+                        generateVerifiableCredential(
+                                USER_ID_1,
+                                PASSPORT,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimb", "oJones", "1000-01-01")));
+
+        // Act & Assert
+        assertFalse(userIdentityService.areVcsCorrelated(vcs));
+    }
+
+    @Test
     void areVCsCorrelatedReturnFalseWhenNameDifferentForBavCRI() throws Exception {
         // Arrange
         var vcs =


### PR DESCRIPTION
TEST IN DEV before merging

## Proposed changes
### What changed

Name normalisation for comparisons when generating shared claims improved to match the normalisation used when checking for VC correlation.
Also full name correlation tweaked so that "Bob Ifford" no longer matches "Bo Bifford"

### Why did it change

Names weren't de-duplicating that should, so we were sending multiple names to fraud when we should have only sent one.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8682](https://govukverify.atlassian.net/browse/PYIC-8682)



[PYIC-8682]: https://govukverify.atlassian.net/browse/PYIC-8682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ