### PR TITLE
PYIC-8650: Remove use of MFA reset feature flag

### DIFF
--- a/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/UserIdentityRequestHandler.java
+++ b/lambdas/build-user-identity/src/main/java/uk/gov/di/ipv/core/builduseridentity/UserIdentityRequestHandler.java
@@ -28,8 +28,6 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredential
 
 import java.time.Instant;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
-
 public abstract class UserIdentityRequestHandler {
     private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
     protected static final Logger LOGGER = LogManager.getLogger();
@@ -109,7 +107,7 @@ public abstract class UserIdentityRequestHandler {
                 clientOAuthSessionItem.getGovukSigninJourneyId());
 
         var scopeClaims = clientOAuthSessionItem.getScopeClaims();
-        if (configService.enabled(MFA_RESET) && !scopeClaims.contains(this.allowedScope)) {
+        if (!scopeClaims.contains(this.allowedScope)) {
             throw new InvalidScopeException();
         }
         return clientOAuthSessionItem;

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -83,7 +83,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.ADDRESS_JSON_1;
@@ -214,7 +213,6 @@ class BuildUserIdentityHandlerTest {
         var testCis = List.of(mitigatedCi);
 
         when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(addressVc));
 
@@ -279,7 +277,6 @@ class BuildUserIdentityHandlerTest {
         var testCis = List.of(mitigatedCi);
 
         when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(addressVc));
 
@@ -345,7 +342,6 @@ class BuildUserIdentityHandlerTest {
         var testCis = List.of(mitigatedCi);
 
         when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
                 .thenReturn(List.of(addressVc));
         doThrow(
@@ -491,7 +487,6 @@ class BuildUserIdentityHandlerTest {
         when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any()))
                 .thenReturn(CONTRA_INDICATORS);
         when(mockConfigService.isCredentialIssuerEnabled(Cri.TICF.getId())).thenReturn(true);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         // Act
         APIGatewayProxyResponseEvent response =
                 buildUserIdentityHandler.handleRequest(testEvent, mockContext);
@@ -554,7 +549,6 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any()))
                 .thenReturn(contraIndicators);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         // Act
         APIGatewayProxyResponseEvent response =
                 buildUserIdentityHandler.handleRequest(testEvent, mockContext);
@@ -712,7 +706,6 @@ class BuildUserIdentityHandlerTest {
                 .thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItemWithScope);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(true);
 
         // Act
         APIGatewayProxyResponseEvent response =
@@ -731,39 +724,6 @@ class BuildUserIdentityHandlerTest {
         verify(mockUserIdentityService, never())
                 .generateUserIdentity(any(), any(), any(), any(), any());
         verify(mockSessionCredentialsService, never()).deleteSessionCredentials(any());
-    }
-
-    @Test
-    void shouldNotReturnErrorResponseWhenScopeIsInvalidAndFeatureDisabled() throws Exception {
-
-        // Arrange
-        ClientOAuthSessionItem clientOAuthSessionItemWithScope =
-                getClientAuthSessionItemWithScope("a-different-scope");
-        // Arrange
-        when(mockIpvSessionService.getIpvSessionByAccessToken(TEST_ACCESS_TOKEN))
-                .thenReturn(ipvSessionItem);
-        when(mockUserIdentityService.generateUserIdentity(any(), any(), any(), any(), any()))
-                .thenReturn(userIdentity);
-        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItemWithScope);
-
-        var mitigatedCi = new ContraIndicator();
-        mitigatedCi.setCode("test_code");
-        mitigatedCi.setMitigation(List.of(new Mitigation()));
-        var testCis = List.of(mitigatedCi);
-
-        when(mockCimitUtilityService.getContraIndicatorsFromVc(any(), any())).thenReturn(testCis);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
-
-        when(mockSessionCredentialsService.getCredentials(TEST_IPV_SESSION_ID, TEST_USER_ID))
-                .thenReturn(List.of(vcAddressOne()));
-
-        // Act
-        APIGatewayProxyResponseEvent response =
-                buildUserIdentityHandler.handleRequest(testEvent, mockContext);
-
-        // Assert
-        assertEquals(200, response.getStatusCode());
     }
 
     @Test

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.ipv.core.initialiseipvsession.validation.JarValidator.CLAIMS_CLAIM;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.REVERIFICATION;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.SCOPE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_LAMBDA_RESULT;
@@ -145,9 +144,7 @@ public class InitialiseIpvSessionHandler
             List<String> vtr = claimsSet.getStringListClaim(REQUEST_VTR_KEY);
 
             var isReverification =
-                    configService.enabled(MFA_RESET)
-                            && Scope.parse(claimsSet.getStringClaim(SCOPE))
-                                    .contains(REVERIFICATION);
+                    Scope.parse(claimsSet.getStringClaim(SCOPE)).contains(REVERIFICATION);
             if (!isReverification && isListEmpty(vtr)) {
                 LOGGER.error(LogHelper.buildLogMessage(ErrorResponse.MISSING_VTR.getMessage()));
                 return ApiGatewayResponseGenerator.proxyJsonResponse(

--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Set;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_FORBIDDEN;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.OPENID;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.REVERIFICATION;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.SCOPE;
@@ -233,11 +232,8 @@ public class JarValidator {
                                 JWTClaimNames.EXPIRATION_TIME,
                                 JWTClaimNames.NOT_BEFORE,
                                 JWTClaimNames.ISSUED_AT,
-                                JWTClaimNames.SUBJECT));
-
-        if (configService.enabled(MFA_RESET)) {
-            requiredClaims.add(SCOPE);
-        }
+                                JWTClaimNames.SUBJECT,
+                                SCOPE));
 
         var verifier =
                 new DefaultJWTClaimsVerifier<>(
@@ -254,9 +250,7 @@ public class JarValidator {
             verifier.verify(claimsSet, null);
 
             validateMaxAllowedJarTtl(claimsSet);
-            if (configService.enabled(MFA_RESET)) {
-                validateScope(clientId, claimsSet);
-            }
+            validateScope(clientId, claimsSet);
 
             return claimsSet;
         } catch (BadJWTException | ParseException e) {

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -166,38 +166,6 @@ class InitialiseIpvSessionHandlerTest {
     }
 
     @Test
-    void shouldReturnIpvSessionIdWhenProvidedValidRequest()
-            throws JsonProcessingException, JarValidationException, ParseException {
-        // Arrange
-        when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
-                .thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(
-                        any(), any(), any(), any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockJarValidator.validateRequestJwt(any(), any()))
-                .thenReturn(signedJWT.getJWTClaimsSet());
-
-        // Act
-        APIGatewayProxyResponseEvent response =
-                initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
-
-        // Assert
-        Map<String, Object> responseBody =
-                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
-
-        assertEquals(HttpStatusCode.OK, response.getStatusCode());
-        assertEquals(ipvSessionItem.getIpvSessionId(), responseBody.get("ipvSessionId"));
-
-        ArgumentCaptor<AuditEvent> auditEventCaptor = ArgumentCaptor.forClass(AuditEvent.class);
-        verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
-        assertEquals(AuditEventTypes.IPV_JOURNEY_START, auditEventCaptor.getValue().getEventName());
-
-        verify(mockClientOAuthSessionDetailsService)
-                .generateClientSessionDetails(any(), any(), any(), stringArgumentCaptor.capture());
-        assertEquals(TEST_EVCS_ACCESS_TOKEN, stringArgumentCaptor.getValue());
-    }
-
-    @Test
     void shouldReturnIpvSessionIdGivenValidReverificationRequest() throws Exception {
         // Arrange
         signedJWT = getSignedJWT(getValidClaimsBuilder("reverification"));

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -38,7 +38,6 @@ import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidatio
 import uk.gov.di.ipv.core.initialiseipvsession.validation.JarValidator;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
-import uk.gov.di.ipv.core.library.config.FeatureFlag;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.fixtures.TestFixtures;

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -80,7 +80,6 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.REVERIFICATION;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.ADDRESS_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.CORE_IDENTITY_JWT_CLAIM_NAME;
@@ -214,7 +213,6 @@ class InitialiseIpvSessionHandlerTest {
                                 signedEncryptedJwt.serialize())));
         validEvent.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
 
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(Boolean.TRUE);
         when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
                 .thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(
@@ -251,7 +249,6 @@ class InitialiseIpvSessionHandlerTest {
             throws JsonProcessingException, JarValidationException, ParseException {
         // Arrange
         clientOAuthSessionItem.setReproveIdentity(true);
-        when(mockConfigService.enabled(any(FeatureFlag.class))).thenReturn(false);
         when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
                 .thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.generateClientSessionDetails(
@@ -286,7 +283,6 @@ class InitialiseIpvSessionHandlerTest {
         // Arrange
         when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
                 .thenReturn(ipvSessionItem);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         var evcsAccessTokenClaims = Map.of(USER_INFO, Map.of());
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(getValidClaimsBuilder().claim(CLAIMS, evcsAccessTokenClaims).build());
@@ -329,7 +325,6 @@ class InitialiseIpvSessionHandlerTest {
                 .thenReturn(clientOAuthSessionItem);
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
 
         // Act
         APIGatewayProxyResponseEvent response =
@@ -360,7 +355,6 @@ class InitialiseIpvSessionHandlerTest {
         // Arrange
         when(mockIpvSessionService.generateIpvSession(any(), any(), any(), anyBoolean()))
                 .thenReturn(ipvSessionItem);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(false);
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(getValidClaimsBuilder().claim(CLAIMS, evcsAccessTokenClaims).build());
 
@@ -422,7 +416,6 @@ class InitialiseIpvSessionHandlerTest {
                     ParseException,
                     JarValidationException {
         // Arrange
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(true);
         var missingVtrClaimsBuilder = getValidClaimsBuilder();
         missingVtrClaimsBuilder.claim(VTR, vtrList);
         var missingVtrSignedJwt = getSignedJWT(missingVtrClaimsBuilder);
@@ -460,7 +453,6 @@ class InitialiseIpvSessionHandlerTest {
         when(mockJarValidator.validateRequestJwt(any(), any()))
                 .thenReturn(signedJWT.getJWTClaimsSet());
 
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(true);
         var missingVtrClaimsBuilder = getValidClaimsBuilder();
         missingVtrClaimsBuilder.claim(VTR, vtrList);
         missingVtrClaimsBuilder.claim(SCOPE, REVERIFICATION);

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
@@ -14,12 +14,9 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -124,8 +121,7 @@ class JarValidatorTest {
     }
 
     @Test
-    void validateRequestJwtShouldPassValidationChecksOnValidJARRequest()
-            throws Exception {
+    void validateRequestJwtShouldPassValidationChecksOnValidJARRequest() throws Exception {
         stubClientIssuer();
         stubComponentId();
         when(mockOAuthKeyService.getClientSigningKey(eq(CLIENT_ID_CLAIM), any()))

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
@@ -55,7 +55,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 import static uk.gov.di.ipv.core.library.domain.ScopeConstants.SCOPE;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PUBLIC_JWK_2;
@@ -124,9 +123,8 @@ class JarValidatorTest {
                 OAuth2Error.INVALID_REQUEST_OBJECT.getCode(), thrown.getErrorObject().getCode());
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void validateRequestJwtShouldPassValidationChecksOnValidJARRequest(boolean mfaResetEnabled)
+    @Test
+    void validateRequestJwtShouldPassValidationChecksOnValidJARRequest()
             throws Exception {
         stubClientIssuer();
         stubComponentId();
@@ -135,10 +133,7 @@ class JarValidatorTest {
         when(configService.getMaxAllowedAuthClientTtl()).thenReturn(TWENTY_FIVE_MINUTES_IN_SECONDS);
         when(configService.getClientValidRedirectUrls(CLIENT_ID_CLAIM))
                 .thenReturn(Collections.singletonList(REDIRECT_URI_CLAIM));
-        when(configService.enabled(MFA_RESET)).thenReturn(mfaResetEnabled);
-        if (mfaResetEnabled) {
-            when(configService.getValidScopes(CLIENT_ID_CLAIM)).thenReturn("openid");
-        }
+        when(configService.getValidScopes(CLIENT_ID_CLAIM)).thenReturn("openid");
 
         SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
 
@@ -164,11 +159,6 @@ class JarValidatorTest {
 
     @Nested
     class ScopeTests {
-        @BeforeEach
-        public void setUp() {
-            when(configService.enabled(MFA_RESET)).thenReturn(true);
-        }
-
         @Test
         void validateRequestJwtShouldThrowRecoverableExceptionIfScopeClaimMissing()
                 throws Exception {

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -9,15 +9,11 @@ states:
   START:
     events:
       next:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
-        checkFeatureFlag:
-          mfaResetEnabled:
-            targetState: CHECK_REVERIFICATION_IDENTITY
-            checkIfDisabled:
-              dcmaw:
-                targetJourney: TECHNICAL_ERROR
-                targetState: ERROR
+        targetState: CHECK_REVERIFICATION_IDENTITY
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
 
   # Parent states
   CRI_STATE:

--- a/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandlerTest.java
+++ b/lambdas/user-reverification/src/test/java/uk/gov/di/ipv/core/userreverification/UserReverificationHandlerTest.java
@@ -54,7 +54,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.MFA_RESET;
 
 @ExtendWith(MockitoExtension.class)
 class UserReverificationHandlerTest {
@@ -325,7 +324,6 @@ class UserReverificationHandlerTest {
                 .thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
                 .thenReturn(clientOAuthSessionItemWithScope);
-        when(mockConfigService.enabled(MFA_RESET)).thenReturn(true);
 
         // Act
         APIGatewayProxyResponseEvent response =

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -4,7 +4,6 @@ public enum CoreFeatureFlag implements FeatureFlag {
     UNUSED_PLACEHOLDER("unusedPlaceHolder"),
     RESET_IDENTITY("resetIdentity"),
     REPEAT_FRAUD_CHECK("repeatFraudCheckEnabled"),
-    MFA_RESET("mfaResetEnabled"),
     SQS_ASYNC("sqsAsync"),
     DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
     STORED_IDENTITY_SERVICE("storedIdentityServiceEnabled"),

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -362,7 +362,6 @@ core:
     pendingF2FResetEnabled: false
     strategicAppEnabled: true
     repeatFraudCheckEnabled: true
-    mfaResetEnabled: true
     parseVcClasses: true
     sqsAsync: true
     kidJarHeaderEnabled: true
@@ -386,9 +385,6 @@ core:
     sisVerification:
       featureFlags:
         sisVerificationEnabled: true
-    mfaReset:
-      featureFlags:
-        mfaResetEnabled: true
     clearUsersIdentity:
       featureFlags:
         resetIdentity: true

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -365,7 +365,6 @@ core:
     pendingF2FResetEnabled: false
     strategicAppEnabled: true
     repeatFraudCheckEnabled: true
-    mfaResetEnabled: true
     parseVcClasses: true
     sqsAsync: true
     kidJarHeaderEnabled: true
@@ -380,9 +379,6 @@ core:
     sisVerification:
       featureFlags:
         sisVerificationEnabled: true
-    mfaReset:
-      featureFlags:
-        mfaResetEnabled: true
     clearUsersIdentity:
       featureFlags:
         resetIdentity: true


### PR DESCRIPTION
## Proposed changes
### What changed

Remove use of MFA reset feature flag

### Why did it change

It's been set to enabled in all environments for a while

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8650](https://govukverify.atlassian.net/browse/PYIC-8650)


[PYIC-8650]: https://govukverify.atlassian.net/browse/PYIC-8650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ