### PR TITLE
PYIC-8706: Routing for Experian KBV CRI error

### DIFF
--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -1,0 +1,225 @@
+@Build
+Feature: Handling unexpected CRI errors
+  Background: Go through web route
+    Given I activate the 'disableStrategicApp' feature set
+    When  I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'page-multiple-doc-check' page response
+
+  Rule: Driving Licence and Passport CRIs
+    Scenario Outline: Unexpected error from <cri> - try CRI again
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'tryAgain' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+      Examples:
+        | cri            | details                      |
+        | ukPassport     | kenneth-passport-valid       |
+        | drivingLicence | kenneth-driving-permit-valid |
+
+    Scenario Outline: Unexpected error from <cri> - try app route
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I override the existing feature sets and activate the 'strategicApp' feature set
+      And I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit an 'app' event
+      Then I get a 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+      Examples:
+        | cri            |
+        | ukPassport     |
+        | drivingLicence |
+
+    Scenario Outline: Unexpected error from <cri> - try post office route
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I override the existing feature sets and activate the 'strategicApp' feature set
+      And I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit an 'postOffice' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit '<details>' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+      Examples:
+        | cri            | details                      |
+        | ukPassport     | kenneth-passport-valid       |
+        | drivingLicence | kenneth-driving-permit-valid |
+
+    Scenario Outline: Unexpected error from <cri> - return to RP
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit an 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+
+      Examples:
+        | cri            |
+        | ukPassport     |
+        | drivingLicence |
+
+  Rule: Experian KBV
+    Background: Route to sorry-technical-problem Experian KBV CRI error page
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'sorry-technical-problem' page response
+
+    Scenario: Unexpected error from Experian KBV CRI - try CRI again
+      When I submit a 'tryAgain' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Unexpected error from Experian KBV CRI - try app route
+      When I override the existing feature sets and activate the 'strategicApp' feature set
+      And I submit a 'app' event
+      Then I get a 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Unexpected error from Experian KBV CRI - try post office route
+      When I submit a 'postOffice' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Unexpected error from Experian KBV CRI - return to RP
+      When I submit an 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -347,11 +347,13 @@ Feature: Handling unexpected CRI errors
       Then I get a 'pyi-post-office' page response
       When I submit a 'next' event
       Then I get a 'claimedIdentity' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
+        # Using a different name in the scenarios to check that the reset_session call after
+        # the 'sorry-technical-problem' page happens
+      When I submit 'lora' details to the CRI stub
       Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
+      When I submit 'lora-current' details to the CRI stub
       Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      When I submit 'lora-score-2' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -1,17 +1,17 @@
 @Build
 Feature: Handling unexpected CRI errors
-  Background: Go through web route
-    Given I activate the 'disableStrategicApp' feature set
-    When  I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I call the CRI stub and get an 'access_denied' OAuth error
-    Then I get a 'page-multiple-doc-check' page response
-
   Rule: Driving Licence and Passport CRIs
+    Background: Go through web route
+      Given I activate the 'disableStrategicApp' feature set
+      When  I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'page-multiple-doc-check' page response
+
     Scenario Outline: Unexpected error from <cri> - try CRI again
       When I submit a '<cri>' event
       Then I get a '<cri>' CRI response
@@ -133,6 +133,15 @@ Feature: Handling unexpected CRI errors
 
   Rule: Experian KBV
     Background: Route to sorry-technical-problem Experian KBV CRI error page
+      Given I activate the 'disableStrategicApp' feature set
+      When  I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'page-multiple-doc-check' page response
       When I submit a 'ukPassport' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -223,3 +232,187 @@ Feature: Handling unexpected CRI errors
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity
+
+  Rule: F2F CRI - P2
+    Background: Route to sorry-technical-problem F2F CRI error page
+      Given I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'sorry-technical-problem' page response with context 'f2fCriError'
+
+    Scenario: Unexpected error from F2F CRI - try CRI again
+      When I submit a 'tryAgain' event
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Unexpected error from F2F CRI - try app route
+      When I override the existing feature sets and activate the 'strategicApp' feature set
+      And I submit a 'app' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Unexpected error from F2F CRI - try web route
+      When I submit a 'webRoute' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Unexpected error from F2F CRI - return to RP
+      When I submit an 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+
+  Rule: F2F CRI - P1
+    Background: Route to sorry-technical-problem F2F CRI error page
+      Given I activate the 'p1Journeys,disableStrategicApp' feature set
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'page-multiple-doc-check' page response with context 'nino'
+      When I submit an 'end' event
+      Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+      Then I get a 'sorry-technical-problem' page response with context 'f2fCriError'
+
+    Scenario: Unexpected error from F2F CRI - try app route
+      When I override the existing feature sets and activate the 'strategicApp' feature set
+      And I submit a 'app' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P1' identity
+
+    Scenario: Unexpected error from F2F CRI - try web route
+      When I submit a 'webRoute' event
+      Then I get a 'page-multiple-doc-check' page response with context 'nino'
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P1' identity

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -157,7 +157,7 @@ Feature: Handling unexpected CRI errors
       When I call the CRI stub with attributes and get a 'server_error' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'sorry-technical-problem' page response
+      Then I get a 'sorry-technical-problem' page response with context 'kbvCriError'
 
     Scenario: Unexpected error from Experian KBV CRI - try CRI again
       When I submit a 'tryAgain' event
@@ -206,14 +206,6 @@ Feature: Handling unexpected CRI errors
 
     Scenario: Unexpected error from Experian KBV CRI - try post office route
       When I submit a 'postOffice' event
-      Then I get a 'claimedIdentity' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
         | Attribute          | Values                                      |

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -4,10 +4,16 @@ description: >-
 
 states:
   # Entry points
-  START:
+  START_MEDIUM_CONFIDENCE:
     events:
       next:
         targetState: PROCESS_PENDING_IDENTITY
+        journeyContextToSet: mediumConfidence
+  START_LOW_CONFIDENCE:
+    events:
+      next:
+        targetState: PROCESS_PENDING_IDENTITY
+        journeyContextToSet: lowConfidence
 
   # Parent states
   CRI_STATE:
@@ -93,11 +99,41 @@ states:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
       error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
+        targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_F2F
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
+
+  SORRY_CRI_TECHNICAL_PROBLEM_CRI_F2F:
+    response:
+      type: page
+      pageId: sorry-technical-problem
+      context: f2fCriError
+    events:
+      tryAgain:
+        targetState: CRI_F2F
+      app:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+        checkJourneyContext:
+          mediumConfidence:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: IDENTITY_DOCUMENT_START
+          lowConfidence:
+            targetJourney: NEW_P1_IDENTITY
+            targetState: IDENTITY_DOCUMENT_START
+      webRoute:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+        checkJourneyContext:
+          mediumConfidence:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: DCMAW_ASYNC_ANOTHER_WAY
+          lowConfidence:
+            targetJourney: NEW_P1_IDENTITY
+            targetState: DCMAW_ASYNC_ANOTHER_WAY
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   RESET_SESSION_BEFORE_F2F_HANDOFF:
     response:
@@ -115,3 +151,8 @@ states:
     response:
       type: page
       pageId: page-face-to-face-handoff
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -117,14 +117,52 @@ states:
         targetState: ERROR_NO_TICF
         checkJourneyContext:
           mediumConfidence:
+            targetState: RESET_SESSION_BEFORE_IDENTITY_DOCUMENT_START
+          lowConfidence:
+            targetState: RESET_SESSION_BEFORE_IDENTITY_DOCUMENT_START
+      webRoute:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+        checkJourneyContext:
+          mediumConfidence:
+            targetState: RESET_SESSION_BEFORE_DCMAW_ASYNC_ANOTHER_WAY
+          lowConfidence:
+            targetState: RESET_SESSION_BEFORE_DCMAW_ASYNC_ANOTHER_WAY
+      returnToRp:
+        targetState: RETURN_TO_RP
+
+  RESET_SESSION_BEFORE_IDENTITY_DOCUMENT_START:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        checkJourneyContext:
+          mediumConfidence:
             targetJourney: NEW_P2_IDENTITY
             targetState: IDENTITY_DOCUMENT_START
           lowConfidence:
             targetJourney: NEW_P1_IDENTITY
             targetState: IDENTITY_DOCUMENT_START
-      webRoute:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
+      error:
+        checkJourneyContext:
+          mediumConfidence:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: IDENTITY_DOCUMENT_START
+          lowConfidence:
+            targetJourney: NEW_P1_IDENTITY
+            targetState: IDENTITY_DOCUMENT_START
+
+  RESET_SESSION_BEFORE_DCMAW_ASYNC_ANOTHER_WAY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
         checkJourneyContext:
           mediumConfidence:
             targetJourney: NEW_P2_IDENTITY
@@ -132,8 +170,14 @@ states:
           lowConfidence:
             targetJourney: NEW_P1_IDENTITY
             targetState: DCMAW_ASYNC_ANOTHER_WAY
-      returnToRp:
-        targetState: RETURN_TO_RP
+      error:
+        checkJourneyContext:
+          mediumConfidence:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: DCMAW_ASYNC_ANOTHER_WAY
+          lowConfidence:
+            targetJourney: NEW_P1_IDENTITY
+            targetState: DCMAW_ASYNC_ANOTHER_WAY
 
   RESET_SESSION_BEFORE_F2F_HANDOFF:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -41,6 +41,21 @@ nestedJourneyStates:
         exitEventToEmit: next
       fail-with-ci:
         exitEventToEmit: fail-with-ci
+      error:
+        targetState: SORRY_CRI_TECHNICAL_PROBLEM_EXPERIAN_KBV_CRI
+  SORRY_CRI_TECHNICAL_PROBLEM_EXPERIAN_KBV_CRI:
+    response:
+      type: page
+      pageId: sorry-technical-problem
+    events:
+      tryAgain:
+        targetState: PRE_EXPERIAN_PAGE
+      app:
+        exitEventToEmit: try-again-app
+      postOffice:
+        exitEventToEmit: try-again-post-office
+      returnToRp:
+        exitEventToEmit: return-to-rp
   PRE_EXPERIAN_PAGE:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -47,6 +47,7 @@ nestedJourneyStates:
     response:
       type: page
       pageId: sorry-technical-problem
+      context: kbvCriError
     events:
       tryAgain:
         targetState: PRE_EXPERIAN_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
@@ -38,6 +38,21 @@ nestedJourneyStates:
               - IPV_MITIGATION_START
             auditContext:
               mitigationType: invalid-passport
+      error:
+        targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_UK_PASSPORT
+  SORRY_CRI_TECHNICAL_PROBLEM_CRI_UK_PASSPORT:
+    response:
+      type: page
+      pageId: sorry-technical-problem
+    events:
+      tryAgain:
+        targetState: CRI_UK_PASSPORT
+      app:
+        exitEventToEmit: try-again-app
+      postOffice:
+        exitEventToEmit: try-again-post-office
+      returnToRp:
+        exitEventToEmit: return-to-rp-cri-error
   ADDRESS_AND_FRAUD_AFTER_PASSPORT:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:
@@ -81,6 +96,21 @@ nestedJourneyStates:
               - IPV_MITIGATION_START
             auditContext:
               mitigationType: invalid-dl
+      error:
+        targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_DRIVING_LICENCE
+  SORRY_CRI_TECHNICAL_PROBLEM_CRI_DRIVING_LICENCE:
+    response:
+      type: page
+      pageId: sorry-technical-problem
+    events:
+      tryAgain:
+        targetState: CRI_DRIVING_LICENCE
+      app:
+        exitEventToEmit: try-again-app
+      postOffice:
+        exitEventToEmit: try-again-post-office
+      returnToRp:
+        exitEventToEmit: return-to-rp-cri-error
   ADDRESS_AND_FRAUD_AFTER_DL:
     nestedJourney: ADDRESS_AND_FRAUD
     exitEvents:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -47,6 +47,11 @@ states:
       next:
         targetState: POST_APP_DOC_CHECK_SUCCESS_PAGE
 
+  IDENTITY_DOCUMENT_START:
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
   # Parent states
 
   CRI_STATE:
@@ -340,7 +345,7 @@ states:
             targetState: ERROR
       f2f:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_LOW_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR
@@ -427,7 +432,7 @@ states:
     exitEvents:
       next:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_LOW_CONFIDENCE
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
@@ -510,7 +515,7 @@ states:
     events:
       f2f:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_LOW_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR
@@ -564,7 +569,7 @@ states:
     events:
       f2f:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_LOW_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR
@@ -695,7 +700,7 @@ states:
             targetState: ERROR
       f2f:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_LOW_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR
@@ -708,7 +713,7 @@ states:
     events:
       next:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_LOW_CONFIDENCE
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -299,6 +299,17 @@ states:
       return-to-rp:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
+      try-again-app:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+      try-again-post-office:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      return-to-rp-cri-error:
+        targetState: RETURN_TO_RP
 
   PYI_ESCAPE:
     response:
@@ -369,6 +380,17 @@ states:
               - IPV_MITIGATION_START
             auditContext:
               mitigationType: enhanced-verification
+      try-again-app:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+      try-again-post-office:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      return-to-rp:
+        targetState: RETURN_TO_RP
 
   # DCMAW journey (J1)
   POST_APP_DOC_CHECK_SUCCESS_PAGE:
@@ -469,6 +491,17 @@ states:
               - IPV_MITIGATION_START
             auditContext:
               mitigationType: enhanced-verification
+      try-again-app:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+      try-again-post-office:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      return-to-rp:
+        targetState: RETURN_TO_RP
 
   MITIGATION_KBV_FAIL_NO_PHOTO_ID:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -393,7 +393,12 @@ states:
             targetState: STRATEGIC_APP_TRIAGE
             targetEntryEvent: appTriage
       try-again-post-office:
-        targetState: CRI_CLAIMED_IDENTITY_J4
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
@@ -504,7 +509,12 @@ states:
             targetState: STRATEGIC_APP_TRIAGE
             targetEntryEvent: appTriage
       try-again-post-office:
-        targetState: CRI_CLAIMED_IDENTITY_J4
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -85,6 +85,23 @@ states:
         targetState: ERROR
 
   # Journey states
+  RESET_SESSION_BEFORE_WEBAPP_RETRY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+      error:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
 
   RESET_SESSION_IDENTITY:
     response:
@@ -386,12 +403,7 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
         targetJourney: F2F_HAND_OFF
         targetState: START_MEDIUM_CONFIDENCE
@@ -502,12 +514,7 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
         targetJourney: F2F_HAND_OFF
         targetState: START_MEDIUM_CONFIDENCE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -314,7 +314,7 @@ states:
       try-again-post-office:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp-cri-error:
-        targetState: RETURN_TO_RP
+        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   PYI_ESCAPE:
     response:
@@ -395,7 +395,7 @@ states:
       try-again-post-office:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp:
-        targetState: RETURN_TO_RP
+        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   # DCMAW journey (J1)
   POST_APP_DOC_CHECK_SUCCESS_PAGE:
@@ -506,7 +506,7 @@ states:
       try-again-post-office:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp:
-        targetState: RETURN_TO_RP
+        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   MITIGATION_KBV_FAIL_NO_PHOTO_ID:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -397,7 +397,7 @@ states:
       try-again-post-office:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp:
-        targetState: RETURN_TO_RP
+        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   # DCMAW journey (J1)
   POST_APP_DOC_CHECK_SUCCESS_PAGE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -47,6 +47,11 @@ states:
       next:
         targetState: POST_APP_DOC_CHECK_INTERNATIONAL_SUCCESS_PAGE
 
+  IDENTITY_DOCUMENT_START:
+    events:
+      next:
+        targetState: IDENTITY_START_PAGE
+
   # Parent states
 
   CRI_STATE:
@@ -342,7 +347,7 @@ states:
             targetState: ERROR
       f2f:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_MEDIUM_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR
@@ -429,7 +434,7 @@ states:
     exitEvents:
       next:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_MEDIUM_CONFIDENCE
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
@@ -526,7 +531,7 @@ states:
     events:
       f2f:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_MEDIUM_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR
@@ -593,7 +598,7 @@ states:
     events:
       f2f:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_MEDIUM_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR
@@ -745,7 +750,7 @@ states:
             targetState: ERROR
       f2f:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_MEDIUM_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR
@@ -758,7 +763,7 @@ states:
     events:
       next:
         targetJourney: F2F_HAND_OFF
-        targetState: START
+        targetState: START_MEDIUM_CONFIDENCE
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -395,7 +395,12 @@ states:
             targetState: STRATEGIC_APP_TRIAGE
             targetEntryEvent: appTriage
       try-again-post-office:
-        targetState: CRI_CLAIMED_IDENTITY_J4
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
@@ -520,7 +525,12 @@ states:
             targetState: STRATEGIC_APP_TRIAGE
             targetEntryEvent: appTriage
       try-again-post-office:
-        targetState: CRI_CLAIMED_IDENTITY_J4
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -85,6 +85,23 @@ states:
         targetState: ERROR
 
   # Journey states
+  RESET_SESSION_BEFORE_WEBAPP_RETRY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+      error:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
 
   RESET_SESSION_IDENTITY:
     response:
@@ -388,12 +405,7 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
         targetJourney: F2F_HAND_OFF
         targetState: START_MEDIUM_CONFIDENCE
@@ -518,12 +530,7 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
         targetJourney: F2F_HAND_OFF
         targetState: START_MEDIUM_CONFIDENCE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -286,6 +286,17 @@ states:
       return-to-rp:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
+      try-again-app:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+      try-again-post-office:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      return-to-rp-cri-error:
+        targetState: RETURN_TO_RP
 
   CHECK_FRAUD_AFTER_DL:
     response:
@@ -371,6 +382,17 @@ states:
               - IPV_MITIGATION_START
             auditContext:
               mitigationType: enhanced-verification
+      try-again-app:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+      try-again-post-office:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      return-to-rp:
+        targetState: RETURN_TO_RP
 
   # DCMAW journey (J1)
   POST_APP_DOC_CHECK_SUCCESS_PAGE:
@@ -485,6 +507,17 @@ states:
               - IPV_MITIGATION_START
             auditContext:
               mitigationType: enhanced-verification
+      try-again-app:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+      try-again-post-office:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      return-to-rp:
+        targetState: RETURN_TO_RP
 
   MITIGATION_KBV_FAIL_NO_PHOTO_ID:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -301,7 +301,7 @@ states:
       try-again-post-office:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp-cri-error:
-        targetState: RETURN_TO_RP
+        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   CHECK_FRAUD_AFTER_DL:
     response:
@@ -522,7 +522,7 @@ states:
       try-again-post-office:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp:
-        targetState: RETURN_TO_RP
+        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   MITIGATION_KBV_FAIL_NO_PHOTO_ID:
     response:


### PR DESCRIPTION
## Proposed changes

### What changed

-  On failure from Experian KBVs just skip straight to F2F (since we already have a name from a document and Address + Fraud VCs)

### Why did it change

- We already have a name from a document and Address + Fraud VCs

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8706](https://govukverify.atlassian.net/browse/PYIC-8706)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8706]: https://govukverify.atlassian.net/browse/PYIC-8706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ