### PR TITLE
PYIC-8724: Update Manual F2F Pending Reset Lambda to throw errors on failure

### DIFF
--- a/lambdas/manual-f2f-pending-reset/src/main/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandler.java
+++ b/lambdas/manual-f2f-pending-reset/src/main/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandler.java
@@ -12,6 +12,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.criresponse.service.CriResponseService;
 import uk.gov.di.ipv.core.library.domain.Cri;
+import uk.gov.di.ipv.core.library.exceptions.ManualF2fPendingResetException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -26,7 +27,6 @@ public class ManualF2fPendingResetHandler implements RequestHandler<String, Map<
 
     private static final String RESULT_KEY = "result";
     private static final String MESSAGE_KEY = "message";
-    private static final String RESULT_ERROR = "error";
     private static final String RESULT_SUCCESS = "success";
 
     private final CriResponseService criResponseService;
@@ -58,24 +58,11 @@ public class ManualF2fPendingResetHandler implements RequestHandler<String, Map<
 
         Map<String, Object> response = new HashMap<>();
 
-        if (input == null || input.isBlank()) {
-            LOGGER.error(LogHelper.buildLogMessage("No userId provided in input"));
-            response.put(RESULT_KEY, RESULT_ERROR);
-            response.put(MESSAGE_KEY, "Missing or empty userId in input");
-            return response;
-        }
-
         try {
-            CriResponseItem item = criResponseService.getCriResponseItem(input, Cri.F2F);
+            validateInput(input);
+            findPendingRecord(input);
+            deletePendingRecord(input);
 
-            if (item == null) {
-                LOGGER.error(LogHelper.buildLogMessage("No F2F pending record found"));
-                response.put(RESULT_KEY, RESULT_ERROR);
-                response.put(MESSAGE_KEY, "No F2F pending record found.");
-                return response;
-            }
-
-            criResponseService.deleteCriResponseItem(input, Cri.F2F);
             LOGGER.info(LogHelper.buildLogMessage("Successfully deleted F2F pending record"));
             response.put(RESULT_KEY, RESULT_SUCCESS);
             response.put(MESSAGE_KEY, "Deleted F2F pending record.");
@@ -85,14 +72,46 @@ public class ManualF2fPendingResetHandler implements RequestHandler<String, Map<
                             AuditEventTypes.IPV_F2F_SUPPORT_CANCEL,
                             configService.getComponentId(),
                             new AuditEventUser(input, null, null, null)));
+
+        } catch (ManualF2fPendingResetException e) {
+            LOGGER.error(LogHelper.buildErrorMessage("Manual F2F pending reset failed", e));
+            throw e;
         } catch (Exception e) {
-            LOGGER.error(LogHelper.buildErrorMessage("Failed to delete record", e));
-            response.put(RESULT_KEY, RESULT_ERROR);
-            response.put(MESSAGE_KEY, "Failed to delete record due to internal error.");
+            LOGGER.error(LogHelper.buildErrorMessage("Unexpected error occurred", e));
+            throw new ManualF2fPendingResetException(
+                    "Unexpected failure in Manual F2F Pending Reset Lambda", e);
         } finally {
             auditService.awaitAuditEvents();
         }
 
         return response;
+    }
+
+    private void validateInput(String input) {
+        if (input == null || input.isBlank()) {
+            throw new ManualF2fPendingResetException("Missing or empty userId in input");
+        }
+    }
+
+    private CriResponseItem findPendingRecord(String userId) {
+        try {
+            CriResponseItem item = criResponseService.getCriResponseItem(userId, Cri.F2F);
+            if (item == null) {
+                throw new ManualF2fPendingResetException("No F2F pending record found.");
+            }
+            return item;
+        } catch (ManualF2fPendingResetException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ManualF2fPendingResetException("Failed to look up F2F record", e);
+        }
+    }
+
+    private void deletePendingRecord(String userId) {
+        try {
+            criResponseService.deleteCriResponseItem(userId, Cri.F2F);
+        } catch (Exception e) {
+            throw new ManualF2fPendingResetException("Failed to delete F2F pending record", e);
+        }
     }
 }

--- a/lambdas/manual-f2f-pending-reset/src/main/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandler.java
+++ b/lambdas/manual-f2f-pending-reset/src/main/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandler.java
@@ -14,7 +14,6 @@ import uk.gov.di.ipv.core.library.criresponse.service.CriResponseService;
 import uk.gov.di.ipv.core.library.domain.Cri;
 import uk.gov.di.ipv.core.library.exceptions.ManualF2fPendingResetException;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
-import uk.gov.di.ipv.core.library.persistence.item.CriResponseItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
@@ -93,13 +92,11 @@ public class ManualF2fPendingResetHandler implements RequestHandler<String, Map<
         }
     }
 
-    private CriResponseItem findPendingRecord(String userId) {
+    private void findPendingRecord(String userId) {
         try {
-            CriResponseItem item = criResponseService.getCriResponseItem(userId, Cri.F2F);
-            if (item == null) {
+            if (criResponseService.getCriResponseItem(userId, Cri.F2F) == null) {
                 throw new ManualF2fPendingResetException("No F2F pending record found.");
             }
-            return item;
         } catch (ManualF2fPendingResetException e) {
             throw e;
         } catch (Exception e) {

--- a/lambdas/manual-f2f-pending-reset/src/main/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandler.java
+++ b/lambdas/manual-f2f-pending-reset/src/main/java/uk/gov/di/ipv/core/manualf2fpendingreset/ManualF2fPendingResetHandler.java
@@ -59,7 +59,7 @@ public class ManualF2fPendingResetHandler implements RequestHandler<String, Map<
 
         try {
             validateInput(input);
-            findPendingRecord(input);
+            checkIfPendingRecordExists(input);
             deletePendingRecord(input);
 
             LOGGER.info(LogHelper.buildLogMessage("Successfully deleted F2F pending record"));
@@ -92,23 +92,14 @@ public class ManualF2fPendingResetHandler implements RequestHandler<String, Map<
         }
     }
 
-    private void findPendingRecord(String userId) {
-        try {
-            if (criResponseService.getCriResponseItem(userId, Cri.F2F) == null) {
-                throw new ManualF2fPendingResetException("No F2F pending record found.");
-            }
-        } catch (ManualF2fPendingResetException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new ManualF2fPendingResetException("Failed to look up F2F record", e);
+    private void checkIfPendingRecordExists(String userId) {
+        var response = criResponseService.getCriResponseItem(userId, Cri.F2F);
+        if (response == null) {
+            throw new ManualF2fPendingResetException("No F2F pending record found.");
         }
     }
 
     private void deletePendingRecord(String userId) {
-        try {
-            criResponseService.deleteCriResponseItem(userId, Cri.F2F);
-        } catch (Exception e) {
-            throw new ManualF2fPendingResetException("Failed to delete F2F pending record", e);
-        }
+        criResponseService.deleteCriResponseItem(userId, Cri.F2F);
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/ManualF2fPendingResetException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/ManualF2fPendingResetException.java
@@ -1,5 +1,8 @@
 package uk.gov.di.ipv.core.library.exceptions;
 
+import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
 public class ManualF2fPendingResetException extends RuntimeException {
     public ManualF2fPendingResetException(String message) {
         super(message);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/ManualF2fPendingResetException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/ManualF2fPendingResetException.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+public class ManualF2fPendingResetException extends RuntimeException {
+    public ManualF2fPendingResetException(String message) {
+        super(message);
+    }
+
+    public ManualF2fPendingResetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## Proposed changes
### What changed

- updates the manual-f2f-pending-reset Lambda so that execution failures are surfaced as red (failed) in the AWS Lambda console. 
- Now, when a failure occurs (e.g., missing user ID, no F2F record found, or an internal exception), the handler throws a RuntimeException, ensuring the Lambda execution result correctly reflects a failure.

<img width="600" height="500" alt="Screenshot 2025-10-15 at 13 22 46" src="https://github.com/user-attachments/assets/df46d778-8f66-439a-afd1-ecf85e925c16" />
<img width="600" height="500" alt="Screenshot 2025-10-15 at 13 23 00" src="https://github.com/user-attachments/assets/d4341b92-8565-4bed-9754-5808080ec4a7" />

### Why did it change

- Previously, even when an operation failed, the Lambda reported a “Succeeded” status because errors were returned in the response map instead of being thrown.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8724](https://govukverify.atlassian.net/browse/PYIC-8724)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8724]: https://govukverify.atlassian.net/browse/PYIC-8724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ