### PR TITLE
PYIC-8679: update CRI error request with new shape

### DIFF
--- a/api-tests/src/types/cri-stub.ts
+++ b/api-tests/src/types/cri-stub.ts
@@ -18,18 +18,17 @@ export interface CriStubRequest {
   requestedError?: CriStubRequestedError;
 }
 
-type CriStubRequestedError =
-  | CriStubOauthErrorRequest
-  | CriStubUserInfoEndpointErrorRequest;
+type CriStubRequestedError = CriStubOauthErrorRequest | CriStubApiErrorRequest;
 
 interface CriStubOauthErrorRequest {
   error: string;
   description: string;
-  endpoint: "auth" | "token";
+  endpoint: "auth";
 }
 
-interface CriStubUserInfoEndpointErrorRequest {
-  userInfoError: "404";
+interface CriStubApiErrorRequest {
+  apiError: string;
+  endpoint: "credential" | "token";
 }
 
 export interface CriStubResponse {

--- a/api-tests/src/utils/request-body-generators.ts
+++ b/api-tests/src/utils/request-body-generators.ts
@@ -129,7 +129,8 @@ export const generateCriStubUserInfoEndpointErrorBody = (
     clientId: urlParams.get("client_id") as string,
     request: urlParams.get("request") as string,
     requestedError: {
-      userInfoError: "404",
+      apiError: "404",
+      endpoint: "credential",
     },
   };
 };


### PR DESCRIPTION
## Proposed changes
### What changed

- update CRI error request with new shape

### Why did it change

- as part of [this PR](https://github.com/govuk-one-login/ipv-stubs/pull/1740), the RequestError has changed shape so we need to update our api tests

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8679](https://govukverify.atlassian.net/browse/PYIC-8679)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8679]: https://govukverify.atlassian.net/browse/PYIC-8679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ