### PR TITLE
PYIC-7697: remove enc key from config pojo

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/dto/OauthCriConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/dto/OauthCriConfig.java
@@ -7,7 +7,6 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.core.library.annotations.RemoveEscapedQuotationMarks;
 
 import java.net.URI;
 
@@ -21,7 +20,6 @@ public class OauthCriConfig extends RestCriConfig {
     @NonNull private URI tokenUrl;
     @NonNull private String clientId;
     private URI authorizeUrl;
-    @RemoveEscapedQuotationMarks private String encryptionKey;
     private URI clientCallbackUrl;
     private boolean requiresAdditionalEvidence;
     private URI jwksUrl;


### PR DESCRIPTION
## Proposed changes
### What changed

- remove enc key from oauth cri config pojo

### Why did it change

- bc we now use the JWKS URLs for retrieving a CRIs enc key

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-7697](https://govukverify.atlassian.net/browse/PYIC-7697)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-7697]: https://govukverify.atlassian.net/browse/PYIC-7697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ