### PR TITLE
BAU stop code deployment for readme updates

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths-ignore:
+      - '**/README.md'
       - '.github/workflows/secure-post-merge.yml'
       - '.github/workflows/secure-post-merge-notags.yml'
   workflow_dispatch:


### PR DESCRIPTION
## Proposed changes
### What changed

Add all readmes to the ignored paths for triggering code deployment workflows
- 

### Why did it change

We don't need to run all the pipelines if the only change is documentation
- 

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
