### PR TITLE
PYIC-8720: give permission for CheckExistingIdentityFunction to get s…

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2668,6 +2668,8 @@ Resources:
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/evcs/apiKey-*
         - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/sis/apiKey-*
+        - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:eu-west-2:*:secret:/${Environment}/core/cimitApi/apiKey-*
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName


### PR DESCRIPTION
…ecret for sis api key

## Proposed changes
### What changed

- give permission for CheckExistingIdentityFunction to get secret for sis api key

### Why did it change

- SIS requests failing bc the lambda couldn't get this secret

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8720](https://govukverify.atlassian.net/browse/PYIC-8720)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8720]: https://govukverify.atlassian.net/browse/PYIC-8720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ