### PR TITLE
PYIC-8726: update TICF consumer tests to return 202 instead of 200 to…

### DIFF
--- a/libs/ticf-cri-service/src/test/java/uk/gov/di/ipv/core/library/ticf/pact/ticfCri/ContractTest.java
+++ b/libs/ticf-cri-service/src/test/java/uk/gov/di/ipv/core/library/ticf/pact/ticfCri/ContractTest.java
@@ -100,7 +100,7 @@ class ContractTest {
                         "Content-Type", APPLICATION_JSON)
                 .body(getRequestBody(List.of(passportVcJwtHelper)))
                 .willRespondWith()
-                .status(200)
+                .status(202)
                 .body(getResponseBody(List.of(noInterventionTicfVcJwtHelper)))
                 .toPact();
     }
@@ -168,7 +168,7 @@ class ContractTest {
                         "Content-Type", APPLICATION_JSON)
                 .body(getRequestBody(List.of(passportVcJwtHelper)))
                 .willRespondWith()
-                .status(200)
+                .status(202)
                 .body(getResponseBody(List.of(noInterventionWithWarningsTicfVcJwtHelper)))
                 .toPact();
     }
@@ -240,7 +240,7 @@ class ContractTest {
                         "Content-Type", APPLICATION_JSON)
                 .body(getRequestBody(List.of(passportVcJwtHelper)))
                 .willRespondWith()
-                .status(200)
+                .status(202)
                 .body(getResponseBody(List.of(interventionTicfVcJwtHelper)))
                 .toPact();
     }
@@ -313,7 +313,7 @@ class ContractTest {
                         "application/json; charset=UTF-8")
                 .body(getRequestBody(List.of(passportVcJwtHelper)))
                 .willRespondWith()
-                .status(200)
+                .status(202)
                 .body(getResponseBody(List.of(emptyTicfVcJwtHelper)))
                 .toPact();
     }
@@ -375,7 +375,7 @@ class ContractTest {
                         "Content-Type", APPLICATION_JSON)
                 .body(getRequestBody(List.of(dvlaVcJwtHelper, passportVcJwtHelper)))
                 .willRespondWith()
-                .status(200)
+                .status(202)
                 .body(getResponseBody(List.of(noInterventionTicfVcJwtHelper)))
                 .toPact();
     }
@@ -441,7 +441,7 @@ class ContractTest {
                 .headers("x-api-key", PRIVATE_API_KEY)
                 .body(getRequestBody(List.of()))
                 .willRespondWith()
-                .status(200)
+                .status(202)
                 .body(getResponseBody(List.of(noInterventionTicfVcJwtHelper)))
                 .toPact();
     }
@@ -507,7 +507,7 @@ class ContractTest {
                         "Content-Type", APPLICATION_JSON)
                 .body(getRequestBody(List.of(dvlaWithCiVcJwtHelper)))
                 .willRespondWith()
-                .status(200)
+                .status(202)
                 .body(getResponseBody(List.of(noInterventionWithWarningsTicfVcJwtHelper)))
                 .toPact();
     }


### PR DESCRIPTION
… reflect what real TICF returns

## Proposed changes
### What changed

- update TICF consumer tests to return 202 instead of 200

### Why did it change

- Real TICF returns a 202 instead of a 200

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8726](https://govukverify.atlassian.net/browse/PYIC-8726)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8726]: https://govukverify.atlassian.net/browse/PYIC-8726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ