### PR TITLE
BAU: Bump nimbusds-oauth2-oidc-sdk to 11.30

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ log4jCore = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log
 lombok = "org.projectlombok:lombok:1.18.30"
 mockitoCore = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockitoJunit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
-nimbusdsOauth2OidcSdk = "com.nimbusds:oauth2-oidc-sdk:11.29.1"
+nimbusdsOauth2OidcSdk = "com.nimbusds:oauth2-oidc-sdk:11.30"
 openTelemetryBom = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.20.1-alpha"
 openTelemetryAwsSdkAutoConfigure = { module = "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure" }
 openTelemetryJavaHttpClient = { module = "io.opentelemetry.instrumentation:opentelemetry-java-http-client" }


### PR DESCRIPTION
## Proposed changes
### What changed

- Bump lib version

### Why did it change

- Dependabot PR stuck and for some reason can not pick sisApiKey from GitHub Secrets which result in failed api tests.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8684](https://govukverify.atlassian.net/browse/PYIC-8684)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8684]: https://govukverify.atlassian.net/browse/PYIC-8684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ