### PR TITLE
BAU: Bump cosign installer to 4.0.0

### DIFF
--- a/.github/workflows/secure-pipeline-api-tests-image.yml
+++ b/.github/workflows/secure-pipeline-api-tests-image.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
           cosign-release: 'v2.5.1'
 


### PR DESCRIPTION
## Proposed changes
### What changed

- BUMP cosign-installer to 4.0.0

### Why did it change

- Dependabot PR stuck and for some reason can not pick sisApiKey from GitHub Secrets which result in failed api tests.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8684](https://govukverify.atlassian.net/browse/PYIC-8684)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8684]: https://govukverify.atlassian.net/browse/PYIC-8684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ