### PR TITLE
BAU: Bump junit-platform to 6.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dat
 jacksonDatatypeJsr = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 javalin = "io.javalin:javalin:6.7.0"
 junitJupiter = "org.junit.jupiter:junit-jupiter:6.0.0"
-junitPlatform = "org.junit.platform:junit-platform-launcher:1.13.0"
+junitPlatform = "org.junit.platform:junit-platform-launcher:6.0.0"
 log4j12Api = { module = "org.apache.logging.log4j:log4j-1.2-api", version.ref = "log4j" }
 log4jApi = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4jCore = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }


### PR DESCRIPTION
## Proposed changes
### What changed

- BUMP junit-platform to 6.0.0

### Why did it change

- Dependabot PR stuck and for some reason can not pick sisApiKey from GitHub Secrets which result in failed api tests.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8684](https://govukverify.atlassian.net/browse/PYIC-8684)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8684]: https://govukverify.atlassian.net/browse/PYIC-8684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ