### PR TITLE
PYIC-8394: Don't include null failure values in audit event

### DIFF
--- a/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/audit/AuditExtensionsSisComparison.java
+++ b/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/audit/AuditExtensionsSisComparison.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.sis.audit;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -31,6 +32,7 @@ public class AuditExtensionsSisComparison implements AuditExtensions {
     private final VerificationOutcome verificationOutcome;
 
     @JsonProperty("failure_code")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final FailureCode failureCode;
 
     public AuditExtensionsSisComparison(

--- a/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/audit/AuditRestrictedSisComparison.java
+++ b/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/audit/AuditRestrictedSisComparison.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.core.library.sis.audit;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestricted;
@@ -12,6 +13,8 @@ public class AuditRestrictedSisComparison implements AuditRestricted {
 
     private final List<String> reconstructedSignatures;
     private final List<String> sisSignatures;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final String failureDetails;
 
     public AuditRestrictedSisComparison(


### PR DESCRIPTION
## Proposed changes
### What changed

Exclude empty failure values from SIS audit event

### Why did it change

They should have been excluded

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8394](https://govukverify.atlassian.net/browse/PYIC-8394)



[PYIC-8394]: https://govukverify.atlassian.net/browse/PYIC-8394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ