### PR TITLE
BAU: Update powertools to 1.20.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ jackson = "2.20.0"
 log4j = "2.25.0"
 mockito = "5.20.0"
 pact = "4.6.17"
-powertools = "1.20.0"
+powertools = "1.20.1"
 
 [libraries]
 apacheHttpCore = "org.apache.httpcomponents.core5:httpcore5:5.3.3"


### PR DESCRIPTION
## Proposed changes
### What changed

- Bump amazon powertools to latest version 1.20.1

[CHANGELOG](https://docs.aws.amazon.com/powertools/java/1.x.x/changelog/)

### Why did it change

- To consume latest available version.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8684](https://govukverify.atlassian.net/browse/PYIC-8684)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8684]: https://govukverify.atlassian.net/browse/PYIC-8684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ