### PR TITLE
Pyic 8691 Add maxVot and strongestAchievableMaxVot to event extensions.

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -343,7 +343,7 @@ public class CheckExistingIdentityHandler
             var evcsAccessToken = clientOAuthSessionItem.getEvcsAccessToken();
             var credentialBundle = getCredentialBundle(userId, evcsAccessToken);
 
-            var previousAchievedVot =
+            var previousAchievedMaxVot =
                     getStrongestAchievableVotFromBundle(credentialBundle.credentials);
 
             var asyncCriStatus =
@@ -399,7 +399,7 @@ public class CheckExistingIdentityHandler
                             credentialBundle,
                             areGpg45VcsCorrelated,
                             contraIndicators,
-                            previousAchievedVot);
+                            previousAchievedMaxVot);
             if (profileMatchResponse.isPresent()) {
                 return profileMatchResponse.get();
             }
@@ -493,7 +493,7 @@ public class CheckExistingIdentityHandler
             VerifiableCredentialBundle credentialBundle,
             boolean areGpg45VcsCorrelated,
             List<ContraIndicator> contraIndicators,
-            Vot previousAchievedVot)
+            Vot previousAchievedMaxVot)
             throws VerifiableCredentialException {
         // Check for attained vot from requested vots
         var votMatchingResult =
@@ -515,7 +515,7 @@ public class CheckExistingIdentityHandler
         return Optional.of(
                 buildReuseResponse(
                         requestedMatch.vot(),
-                        previousAchievedVot,
+                        previousAchievedMaxVot,
                         ipvSessionItem,
                         credentialBundle,
                         auditEventUser,
@@ -610,7 +610,7 @@ public class CheckExistingIdentityHandler
 
     private JourneyResponse buildReuseResponse(
             Vot attainedVot,
-            Vot previousAchievedVot,
+            Vot previousAchievedMaxVot,
             IpvSessionItem ipvSessionItem,
             VerifiableCredentialBundle credentialBundle,
             AuditEventUser auditEventUser,
@@ -637,7 +637,8 @@ public class CheckExistingIdentityHandler
                 AuditEventTypes.IPV_IDENTITY_REUSE_COMPLETE,
                 auditEventUser,
                 deviceInformation,
-                new AuditExtensionPreviousAchievedVot(previousAchievedVot, previousAchievedVot));
+                new AuditExtensionPreviousAchievedVot(
+                        previousAchievedMaxVot, previousAchievedMaxVot));
         EmbeddedMetricHelper.identityReuse();
 
         ipvSessionItem.setVot(attainedVot);

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -637,7 +637,7 @@ public class CheckExistingIdentityHandler
                 AuditEventTypes.IPV_IDENTITY_REUSE_COMPLETE,
                 auditEventUser,
                 deviceInformation,
-                new AuditExtensionPreviousAchievedVot(previousAchievedVot));
+                new AuditExtensionPreviousAchievedVot(previousAchievedVot, previousAchievedVot));
         EmbeddedMetricHelper.identityReuse();
 
         ipvSessionItem.setVot(attainedVot);

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1007,7 +1007,7 @@ class CheckExistingIdentityHandlerTest {
             var ext =
                     (AuditExtensionPreviousAchievedVot)
                             auditEventArgumentCaptor.getAllValues().get(0).getExtensions();
-            assertEquals(P2, ext.getPreviousAchievedVot());
+            assertEquals(P2, ext.getPreviousAchievedMaxVot());
 
             verify(mockSessionCredentialService)
                     .persistCredentials(List.of(gpg45Vc), ipvSessionItem.getIpvSessionId(), false);
@@ -1051,7 +1051,7 @@ class CheckExistingIdentityHandlerTest {
             var ext =
                     (AuditExtensionPreviousAchievedVot)
                             auditEventArgumentCaptor.getAllValues().get(0).getExtensions();
-            assertEquals(null, ext.getPreviousAchievedVot());
+            assertEquals(null, ext.getPreviousAchievedMaxVot());
         }
 
         @Test

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1007,7 +1007,7 @@ class CheckExistingIdentityHandlerTest {
             var ext =
                     (AuditExtensionPreviousAchievedVot)
                             auditEventArgumentCaptor.getAllValues().get(0).getExtensions();
-            assertEquals(P2, ext.getPreviousAchievedMaxVot());
+            assertEquals(P2, ext.previousAchievedMaxVot());
 
             verify(mockSessionCredentialService)
                     .persistCredentials(List.of(gpg45Vc), ipvSessionItem.getIpvSessionId(), false);
@@ -1051,7 +1051,7 @@ class CheckExistingIdentityHandlerTest {
             var ext =
                     (AuditExtensionPreviousAchievedVot)
                             auditEventArgumentCaptor.getAllValues().get(0).getExtensions();
-            assertEquals(null, ext.getPreviousAchievedMaxVot());
+            assertEquals(null, ext.previousAchievedMaxVot());
         }
 
         @Test

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -92,7 +92,7 @@ public class StoreIdentityService {
             SharedAuditEventParameters auditEventParameters,
             boolean isSiRecordCreated) {
 
-        var vot = Objects.isNull(strongestMatchedVot) ? null : strongestMatchedVot.vot();
+        var maxVot = Objects.isNull(strongestMatchedVot) ? null : strongestMatchedVot.vot();
 
         auditService.sendAuditEvent(
                 AuditEvent.createWithDeviceInformation(
@@ -100,7 +100,7 @@ public class StoreIdentityService {
                         configService.getComponentId(),
                         auditEventParameters.auditEventUser(),
                         new AuditExtensionCandidateIdentityType(
-                                identityType, isSiRecordCreated, vot),
+                                identityType, isSiRecordCreated, maxVot, maxVot),
                         new AuditRestrictedDeviceInformation(
                                 auditEventParameters.deviceInformation())));
     }

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
@@ -161,7 +161,8 @@ class StoreIdentityServiceTest {
 
             assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
             assertEquals(
-                    P2, ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).vot());
+                    P2,
+                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
             assertEquals(
                     CandidateIdentityType.NEW,
                     ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
@@ -191,7 +192,8 @@ class StoreIdentityServiceTest {
 
             assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
             assertEquals(
-                    P2, ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).vot());
+                    P2,
+                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
             assertEquals(
                     CandidateIdentityType.UPDATE,
                     ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
@@ -218,7 +220,7 @@ class StoreIdentityServiceTest {
             verify(auditService).sendAuditEvent(auditEventCaptor.capture());
             var auditEvent = auditEventCaptor.getValue();
             assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertNull(((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).vot());
+            assertNull(((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
             assertEquals(
                     CandidateIdentityType.PENDING,
                     ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
@@ -249,7 +251,7 @@ class StoreIdentityServiceTest {
             var auditEvent = auditEventCaptor.getValue();
 
             assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertNull(((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).vot());
+            assertNull(((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
             assertEquals(
                     CandidateIdentityType.PENDING,
                     ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionCandidateIdentityType.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionCandidateIdentityType.java
@@ -9,5 +9,6 @@ import uk.gov.di.ipv.core.library.enums.Vot;
 public record AuditExtensionCandidateIdentityType(
         @JsonProperty(value = "identity_type", required = true) CandidateIdentityType identityType,
         @JsonProperty(value = "sis_record_created", required = true) Boolean sisRecordCreated,
-        @JsonProperty(required = false) Vot vot)
+        @JsonProperty(required = false) Vot vot,
+        @JsonProperty(value = "max_vot", required = false) Vot maxVot)
         implements AuditExtensions {}

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionPreviousAchievedVot.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionPreviousAchievedVot.java
@@ -1,27 +1,12 @@
 package uk.gov.di.ipv.core.library.auditing.extension;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.enums.Vot;
 
 @ExcludeFromGeneratedCoverageReport
-@Getter
-public class AuditExtensionPreviousAchievedVot implements AuditExtensions {
-
-    @JsonProperty("previous_achieved_vot")
-    private final Vot previousAchievedVot;
-
-    @JsonProperty("previous_achieved_max_vot")
-    private final Vot previousAchievedMaxVot;
-
-    @JsonCreator
-    public AuditExtensionPreviousAchievedVot(
-            @JsonProperty(value = "previous_achieved_vot", required = true) Vot previousAchievedVot,
-            @JsonProperty(value = "previous_achieved_max_vot", required = true)
-                    Vot previousAchievedMaxVot) {
-        this.previousAchievedVot = previousAchievedVot;
-        this.previousAchievedMaxVot = previousAchievedMaxVot;
-    }
-}
+public record AuditExtensionPreviousAchievedVot(
+        @JsonProperty(value = "previous_achieved_vot", required = true) Vot previousAchievedVot,
+        @JsonProperty(value = "previous_achieved_max_vot", required = true)
+                Vot previousAchievedMaxVot)
+        implements AuditExtensions {}

--- a/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionPreviousAchievedVot.java
+++ b/libs/audit-service/src/main/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionPreviousAchievedVot.java
@@ -13,10 +13,15 @@ public class AuditExtensionPreviousAchievedVot implements AuditExtensions {
     @JsonProperty("previous_achieved_vot")
     private final Vot previousAchievedVot;
 
+    @JsonProperty("previous_achieved_max_vot")
+    private final Vot previousAchievedMaxVot;
+
     @JsonCreator
     public AuditExtensionPreviousAchievedVot(
-            @JsonProperty(value = "previous_achieved_vot", required = true)
-                    Vot previousAchievedVot) {
+            @JsonProperty(value = "previous_achieved_vot", required = true) Vot previousAchievedVot,
+            @JsonProperty(value = "previous_achieved_max_vot", required = true)
+                    Vot previousAchievedMaxVot) {
         this.previousAchievedVot = previousAchievedVot;
+        this.previousAchievedMaxVot = previousAchievedMaxVot;
     }
 }


### PR DESCRIPTION
HOLD MERGE UNTIL THIS PR IS APPROVED
https://github.com/govuk-one-login/event-catalogue/pull/475


## Proposed changes
### What changed

- Added previousAchievedMaxVot additional property in IPV_IDENTITY_REUSE_COMPLETE event extension.
- Added maxVot additional property in IPV_IDENTITY_STORED event extension.

### Why did it change

We’re using “vot” as an extension in audit events to mean two different things in different circumstances:

the VOT returned to the RP which respects the vtr of the RP’s request (e.g. RP requests P2, user achieves P3 → “vot” is P2)

the VOT as the ‘maximum’ VOT the user could achieve given their bundle of VCs (user achieves P3 → max “vot” is P3)

D&A would like us to rename “vot” in the following extensions to make it explicit that we mean ‘maximum’ VOT:

extensions.previous_achieved_vot -> extensions.previous_achieved_max_vot in IPV_IDENTITY_REUSE_COMPLETE

extensions.vot -> extensions.max_vot in IPV_IDENTITY_STORED

Given these are live events already being consumed, for now we must add these as new extensions alongside the existing ones. Once all consumers are consuming the new extensions we will later remove the old ones.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8691](https://govukverify.atlassian.net/browse/PYIC-8691)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8691]: https://govukverify.atlassian.net/browse/PYIC-8691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ