### PR TITLE
Pyic 8068 mobile error routing

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -316,7 +316,7 @@ Feature: Audit Events
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
-    Then I get a 'identify-device' page response
+    Then I get an 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
     When I submit a 'smartphone' event
@@ -333,7 +333,7 @@ Feature: Audit Events
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
-    Then I get a 'identify-device' page response
+    Then I get an 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
     When I submit a 'smartphone' event

--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -194,7 +194,7 @@ Feature: P2 no photo id journey
     Scenario: P2 no photo id journey - Abandon - Strategic app
       Given I activate the 'strategicApp' feature set
       When I submit an 'mobileApp' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
 
     Scenario: P2 no photo id journey - Abandon - Passport
       When I submit an 'passport' event
@@ -290,7 +290,7 @@ Feature: P2 no photo id journey
     Scenario: P2 no photo id journey - KBV mitigation - Strategic app
       Given I activate the 'strategicApp' feature set
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
 
     Scenario: P2 no photo id journey - KBV mitigation - F2F
       When I submit an 'f2f' event
@@ -340,7 +340,7 @@ Feature: P2 no photo id journey
     Scenario: P2 no photo id journey - KBV dropout - Strategic app
       Given I activate the 'strategicApp' feature set
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
 
     Scenario: P2 no photo id journey - KBV dropout - F2F
       When I submit an 'f2f' event

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -6,7 +6,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
-    Then I get a 'identify-device' page response
+    Then I get an 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
     When I submit a 'computer-or-tablet' event
@@ -36,7 +36,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
 
     Scenario: Same session async DCMAW enhanced verification mitigation - successful
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -86,7 +86,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
 
     Scenario: Same session DCMAW enhanced verification mitigation - breaching CI received from async DCMAW
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -108,7 +108,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
 
     Scenario: Same session DCMAW enhanced verification mitigation - DL auth check invalid
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -207,7 +207,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I start a new 'low-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -264,7 +264,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I start a new 'low-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -288,7 +288,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I start a new 'low-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -155,12 +155,6 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I submit a 'next' event
 
       # Attempt 2 - retry after viewing prove-identity-another-way
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
@@ -177,12 +171,6 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I submit an 'anotherTypePhotoId' event
 
       # Attempt 3 - give up
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
@@ -7,7 +7,7 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
 
   Scenario: Cross-browser scenario
     When I submit an 'appTriage' event
-    Then I get a 'identify-device' page response
+    Then I get an 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
     When I submit a 'smartphone' event
@@ -43,7 +43,7 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
   Rule:
     Background:
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
@@ -83,12 +83,6 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I submit a 'next' event
 
       # Attempt 1 - retry after viewing prove-identity-another-way
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
@@ -105,12 +99,6 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I submit an 'anotherTypePhotoId' event
 
       # Attempt 2 - give up
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front

--- a/api-tests/features/strategic-app/p1-strategic-app.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app.feature
@@ -6,7 +6,7 @@ Feature: M2B Strategic App Journeys
       When I start a new 'low-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
 
     Scenario: Happy path MAM journey declared iphone
       When I submit an 'appTriage' event

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -8,7 +8,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
-    Then I get a 'identify-device' page response
+    Then I get an 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
     When I submit a 'computer-or-tablet' event
@@ -38,7 +38,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
 
     Scenario: Same session async DCMAW enhanced verification mitigation - successful
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -88,7 +88,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
 
     Scenario: Same session DCMAW enhanced verification mitigation - breaching CI received from async DCMAW
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -110,7 +110,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
 
     Scenario: Same session DCMAW enhanced verification mitigation - DL auth check invalid
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -209,7 +209,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -265,7 +265,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -289,7 +289,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -157,12 +157,6 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I submit a 'next' event
 
       # Attempt 2 - retry after viewing prove-identity-another-way
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
@@ -179,12 +173,6 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I submit an 'anotherTypePhotoId' event
 
       # Attempt 3 - give up
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
@@ -360,12 +348,6 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I submit an 'anotherTypePhotoId' event
 
       # Attempt 3 - give up
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
@@ -88,12 +88,6 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I submit a 'next' event
 
       # Attempt 1 - retry after viewing prove-identity-another-way
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
@@ -110,12 +104,6 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I submit an 'anotherTypePhotoId' event
 
       # Attempt 2 - give up
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
@@ -140,12 +128,6 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I submit a 'next' event
 
       # Reattempt
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       # And the user returns from the app to core-front
@@ -197,12 +179,6 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
 
       # The user tries again
       When I submit an 'next' event
-      Then I get an 'identify-device' page response
-      When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-      When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
@@ -7,7 +7,7 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
-    Then I get a 'identify-device' page response
+    Then I get an 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
     When I submit a 'smartphone' event
@@ -48,7 +48,7 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -12,7 +12,7 @@ Feature: M2B Strategic App Journeys
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
-    Then I get a 'identify-device' page response
+    Then I get an 'identify-device' page response
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
     When I submit a 'computer-or-tablet' event
@@ -29,7 +29,7 @@ Feature: M2B Strategic App Journeys
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
 
     Scenario: Happy path MAM journey declared iphone
       When I submit an 'appTriage' event
@@ -370,7 +370,7 @@ Feature: M2B Strategic App Journeys
 
     Scenario: Happy path successful P2 identity
       When I submit a 'next' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -410,11 +410,11 @@ Feature: M2B Strategic App Journeys
       When I submit a 'abandon' event
       Then I get a 'non-uk-no-passport' page response
       When I submit a 'useApp' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
 
     Scenario: Strategic app non-uk address user retries with app
       When I submit a 'next' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'computer-or-tablet' event
@@ -426,7 +426,7 @@ Feature: M2B Strategic App Journeys
 
     Scenario: Strategic app non-uk address user wants to prove identity another way from download page
       When I submit a 'next' event
-      Then I get a 'identify-device' page response
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'computer-or-tablet' event

--- a/api-tests/features/strategic-app/p3-strategic-app.feature
+++ b/api-tests/features/strategic-app/p3-strategic-app.feature
@@ -7,7 +7,7 @@ Feature: P3 strategic app
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
-    Then I get a 'identify-device' page response
+    Then I get an 'identify-device' page response
 
   Scenario: Successful P3 strategic app journey - MAM
     When I submit an 'appTriage' event

--- a/api-tests/features/strategic-app/strategic-app-dl-auth-source-check-reuse-update-details.feature
+++ b/api-tests/features/strategic-app/strategic-app-dl-auth-source-check-reuse-update-details.feature
@@ -169,12 +169,6 @@ Feature: Identity reuse update details with Strategic App
             When I submit a 'next' event
 
             # Attempt 2 - retry after viewing prove-identity-another-way
-            Then I get an 'identify-device' page response
-            When I submit an 'appTriage' event
-            Then I get a 'pyi-triage-select-device' page response
-            When I submit a 'smartphone' event
-            Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-            When I submit an 'iphone' event
             Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
             # And the user returns from the app to core-front
@@ -191,12 +185,6 @@ Feature: Identity reuse update details with Strategic App
             When I submit an 'anotherTypePhotoId' event
 
             # Attempt 3 - give up
-            Then I get an 'identify-device' page response
-            When I submit an 'appTriage' event
-            Then I get a 'pyi-triage-select-device' page response
-            When I submit a 'smartphone' event
-            Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
-            When I submit an 'iphone' event
             Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
             # And the user returns from the app to core-front

--- a/api-tests/features/strategic-app/strategic-app-retry-routing.feature
+++ b/api-tests/features/strategic-app/strategic-app-retry-routing.feature
@@ -1,0 +1,116 @@
+@Build @InitialisesDCMAWSessionState
+Feature: Strategic App Retry Journeys
+  Background: Trying again goes directly to the correct download page
+    Given I activate the 'strategicApp,drivingLicenceAuthCheck' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+
+  Scenario Outline: Trying again with a mobile device goes directly to the correct download page
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an '<device-type>' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context '<device-type>'
+    When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get a 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'drivingLicence' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'uk-driving-licence-details-not-correct' page response with context 'strategicApp'
+    When I submit a 'next' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context '<device-type>'
+
+    Examples:
+      | device-type |
+      | iphone      |
+      | android     |
+
+  Scenario Outline: Trying again with a desktop device goes directly to the correct download page
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+    When I submit an '<device-type>' event
+    Then I get a 'pyi-triage-desktop-download-app' page response with context '<device-type>'
+    When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
+    And I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'drivingLicence' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'uk-driving-licence-details-not-correct' page response with context 'strategicApp'
+    When I submit a 'next' event
+    Then I get a 'pyi-triage-desktop-download-app' page response with context '<device-type>'
+
+    Examples:
+      | device-type |
+      | iphone      |
+      | android     |
+
+  Scenario Outline: Trying again with a mobile device app only goes directly to the correct download page
+    When I submit a 'international' event
+    Then I get a 'non-uk-passport' page response
+    When I submit a 'next' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an '<device-type>' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context '<device-type>-appOnly'
+    When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get a 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'drivingLicence' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'uk-driving-licence-details-not-correct' page response with context 'strategicApp'
+    When I submit a 'next' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context '<device-type>-appOnly'
+
+    Examples:
+      | device-type |
+      | iphone      |
+      | android     |
+
+  Scenario Outline: Trying again with a desktop device app only goes directly to the correct download page
+    When I submit a 'international' event
+    Then I get a 'non-uk-passport' page response
+    When I submit a 'next' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+    When I submit an '<device-type>' event
+    Then I get a 'pyi-triage-desktop-download-app' page response with context '<device-type>-appOnly'
+    When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
+    And I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'drivingLicence' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'uk-driving-licence-details-not-correct' page response with context 'strategicApp'
+    When I submit a 'next' event
+    Then I get a 'pyi-triage-desktop-download-app' page response with context '<device-type>-appOnly'
+
+    Examples:
+      | device-type |
+      | iphone      |
+      | android     |

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/EventResolver.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/EventResolver.java
@@ -16,6 +16,7 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.TransitionResult;
 import uk.gov.di.ipv.core.processjourneyevent.statemachine.exceptions.UnknownEventException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -116,13 +117,13 @@ public class EventResolver {
             List<String> journeyContextsToSet = new ArrayList<>();
             var eventContextToSet = event.getJourneyContextToSet();
             if (eventContextToSet != null && !eventContextToSet.isEmpty()) {
-                journeyContextsToSet.add(eventContextToSet);
+                Collections.addAll(journeyContextsToSet, eventContextToSet.split(","));
             }
 
             List<String> journeyContextsToUnset = new ArrayList<>();
             var eventContextToUnset = event.getJourneyContextToUnset();
             if (eventContextToUnset != null && !eventContextToUnset.isEmpty()) {
-                journeyContextsToUnset.add(eventContextToUnset);
+                Collections.addAll(journeyContextsToUnset, eventContextToUnset.split(","));
             }
 
             return new TransitionResult(

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -4,7 +4,17 @@ description: >-
   and handover to the appropriate journey type.
 entryEvents:
   appTriage:
+    checkJourneyContext:
+      mamIphone:
+        targetState: MOBILE_IPHONE_START_SESSION
+      mamAndroid:
+        targetState: MOBILE_ANDROID_START_SESSION
+      dadIphone:
+        targetState: DAD_IPHONE_START_SESSION
+      dadAndroid:
+        targetState: DAD_ANDROID_START_SESSION
     targetState: IDENTIFY_DEVICE
+    journeyContextToUnset: mamIphone,mamAndroid,dadIphone,dadAndroid
   dl-auth-source-check:
     targetState: STRATEGIC_APP_HANDLE_RESULT
     targetEntryEvent: dl-auth-source-check
@@ -70,9 +80,11 @@ nestedJourneyStates:
     events:
       next:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE
+        journeyContextToSet: dadIphone
         checkJourneyContext:
           appOnly:
             targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
+            journeyContextToSet: dadIphone
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -258,9 +270,11 @@ nestedJourneyStates:
     events:
       next:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE
+        journeyContextToSet: dadAndroid
         checkJourneyContext:
           appOnly:
             targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
+            journeyContextToSet: dadAndroid
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -287,9 +301,11 @@ nestedJourneyStates:
     events:
       next:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE
+        journeyContextToSet: mamIphone
         checkJourneyContext:
           appOnly:
             targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
+            journeyContextToSet: mamIphone
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -347,9 +363,11 @@ nestedJourneyStates:
     events:
       next:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
+        journeyContextToSet: mamAndroid
         checkJourneyContext:
           appOnly:
             targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
+            journeyContextToSet: mamAndroid
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -440,4 +458,13 @@ nestedJourneyStates:
       failedDlAuthCheckInvalidDl:
         exitEventToEmit: failedDlAuthCheckInvalidDl
       retryApp:
+        checkJourneyContext:
+          mamIphone:
+            targetState: MOBILE_IPHONE_START_SESSION
+          mamAndroid:
+            targetState: MOBILE_ANDROID_START_SESSION
+          dadIphone:
+            targetState: DAD_IPHONE_START_SESSION
+          dadAndroid:
+            targetState: DAD_ANDROID_START_SESSION
         targetState: IDENTIFY_DEVICE

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/EventResolverTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/events/EventResolverTest.java
@@ -93,6 +93,24 @@ public class EventResolverTest {
         }
 
         @Test
+        void resolveShouldReturnAStateWithMultipleJourneyContexts() throws Exception {
+            var expectedResult =
+                    new TransitionResult(
+                            new BasicState(),
+                            null,
+                            null,
+                            null,
+                            List.of("test-context-to-set1", "test-context-to-set2"),
+                            List.of("test-context-to-unset1", "test-context-to-unset2"));
+            BasicEvent basicEvent = new BasicEvent();
+            basicEvent.setTargetStateObj(expectedResult.state());
+            basicEvent.setJourneyContextToSet("test-context-to-set1,test-context-to-set2");
+            basicEvent.setJourneyContextToUnset("test-context-to-unset1,test-context-to-unset2");
+
+            assertEquals(expectedResult, eventResolver.resolve(basicEvent, eventResolveParameters));
+        }
+
+        @Test
         void resolveShouldReturnAlternativeStateIfACheckedCriIsDisabled() throws Exception {
             BasicEvent basicEventWithCheckIfDisabledConfigured = new BasicEvent();
             basicEventWithCheckIfDisabledConfigured.setTargetStateObj(new BasicState());


### PR DESCRIPTION
DO NOT MERGE until QA completed in dev

## Proposed changes
### What changed

When a user wants to retry with the strategic app we send them back to the correct download page

### Why did it change

So the user doesn't have to go through the triage process again

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8068](https://govukverify.atlassian.net/browse/PYIC-8068)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8068]: https://govukverify.atlassian.net/browse/PYIC-8068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ