### PR TITLE
PYIC-8440: Make JWT field optional

### DIFF
--- a/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/dto/SisStoredIdentityContent.java
+++ b/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/dto/SisStoredIdentityContent.java
@@ -45,7 +45,7 @@ public class SisStoredIdentityContent extends UserClaims {
             @JsonProperty(value = VOT_CLAIM_NAME, required = true) Vot vot,
             @JsonProperty(value = "vtm", required = true) String vtm,
             @JsonProperty(value = "credentials", required = true) List<String> credentialSignatures,
-            @JsonProperty(value = VCS_CLAIM_NAME, required = true) List<String> vcs,
+            @JsonProperty(value = VCS_CLAIM_NAME) List<String> vcs,
             @JsonProperty(value = IDENTITY_CLAIM_NAME) IdentityClaim identityClaim,
             @JsonProperty(value = ADDRESS_CLAIM_NAME) List<PostalAddress> addressClaim,
             @JsonProperty(value = PASSPORT_CLAIM_NAME) List<PassportDetails> passportClaim,


### PR DESCRIPTION
## Proposed changes
### What changed

Make the JWT field in the SIS response optional

### Why did it change

It should be optional (https://github.com/govuk-one-login/ipv-identity-reuse-service/blob/main/openAPI/api.yaml)

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8440](https://govukverify.atlassian.net/browse/PYIC-8440)



[PYIC-8440]: https://govukverify.atlassian.net/browse/PYIC-8440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ