### PR TITLE
PYIC-8440: Ignore unused fields like "aud", "iss", etc

### DIFF
--- a/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/dto/SisStoredIdentityContent.java
+++ b/libs/sis-service/src/main/java/uk/gov/di/ipv/core/library/sis/dto/SisStoredIdentityContent.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.core.library.sis.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +25,7 @@ import static uk.gov.di.ipv.core.library.domain.VocabConstants.VCS_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.VOT_CLAIM_NAME;
 
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SisStoredIdentityContent extends UserClaims {
     @NonNull
     @JsonProperty(value = "credentials")


### PR DESCRIPTION
## Proposed changes
### What changed

Ignore fields we're not interested in in the SIS identity response

### Why did it change

Deserialisation was throwing exceptions on unrecognised fields

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8440](https://govukverify.atlassian.net/browse/PYIC-8440)


[PYIC-8440]: https://govukverify.atlassian.net/browse/PYIC-8440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ