### PR TITLE
PYIC-8634: Toggle on DWP KBVs

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -383,7 +383,6 @@ Feature: Audit Events
 
   Rule: DWP KBV
     Background: Start a journey to DWP KBV CRI
-      Given I activate the 'dwpKbvTest' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event

--- a/api-tests/features/cimit/p1-alternate-doc.feature
+++ b/api-tests/features/cimit/p1-alternate-doc.feature
@@ -83,7 +83,6 @@ Feature: P1 CIMIT - Alternate doc
         | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'pyi-passport-no-match'        | 'pyi-continue-with-driving-licence' |'drivingLicence'| 'kenneth-driving-permit-valid' |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV
-      Given I activate the 'dwpKbvTest' feature set
       When I submit an <initialCri> event
       Then I get a <initialCri> CRI response
       When I submit <initialInvalidDoc> details to the CRI stub
@@ -117,7 +116,6 @@ Feature: P1 CIMIT - Alternate doc
         | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
     Scenario Outline: Alternate doc mitigation user drops out of DWP KBV CRI via thin file
-      Given I activate the 'dwpKbvTest' feature set
       When I submit an <initialCri> event
       Then I get a <initialCri> CRI response
       When I submit <initialInvalidDoc> details to the CRI stub
@@ -159,7 +157,6 @@ Feature: P1 CIMIT - Alternate doc
         | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV PIP page dropout
-      Given I activate the 'dwpKbvTest' feature set
       When I submit an <initialCri> event
       Then I get a <initialCri> CRI response
       When I submit <initialInvalidDoc> details to the CRI stub
@@ -193,7 +190,6 @@ Feature: P1 CIMIT - Alternate doc
         | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV transition page dropout
-      Given I activate the 'dwpKbvTest' feature set
       When I submit an <initialCri> event
       Then I get a <initialCri> CRI response
       When I submit <initialInvalidDoc> details to the CRI stub

--- a/api-tests/features/cimit/p2-alternate-doc.feature
+++ b/api-tests/features/cimit/p2-alternate-doc.feature
@@ -85,7 +85,6 @@ Feature: P2 CIMIT - Alternate doc
         | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'pyi-passport-no-match'        | 'pyi-continue-with-driving-licence' |'drivingLicence'| 'kenneth-driving-permit-valid' |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV
-      Given I activate the 'dwpKbvTest' feature set
       When I submit an <initialCri> event
       Then I get a <initialCri> CRI response
       When I submit <initialInvalidDoc> details to the CRI stub
@@ -119,7 +118,6 @@ Feature: P2 CIMIT - Alternate doc
         | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
     Scenario Outline: Alternate doc mitigation user drops out of DWP KBV CRI via thin file
-      Given I activate the 'dwpKbvTest' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
@@ -169,7 +167,6 @@ Feature: P2 CIMIT - Alternate doc
         | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV PIP page dropout
-      Given I activate the 'dwpKbvTest' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
@@ -211,7 +208,6 @@ Feature: P2 CIMIT - Alternate doc
         | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV transition page dropout
-      Given I activate the 'dwpKbvTest' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -241,18 +241,17 @@ Feature: Disabled CRI journeys
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
 
-    Scenario: Experian KBV is offered first
-      Given I activate the 'dwpKbvDisabled' feature sets
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'page-pre-experian-kbv-transition' page response
-
     Scenario: Experian KBV is offered if DWP KBV unsuitable
-      Given I activate the 'dwpKbvTest' feature set
       When I submit 'kenneth-score-2' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'personal-independence-payment' page response
       When I submit an 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+
+    Scenario: Experian KBV is offered first
+      Given I activate the 'dwpKbvDisabled' feature sets
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'page-pre-experian-kbv-transition' page response

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -69,7 +69,6 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No Photo Id Journey - NINO dropout
-    Given I activate the 'dwpKbvTest' feature sets
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -127,7 +126,6 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No Photo Id Journey - DWP KBV
-    Given I activate the 'dwpKbvTest' feature sets
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -162,7 +160,6 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No Photo Id Journey user drops out of DWP KBV CRI via thin file or failed checks - DWP KBV
-    Given I activate the 'dwpKbvTest' feature sets
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -203,7 +200,6 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No Photo Id Journey - DWP KBV PIP page dropout
-    Given I activate the 'dwpKbvTest' feature sets
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event
@@ -238,7 +234,7 @@ Feature: P1 No Photo Id Journey
     Then I get a 'P1' identity
 
   Scenario: P1 No Photo Id Journey - DWP KBV transition page dropout
-    Given I activate the 'dwpKbvTest,disableStrategicApp' feature sets
+    Given I activate the 'disableStrategicApp' feature sets
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'end' event

--- a/api-tests/features/p1-web-journey.feature
+++ b/api-tests/features/p1-web-journey.feature
@@ -194,9 +194,6 @@ Feature: P1 Web Journeys
       | ukPassport     | kenneth-passport-valid       |
 
   Rule: Route through DWP KBV
-    Background: Enable DWP KBV
-      Given I activate the 'dwpKbvTest' feature set
-
     Scenario Outline: Successful P1 journey - via <cri> and DWP KBV
       When I submit an '<cri>' event
       Then I get a '<cri>' CRI response

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -210,7 +210,6 @@ Feature: P2 Web document journey
 
   Rule: P2 VTR only - DWP KBV
     Background: Start web journey
-      Given I activate the 'dwpKbvTest' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -314,7 +314,7 @@ core:
     dwpKbv:
       id: dwpKbv
       name: DWP KBV
-      enabled: "false"
+      enabled: "true"
       unavailable: false # temporarily unavailable
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
@@ -420,7 +420,3 @@ core:
         ticf:
           enabled: true
     # CRI enablement combinations
-    dwpKbvTest:
-      credentialIssuers:
-        dwpKbv:
-          enabled: true

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -317,7 +317,7 @@ core:
     dwpKbv:
       id: dwpKbv
       name: DWP KBV
-      enabled: "false"
+      enabled: "true"
       unavailable: false # temporarily unavailable
       allowedSharedAttributes: "name,birthDate,address"
       activeConnection: "stub"
@@ -414,7 +414,3 @@ core:
         ticf:
           enabled: true
     # CRI enablement combinations
-    dwpKbvTest:
-      credentialIssuers:
-        dwpKbv:
-          enabled: true


### PR DESCRIPTION
## Proposed changes
### What changed

-  Toggle on DWP KBVs

### Why did it change

- Ahead of DWP KBVs go-live we should toggle on the journey up to and including staging

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8634](https://govukverify.atlassian.net/browse/PYIC-8634)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8634]: https://govukverify.atlassian.net/browse/PYIC-8634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ