### PR TITLE
PYIC-8698: highlight edges and their labels on the journey map

### DIFF
--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -236,3 +236,6 @@ form fieldset p {
 span.edgeLabel .defaultEdgeLabel:last-child {
   border-bottom: none;
 }
+span.edgeLabelIdentifier {
+  text-shadow: 0.5px 0px 0px #555, -0.5px 0px 0px #555;
+}

--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -237,5 +237,5 @@ span.edgeLabel .defaultEdgeLabel:last-child {
   border-bottom: none;
 }
 span.edgeLabelIdentifier {
-  text-shadow: 0.5px 0px 0px #555, -0.5px 0px 0px #555;
+  text-shadow: 0.3px 0px 0px #555, -0.3px 0px 0px #555;
 }

--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -237,5 +237,5 @@ span.edgeLabel .defaultEdgeLabel:last-child {
   border-bottom: none;
 }
 span.edgeLabelIdentifier {
-  text-shadow: 0.3px 0px 0px #555, -0.3px 0px 0px #555;
+  text-shadow: 0.45px 0px 0px #333, -0.45px 0px 0px #333;
 }

--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -313,6 +313,45 @@ const updateView = async (): Promise<void> => {
   await renderSvg(selectedJourney, selectedNestedJourney, options);
 };
 
+const highlightEdgeAndLabel = (edge: Element, edgeLabel: Element) => {
+  // Reset all edges and paths to default styling
+  Array.from(document.querySelectorAll(`g.edgePaths path`))
+    .filter((edge) => edge.style.stroke === "black")
+    .forEach((edge) => (edge.style.stroke = DEFAULT_EDGE_COLOUR));
+  Array.from(document.getElementsByClassName("edgeLabelIdentifier")).forEach(
+    (edgeLabel) => edgeLabel.classList.remove("edgeLabelIdentifier"),
+  );
+
+  edge.style.stroke = "black";
+  edgeLabel.classList.add("edgeLabelIdentifier");
+};
+
+const setEdgeAndLabelClickHandlers = (edgeIds: string[]) => {
+  const edgeLabels = document.querySelectorAll("span.edgeLabel");
+  edgeLabels.forEach((label, idx) => {
+    // There isn't a native way in mermaid.js to add an id to the
+    // edge labels so we manually add them after the diagram
+    // has been rendered onto the dom
+    label.id = edgeIds[idx];
+    label.addEventListener("click", () => {
+      const edge = document.querySelector(`path[id^=${label.id}]`);
+      if (edge) {
+        highlightEdgeAndLabel(edge, label);
+      }
+    });
+  });
+
+  const edges = document.querySelectorAll("g.edgePaths path");
+  edges.forEach((edge) => {
+    edge.addEventListener("click", () => {
+      const label = document.querySelector(`span[id=${edge.id}]`);
+      if (label) {
+        highlightEdgeAndLabel(edge, label);
+      }
+    });
+  });
+};
+
 // Render the journey map SVG
 const renderSvg = async (
   selectedJourney: string,
@@ -332,30 +371,7 @@ const renderSvg = async (
     bindFunctions(diagramElement);
   }
 
-  // There isn't a native way in mermaid.js to add an id to the
-  // edge labels so we manually add them after the diagram
-  // has been rendered onto the dom
-  const edgeLabels = document.querySelectorAll("span.edgeLabel");
-  edgeLabels.forEach((label, idx) => {
-    label.id = edgeIds[idx];
-    label.addEventListener("click", () => {
-      const edge = document.querySelector(`path[id^=${label.id}]`);
-      if (edge) {
-        // Reset all edges and paths to default styling
-        Array.from(document.querySelectorAll(`g.edgePaths path`))
-          .filter((edge) => edge.style.stroke === "black")
-          .forEach((edge) => (edge.style.stroke = DEFAULT_EDGE_COLOUR));
-        Array.from(
-          document.getElementsByClassName("edgeLabelIdentifier"),
-        ).forEach((edgeLabel) =>
-          edgeLabel.classList.remove("edgeLabelIdentifier"),
-        );
-
-        edge.style.stroke = "black";
-        label.classList.add("edgeLabelIdentifier");
-      }
-    });
-  });
+  setEdgeAndLabelClickHandlers(edgeIds);
 
   svgPanZoomInstance = svgPanZoom("#diagramSvg", {
     controlIconsEnabled: true,

--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -1,7 +1,7 @@
 import mermaid from "mermaid";
 import svgPanZoom from "svg-pan-zoom";
 import yaml from "yaml";
-import { DEFAULT_EDGE_COLOUR, render } from "./render.js";
+import { render } from "./render.js";
 import { getAsFullJourneyMap } from "./helpers/uplift-nested.js";
 import {
   COMMON_JOURNEY_TYPES,
@@ -30,6 +30,8 @@ declare global {
     style: {
       stroke: string;
     };
+    // Used to keep track of the previous colour or a path
+    previousColour: string;
   }
 }
 
@@ -317,7 +319,7 @@ const highlightEdgeAndLabel = (edge: Element, edgeLabel: Element) => {
   // Reset all edges and paths to default styling
   Array.from(document.querySelectorAll(`g.edgePaths path`))
     .filter((edge) => edge.style.stroke === "black")
-    .forEach((edge) => (edge.style.stroke = DEFAULT_EDGE_COLOUR));
+    .forEach((edge) => (edge.style.stroke = edge.previousColour));
   Array.from(document.getElementsByClassName("edgeLabelIdentifier")).forEach(
     (edgeLabel) => edgeLabel.classList.remove("edgeLabelIdentifier"),
   );
@@ -343,6 +345,7 @@ const setEdgeAndLabelClickHandlers = (edgeIds: string[]) => {
 
   const edges = document.querySelectorAll("g.edgePaths path");
   edges.forEach((edge) => {
+    edge.previousColour = edge.style.stroke;
     edge.addEventListener("click", () => {
       const label = document.querySelector(`span[id=${edge.id}]`);
       if (label) {
@@ -371,6 +374,9 @@ const renderSvg = async (
     bindFunctions(diagramElement);
   }
 
+  // There isn't a native way in mermaid.js to add event handlers
+  // to edges and their labels so we create them once the svg
+  // has been rendered onto the dom
   setEdgeAndLabelClickHandlers(edgeIds);
 
   svgPanZoomInstance = svgPanZoom("#diagramSvg", {

--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -28,10 +28,10 @@ declare global {
   }
   interface Element {
     style: {
-      stroke: string;
+      stroke?: string;
     };
     // Used to keep track of the previous colour or a path
-    previousColour: string;
+    previousColour?: string;
   }
 }
 

--- a/journey-map/src/render.ts
+++ b/journey-map/src/render.ts
@@ -30,6 +30,9 @@ interface RenderableMap {
   states: StateNode[];
 }
 
+const DEFAULT_EDGE_COLOUR = "#ADADAC";
+const HIGHLIGHTED_JOURNEY_EDGE_COLOUR = "#FF8888";
+
 // Trace transitions (edges) and states (nodes) traced from the initial states
 // This allows us to skip unreachable states
 const getVisibleEdgesAndNodes = async (
@@ -235,8 +238,8 @@ export const render = async (
   );
   const transitionStrings = transitions.flatMap((t, i) => {
     const colour = t.transitionCount
-      ? `#FF8888${alphaFromCount(t.transitionCount, maxCount)}`
-      : "#E5E4E2";
+      ? `${HIGHLIGHTED_JOURNEY_EDGE_COLOUR}${alphaFromCount(t.transitionCount, maxCount)}`
+      : DEFAULT_EDGE_COLOUR;
     const strokeWidth = getStrokeWidth(t.transitionCount ?? 0, maxCount);
     return [
       renderTransition(t),

--- a/journey-map/src/render.ts
+++ b/journey-map/src/render.ts
@@ -30,8 +30,6 @@ interface RenderableMap {
   states: StateNode[];
 }
 
-export const DEFAULT_EDGE_COLOUR = "#E5E4E2";
-
 // Trace transitions (edges) and states (nodes) traced from the initial states
 // This allows us to skip unreachable states
 const getVisibleEdgesAndNodes = async (

--- a/journey-map/src/render.ts
+++ b/journey-map/src/render.ts
@@ -265,8 +265,8 @@ export const render = async (
 };
 
 const getStrokeWidth = (count: number, maxCount: number): number => {
-  if (maxCount <= 0) return 1;
-  const minWidth = 1;
+  if (maxCount <= 0) return 2;
+  const minWidth = 2;
   const maxWidth = 8;
   const ratio = Math.min(1, Math.max(0, count / maxCount));
   return minWidth + (maxWidth - minWidth) * ratio;

--- a/journey-map/src/render.ts
+++ b/journey-map/src/render.ts
@@ -30,6 +30,8 @@ interface RenderableMap {
   states: StateNode[];
 }
 
+export const DEFAULT_EDGE_COLOUR = "#E5E4E2";
+
 // Trace transitions (edges) and states (nodes) traced from the initial states
 // This allows us to skip unreachable states
 const getVisibleEdgesAndNodes = async (
@@ -200,7 +202,7 @@ export const render = async (
   nestedJourneys: Record<string, NestedJourneyMap>,
   options: RenderOptions,
   journeyMaps: Record<string, JourneyMap>,
-): Promise<string> => {
+): Promise<{ mermaidString: string; edgeIds: string[] }> => {
   const isNestedJourney = selectedJourney in nestedJourneys;
   const direction = TOP_DOWN_JOURNEYS.includes(selectedJourney) ? "TD" : "LR";
 
@@ -244,11 +246,21 @@ export const render = async (
     ];
   });
 
-  return `${getMermaidHeader(direction)}
+  const edgeIds = transitionStrings
+    .filter((_, idx) => (idx + 1) % 2 !== 0)
+    .map((transitionString) => {
+      const trimmed = transitionString.trimStart();
+      return trimmed.slice(trimmed.indexOf(" ") + 1, trimmed.indexOf("@"));
+    });
+
+  return {
+    mermaidString: `${getMermaidHeader(direction)}
     ${states.map(renderState).join("\n")}
     ${states.map(renderClickHandler).join("\n")}
     ${transitionStrings.join("\n")}
-  `;
+  `,
+    edgeIds,
+  };
 };
 
 const getStrokeWidth = (count: number, maxCount: number): number => {


### PR DESCRIPTION
## Proposed changes
### What changed

- adds click handlers to edges and edge labels so that they turn black/bold to highlight associated edges + their label
- makes the default colour for the edges darker so it's easier to see them
- sets the min edge width to 2 instead of 1, again for visibility and to make it easier to select them

| Example | Screenshot |
|-|-|
| Selected edge is also a highlighted edge | <img width="758" height="691" alt="Screenshot 2025-10-23 at 13 50 10" src="https://github.com/user-attachments/assets/d5833828-e32f-4f9a-9291-9abc463ac7f8" /> |
| Selected edge is non-highlighted edge | <img width="1110" height="695" alt="Screenshot 2025-10-23 at 13 50 39" src="https://github.com/user-attachments/assets/ddad8679-3b2c-4c2e-a264-1b7132fb9f41" /> |


### Why did it change

- Atm, it's quite difficult which edge each edge label (event) belongs to. This updates the journey map so that clicking on either the edge/edge label highlights the associated edge label/edge

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8698](https://govukverify.atlassian.net/browse/PYIC-8698)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8698]: https://govukverify.atlassian.net/browse/PYIC-8698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ