### PR TITLE
BAU: Add powertools metrics namespace to env variables in local running.

### DIFF
--- a/local-running/build.gradle
+++ b/local-running/build.gradle
@@ -60,6 +60,7 @@ application {
 tasks.named('run', JavaExec) {
 	environment 'AWS_EMF_ENVIRONMENT', 'Local'
 	environment 'AWS_XRAY_CONTEXT_MISSING', 'IGNORE_ERROR'
+	environment 'POWERTOOLS_METRICS_NAMESPACE', 'test'
 }
 
 sonar {


### PR DESCRIPTION
## Proposed changes
### What changed

- Add powertools metrics namespace to env variable in local running

### Why did it change

- To resolve 'java.lang.IllegalArgumentException: Namespace must be specified before flushing metrics' while executing api test in local running 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- BAU

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
