### PR TITLE
PYIC-8748: Upgrade Pact dependencies to 4.6.18 to resolve Netty security vulnerability

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ awsSdk = "2.35.11"
 jackson = "2.20.0"
 log4j = "2.25.0"
 mockito = "5.20.0"
-pact = "4.6.17"
+pact = "4.6.18"
 powertools = "2.5.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ awsSdk = "2.35.11"
 jackson = "2.20.0"
 log4j = "2.25.0"
 mockito = "5.20.0"
-pact = "4.6.18"
+pact = "4.6.17"
 powertools = "2.5.0"
 
 [libraries]
@@ -38,8 +38,8 @@ mockitoJunit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mo
 nimbusdsOauth2OidcSdk = "com.nimbusds:oauth2-oidc-sdk:11.30"
 openTelemetryBom = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.20.1-alpha"
 openTelemetryJavaHttpClient = { module = "io.opentelemetry.instrumentation:opentelemetry-java-http-client" }
-pactConsumerJunit = { module = "au.com.dius.pact.consumer:junit5", version.ref = "pact" }
-pactProviderJunit = { module = "au.com.dius.pact.provider:junit5", version.ref = "pact" }
+pactConsumerJunit = "au.com.dius.pact.consumer:junit5:4.6.19"
+pactProviderJunit = "au.com.dius.pact.provider:junit5:4.6.19"
 powertoolsLogging = { module = "software.amazon.lambda:powertools-logging-log4j", version.ref = "powertools" }
 powertoolsMetrics = { module = "software.amazon.lambda:powertools-metrics", version.ref = "powertools" }
 powertoolsParameters = { module = "software.amazon.lambda:powertools-parameters", version.ref = "powertools" }


### PR DESCRIPTION
## Proposed changes
### What changed

- Upgrade Pact dependencies to 4.6.18 

### Why did it change

- To resolve Netty security vulnerability

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8748](https://govukverify.atlassian.net/browse/PYIC-8748)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8748]: https://govukverify.atlassian.net/browse/PYIC-8748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ