### PR TITLE
PYIC-8731: Add comment Validation lambda invoke permission resource

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3077,6 +3077,8 @@ Resources:
       SourceArn: !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/${AppConfigApplication}/configurationprofile/${AppConfigConfigurationProfile}"
 
 #  App Config Pipeline
+#  This may fail on first deployment due to not existing alias.
+#  Simply comment it out to deploy and then uncomment and update the stack to give app config pipeline permissions to invoke validation lambda
   AppConfigPipelineValidateFunctionInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:


### PR DESCRIPTION
## Proposed changes
### What changed

- Added comment to the resource indicating difficulties with first time deployment. 

### Why did it change

- Deployment will fail during first time deploy due to the not existing Validation Lambda alias. 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8731](https://govukverify.atlassian.net/browse/PYIC-8731)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8731]: https://govukverify.atlassian.net/browse/PYIC-8731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ