### PR TITLE
PYIC-8706: Routing for Experian KBV CRI error

### DIFF
--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -157,7 +157,7 @@ Feature: Handling unexpected CRI errors
       When I call the CRI stub with attributes and get a 'server_error' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'sorry-technical-problem' page response
+      Then I get a 'sorry-technical-problem' page response with context 'kbvCriError'
 
     Scenario: Unexpected error from Experian KBV CRI - try CRI again
       When I submit a 'tryAgain' event
@@ -206,14 +206,6 @@ Feature: Handling unexpected CRI errors
 
     Scenario: Unexpected error from Experian KBV CRI - try post office route
       When I submit a 'postOffice' event
-      Then I get a 'claimedIdentity' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
         | Attribute          | Values                                      |

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -53,6 +53,7 @@ nestedJourneyStates:
     response:
       type: page
       pageId: sorry-technical-problem
+      context: kbvCriError
     events:
       tryAgain:
         targetState: PRE_EXPERIAN_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -406,7 +406,7 @@ states:
         targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
         targetJourney: F2F_HAND_OFF
-        targetState: START_MEDIUM_CONFIDENCE
+        targetState: START_LOW_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR
@@ -517,7 +517,7 @@ states:
         targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
         targetJourney: F2F_HAND_OFF
-        targetState: START_MEDIUM_CONFIDENCE
+        targetState: START_LOW_CONFIDENCE
         checkIfDisabled:
           f2f:
             targetJourney: TECHNICAL_ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -85,6 +85,23 @@ states:
         targetState: ERROR
 
   # Journey states
+  RESET_SESSION_BEFORE_WEBAPP_RETRY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+      error:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
 
   RESET_SESSION_IDENTITY:
     response:
@@ -386,14 +403,14 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
-        targetState: CRI_CLAIMED_IDENTITY_J4
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
@@ -497,14 +514,14 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
-        targetState: CRI_CLAIMED_IDENTITY_J4
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -85,6 +85,23 @@ states:
         targetState: ERROR
 
   # Journey states
+  RESET_SESSION_BEFORE_WEBAPP_RETRY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL
+    events:
+      next:
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: appTriage
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
+      error:
+        targetState: APP_DOC_CHECK
+        targetEntryEvent: next
 
   RESET_SESSION_IDENTITY:
     response:
@@ -393,14 +410,14 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
-        targetState: CRI_CLAIMED_IDENTITY_J4
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
@@ -518,14 +535,14 @@ states:
             auditContext:
               mitigationType: enhanced-verification
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: RESET_SESSION_BEFORE_WEBAPP_RETRY
       try-again-post-office:
-        targetState: CRI_CLAIMED_IDENTITY_J4
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 


### PR DESCRIPTION

## Proposed changes
### What changed

- On failure from Experian KBVs just skip straight to F2F (since we already have a name from a document and Address + Fraud VCs) 
- Reset users identity when looping back to web app journey from technical error page

### Why did it change

- We already have a name from a document and Address + Fraud VCs

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8706](https://govukverify.atlassian.net/browse/PYIC-8706)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8706]: https://govukverify.atlassian.net/browse/PYIC-8706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ