### PR TITLE
BAU: Bump actions/upload-artifact from 4 to 5

### DIFF
--- a/.github/workflows/contract-tests.yaml
+++ b/.github/workflows/contract-tests.yaml
@@ -58,19 +58,19 @@ jobs:
           POWERTOOLS_METRICS_NAMESPACE: 'TestMetricsNamespace'
       - name: Upload build-user-identity provider pact test report
         if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: build-user-identity provider pact test report
           path: /home/runner/work/ipv-core-back/ipv-core-back/lambdas/build-user-identity/build/reports/tests/pactProviderTests/
       - name: Upload issue-client-access-token provider pact test report
         if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: issue-client-access-token provider pact test report
           path: /home/runner/work/ipv-core-back/ipv-core-back/lambdas/issue-client-access-token/build/reports/tests/pactProviderTests/
       - name: Upload user-reverification provider pact test report
         if: ${{ !cancelled() && github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: user-reverification provider pact test report
           path: /home/runner/work/ipv-core-back/ipv-core-back/lambdas/user-reverification/build/reports/tests/pactProviderTests/

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload API test report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: API test report
           path: api-tests/reports/
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload Application logs
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: Application logs
           path: api-tests/core-back-output.log


### PR DESCRIPTION
## Proposed changes
### What changed

Update upload artifact github action to v5

### Why did it change

To copy the dependabot PR that is failing API tests: https://github.com/govuk-one-login/ipv-core-back/pull/3534
