### PR TITLE
PYIC-8731: Fix api tests for shared dev pipeline

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -124,7 +124,7 @@ Feature: Audit Events
     # We want to wait a suitable period of time to let the request to the process-async-cri lambda to finish before
     # starting a new session. This will hopefully reduce flakiness with this test where we expect an exact sequence
     # of audit events to be generated.
-    When I wait for 3 seconds for the async credential to be processed
+    When I wait for 5 seconds for the async credential to be processed
     And I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'next' event

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -157,7 +157,7 @@ Feature: Handling unexpected CRI errors
       When I call the CRI stub with attributes and get a 'server_error' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'sorry-technical-problem' page response with context 'kbvCriError'
+      Then I get an 'sorry-technical-problem' page response with context 'kbvCriError'
 
     Scenario: Unexpected error from Experian KBV CRI - try CRI again
       When I submit a 'tryAgain' event

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -157,7 +157,7 @@ Feature: Handling unexpected CRI errors
       When I call the CRI stub with attributes and get a 'server_error' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get an 'sorry-technical-problem' page response with context 'kbvCriError'
+      Then I get a 'sorry-technical-problem' page response with context 'kbvCriError'
 
     Scenario: Unexpected error from Experian KBV CRI - try CRI again
       When I submit a 'tryAgain' event

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -112,6 +112,7 @@ Conditions:
     - !Equals [ !Ref AWS::AccountId, "130355686670" ]
     - !Equals [ !Ref AWS::AccountId, "175872367215" ]
   IsDev01: !Equals [ !Ref AWS::AccountId, "130355686670" ]
+  IsSharedDev: !Equals [ !Ref Environment, "dev" ]
   IsNotDevelopment: !Not [ !Condition IsDevelopment ]
   IsBuild: !Equals [ !Ref Environment, "build" ]
   IsDevPerf: !Equals [ !Ref Environment, "dev-perf" ]
@@ -507,8 +508,15 @@ Resources:
     Condition: IsTestApiEnv
     Properties:
       Enabled: true
-      Value: !Sub "{{resolve:secretsmanager:CoreBackInternalTestingApiKey:SecretString}}" # pragma: allowlist secret
-
+      Value: !Sub
+        - "{{resolve:secretsmanager:CoreBackInternalTestingApiKey:SecretString}}${env}" # pragma: allowlist secret
+        - env: !If
+            - IsDevelopment
+            - !If
+              - IsSharedDev
+              - ""
+              - !Sub "-${Environment}"
+            - ""
 
   IPVCoreInternalTestingApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -507,12 +507,8 @@ Resources:
     Condition: IsTestApiEnv
     Properties:
       Enabled: true
-      Value: !Sub
-        - "{{resolve:secretsmanager:CoreBackInternalTestingApiKey:SecretString}}${env}" # pragma: allowlist secret
-        - env: !If
-            - IsDevelopment
-            - !Sub "-${Environment}"
-            - ""
+      Value: !Sub "{{resolve:secretsmanager:CoreBackInternalTestingApiKey:SecretString}}" # pragma: allowlist secret
+
 
   IPVCoreInternalTestingApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan


### PR DESCRIPTION
## Proposed changes
### What changed

- Removed suffix addition to internal api gateway key for shared dev
- Increased wait time for the async credential to be processed in api test from 3 to 5 seconds.

### Why did it change

- API Test image picks Internal Api Gateway - API Key from secret manager which is pure value without any additions where our template.yaml add suffix ( !Sub "-${Environment}" to that API Key for development accounts.

- process-async-credential couldn't complete the task within 3 seconds in shared dev environment 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8731](https://govukverify.atlassian.net/browse/PYIC-8731)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8731]: https://govukverify.atlassian.net/browse/PYIC-8731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ