### PR TITLE
PYIC-8731: Add GetFunctionConfiguration for manual f2f reset lambda p…

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -892,6 +892,7 @@ Resources:
             Action:
               - lambda:InvokeFunction
               - lambda:GetFunction
+              - lambda:GetFunctionConfiguration
             Resource:
               - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:manual-f2f-pending-reset-${Environment}
 


### PR DESCRIPTION
…ermission.

## Proposed changes
### What changed

- Added "lambda:GetFunctionConfiguration" permission for manual f2f reset assumed role 

### Why did it change

- Since Friday, the invocation of Lambda functions by the TSD, utilising the Switch run-book role, has failed. Our analysis indicates that the AWS role now mandates the lambda:GetFunctionConfiguration permission for running test events on Lambda functions via the AWS Console. This appears to be a recent, unannounced change implemented by AWS, or one for which we may have missed the notification

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- BAU

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
