### PR TITLE
BAU: ignore test only changes when running deploy job

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths-ignore:
       - '**/README.md'
-      - '**/test/**'
+      - '/lambdas/*/src/test/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -6,7 +6,8 @@ on:
       - main
     paths-ignore:
       - '**/README.md'
-      - '/lambdas/*/src/test/**'
+      - 'lambdas/*/src/test/**'
+      - 'journey-map/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - '**/README.md'
+      - '**/test/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Proposed changes
### What changed

- prevent deploying to aws if the PR only has a test change

### Why did it change

- Putting up a PR which changed just the contract tests triggered deployment to AWS even though it wasn't really changing any application code. Ignoring test only changes means we don't have to run the deployment


## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
