### PR TITLE
PYIC-8769: Clear pending DCMAW_ASYNC cri vcs for DCMAW_ASYNC reset type.

### DIFF
--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -202,8 +202,7 @@ public class ResetSessionIdentityHandler
     }
 
     private void resetCriPendingResponse(
-            ClientOAuthSessionItem clientOAuthSessionItem, Cri asyncCri)
-            throws EvcsServiceException {
+            ClientOAuthSessionItem clientOAuthSessionItem, Cri asyncCri) {
         var userId = clientOAuthSessionItem.getUserId();
         criResponseService.deleteCriResponseItem(userId, asyncCri);
         LOGGER.info(

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -144,9 +144,11 @@ public class ResetSessionIdentityHandler
                 doResetForPendingVc(clientOAuthSessionItem, F2F);
             }
 
-            if (sessionCredentialsResetType.equals(PENDING_DCMAW_ASYNC_ALL)
-                    || sessionCredentialsResetType.equals(
-                            SessionCredentialsResetType.DCMAW_ASYNC)) {
+            if (sessionCredentialsResetType.equals(SessionCredentialsResetType.DCMAW_ASYNC)) {
+                resetCriPendingResponse(clientOAuthSessionItem, Cri.DCMAW_ASYNC);
+            }
+
+            if (sessionCredentialsResetType.equals(PENDING_DCMAW_ASYNC_ALL)) {
                 doResetForPendingVc(clientOAuthSessionItem, Cri.DCMAW_ASYNC);
             }
 
@@ -197,5 +199,16 @@ public class ResetSessionIdentityHandler
         LOGGER.info(
                 LogHelper.buildLogMessage(
                         String.format("Reset done for %s pending identity.", asyncCri.getId())));
+    }
+
+    private void resetCriPendingResponse(
+            ClientOAuthSessionItem clientOAuthSessionItem, Cri asyncCri)
+            throws EvcsServiceException {
+        var userId = clientOAuthSessionItem.getUserId();
+        criResponseService.deleteCriResponseItem(userId, asyncCri);
+        LOGGER.info(
+                LogHelper.buildLogMessage(
+                        String.format(
+                                "Reset done for %s pending cri response.", asyncCri.getId())));
     }
 }

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -144,11 +144,9 @@ public class ResetSessionIdentityHandler
                 doResetForPendingVc(clientOAuthSessionItem, F2F);
             }
 
-            if (sessionCredentialsResetType.equals(SessionCredentialsResetType.DCMAW_ASYNC)) {
-                resetCriPendingResponse(clientOAuthSessionItem, Cri.DCMAW_ASYNC);
-            }
-
-            if (sessionCredentialsResetType.equals(PENDING_DCMAW_ASYNC_ALL)) {
+            if (sessionCredentialsResetType.equals(PENDING_DCMAW_ASYNC_ALL)
+                    || sessionCredentialsResetType.equals(
+                            SessionCredentialsResetType.DCMAW_ASYNC)) {
                 doResetForPendingVc(clientOAuthSessionItem, Cri.DCMAW_ASYNC);
             }
 
@@ -199,15 +197,5 @@ public class ResetSessionIdentityHandler
         LOGGER.info(
                 LogHelper.buildLogMessage(
                         String.format("Reset done for %s pending identity.", asyncCri.getId())));
-    }
-
-    private void resetCriPendingResponse(
-            ClientOAuthSessionItem clientOAuthSessionItem, Cri asyncCri) {
-        var userId = clientOAuthSessionItem.getUserId();
-        criResponseService.deleteCriResponseItem(userId, asyncCri);
-        LOGGER.info(
-                LogHelper.buildLogMessage(
-                        String.format(
-                                "Reset done for %s pending cri response.", asyncCri.getId())));
     }
 }

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -43,7 +43,6 @@ import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.REINS
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.CURRENT;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_RESET_TYPE;
-import static uk.gov.di.ipv.core.library.helpers.RequestHelper.getIpvSessionId;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_NEXT_PATH;
 
@@ -100,7 +99,7 @@ public class ResetSessionIdentityHandler
         configService.setFeatureSet(RequestHelper.getFeatureSet(input));
 
         try {
-            String ipvSessionId = getIpvSessionId(input);
+            String ipvSessionId = RequestHelper.getIpvSessionId(input);
             IpvSessionItem ipvSessionItem = ipvSessionService.getIpvSession(ipvSessionId);
 
             ClientOAuthSessionItem clientOAuthSessionItem =
@@ -121,6 +120,12 @@ public class ResetSessionIdentityHandler
             sessionCredentialsService.deleteSessionCredentialsForResetType(
                     ipvSessionId, sessionCredentialsResetType);
             LOGGER.info(LogHelper.buildLogMessage("Session credentials deleted"));
+
+            LOGGER.info(
+                    LogHelper.buildLogMessage(
+                            String.format(
+                                    "Session credentials reset type: %s",
+                                    sessionCredentialsResetType)));
 
             if (sessionCredentialsResetType == REINSTATE) {
                 var existingIdentityVcs =


### PR DESCRIPTION
## Proposed changes
### What changed

- Added pending DCMAW_ASYNC cri vcs reset for DCMAW_ASYNC reset type in reset session credentials.

### Why did it change

- COI journey that result in CI - D02 from driving licence check, after re logging to the system, it redirect user to the driving licence CRI as pending vcs were present in dynamodb table.

After deleting pending vcs, user after re logging to the system will start "New P2 Mitigation Web Journey" which also is incorrect but it doesn't allow user to create new identity. 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXXX)

## Checklists

- [x] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
