### PR TITLE
PYIC-8798: Return 400 from check-mobile-app-vc-receipt if IPV Session is expired.

### DIFF
--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -207,6 +207,7 @@ public class CheckMobileAppVcReceiptHandler
         LogHelper.attachFeatureSetToLogs(request.getFeatureSet());
 
         if (ipvSessionService.checkIfSessionExpired(ipvSessionItem)) {
+            LOGGER.warn(LogHelper.buildLogMessage("Ipv Session expired."));
             throw new IpvSessionExpiredException(ErrorResponse.IPV_SESSION_ITEM_EXPIRED);
         }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -120,7 +120,8 @@ public enum ErrorResponse {
     FAILED_TO_EXTRACT_CIS_FROM_VC(1106, "Failed to extract contra-indicators from VC"),
     MISSING_SECURITY_CHECK_CREDENTIAL(1107, "Missing security check credential"),
     FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS(1108, "Failed to create stored identity for EVCS"),
-    ERROR_CALLING_AIS_API(1109, "Error when calling AIS API");
+    ERROR_CALLING_AIS_API(1109, "Error when calling AIS API"),
+    IPV_SESSION_ITEM_EXPIRED(1110, "Session expired.");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/IpvSessionExpiredException.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/exceptions/IpvSessionExpiredException.java
@@ -1,0 +1,10 @@
+package uk.gov.di.ipv.core.library.exceptions;
+
+import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+
+public class IpvSessionExpiredException extends Exception {
+
+    public IpvSessionExpiredException(ErrorResponse errorResponse) {
+        super(errorResponse.getMessage());
+    }
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -199,6 +199,13 @@ public class IpvSessionService {
         dataStore.update(ipvSessionItem);
     }
 
+    public boolean checkIfSessionExpired(IpvSessionItem ipvSessionItem) {
+        var creationDateTime = Instant.parse(ipvSessionItem.getCreationDateTime());
+        var expirationDateTime =
+                creationDateTime.plusSeconds(configService.getBackendSessionTimeout());
+        return Instant.now().isAfter(expirationDateTime);
+    }
+
     private String toExpiryDateTime(long expirySeconds) {
         return Instant.now().plusSeconds(expirySeconds).toString();
     }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -18,11 +18,14 @@ import uk.gov.di.ipv.core.library.persistence.DataStore;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.retry.Sleeper;
 
+import java.time.Instant;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -338,5 +341,33 @@ class IpvSessionServiceTest {
                         .getValue()
                         .getAccessTokenMetadata()
                         .getRevokedAtDateTime());
+    }
+
+    @Test
+    void checkIfSessionExpired_shouldReturnTrueIfIpvSessionIsExpired() {
+        // Arrange
+        var expiredIpvSessionItem = new IpvSessionItem();
+        expiredIpvSessionItem.setCreationDateTime(Instant.now().minusSeconds(4000).toString());
+        when(mockConfigService.getBackendSessionTimeout()).thenReturn(3600L);
+
+        // Act
+        var result = ipvSessionService.checkIfSessionExpired(expiredIpvSessionItem);
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    void checkIfSessionExpired_shouldReturnFalseIfIpvSessionIsNotExpired() {
+        // Arrange
+        var validIpvSessionItem = new IpvSessionItem();
+        validIpvSessionItem.setCreationDateTime(Instant.now().minusSeconds(1000).toString());
+        when(mockConfigService.getBackendSessionTimeout()).thenReturn(3600L);
+
+        // Act
+        var result = ipvSessionService.checkIfSessionExpired(validIpvSessionItem);
+
+        // Assert
+        assertFalse(result);
     }
 }


### PR DESCRIPTION
## Proposed changes
### What changed

- Added method to evaluate if IPV Session is expired 
- Created exception and error response message 
- Added check for expired IPV Session in check-mobile-app-vc-receipt and return 400 if it is.

### Why did it change

- Trust & Reuse have reported seeing a daily number of EVCS ‘get VCs’ requests using an expired access token which they reject with a 401 response (apparently it also triggers some alarms on their side). We believe the vast majority if not all of these requests are coming from the check-mobile-app-vc-receipt lambda which the frontend v2 app polling calls to check if an app VC has been received yet or not. It seems, perhaps from users abandoning the journey at the app polling pages, that calls are being made beyond the 1 hour expiry of the EVCS access token (which Orch sends us at the start of a journey). 

Currently the only place we explicitly check our (IPV) session expiry (also 1 hour) is in the journey engine when transitioning between states. The actual session item in DynamoDB has a longer TTL of 24 hours.

We should add a check in the check-mobile-app-vc-receipt lambda to reject requests (with a 400 error) where the user's IPV session has expired. In turn this should drastically reduce, hopefully diminish calls to EVCS being made with an expired access token.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8798](https://govukverify.atlassian.net/browse/PYIC-8798)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8798]: https://govukverify.atlassian.net/browse/PYIC-8798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ