### PR TITLE
PYIC-8798: Refactor ProcessJourneyEventHandler to reuse checkIfSessio…

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -55,7 +55,6 @@ import uk.gov.di.ipv.core.processjourneyevent.statemachine.stepresponses.StepRes
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
@@ -417,10 +416,7 @@ public class ProcessJourneyEventHandler
 
     private boolean sessionIsNewlyExpired(IpvSessionItem ipvSessionItem) {
         return (!SESSION_TIMEOUT.equals(ipvSessionItem.getState().subJourney()))
-                && Instant.parse(ipvSessionItem.getCreationDateTime())
-                        .isBefore(
-                                Instant.now()
-                                        .minusSeconds(configService.getBackendSessionTimeout()));
+                && ipvSessionService.checkIfSessionExpired(ipvSessionItem);
     }
 
     private Map<IpvJourneyTypes, StateMachine> loadStateMachines(

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -393,7 +393,7 @@ class ProcessJourneyEventHandlerTest {
         mockIpvSessionItemAndTimeout("CRI_STATE");
         IpvSessionItem ipvSessionItem = mockIpvSessionService.getIpvSession(TEST_IP);
         ipvSessionItem.setCreationDateTime(Instant.now().minusSeconds(100).toString());
-        when(mockConfigService.getBackendSessionTimeout()).thenReturn(99L);
+        when(mockIpvSessionService.checkIfSessionExpired(ipvSessionItem)).thenReturn(true);
 
         Map<String, Object> output =
                 getProcessJourneyStepHandler().handleRequest(input, mockContext);
@@ -1323,7 +1323,7 @@ class ProcessJourneyEventHandlerTest {
         ipvSessionItem.setSecurityCheckCredential(SIGNED_CONTRA_INDICATOR_VC_1);
 
         when(mockConfigService.getComponentId()).thenReturn("core");
-        when(mockConfigService.getBackendSessionTimeout()).thenReturn(7200L);
+        when(mockIpvSessionService.checkIfSessionExpired(ipvSessionItem)).thenReturn(false);
         when(mockIpvSessionService.getIpvSession(anyString())).thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionService.getClientOAuthSession(any()))
                 .thenReturn(getClientOAuthSessionItem());


### PR DESCRIPTION
…nExpired method.

## Proposed changes
### What changed

- Added call to IpvSessionService to check if session expired

### Why did it change

- As we checking if session expired in another lambda we could reuse one method and avoid duplications in the code.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8798](https://govukverify.atlassian.net/browse/PYIC-8798)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8798]: https://govukverify.atlassian.net/browse/PYIC-8798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ