### PR TITLE
PYIC-8804: manually update pact libraries

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ awsSdk = "2.39.1"
 jackson = "2.20.0"
 log4j = "2.25.0"
 mockito = "5.20.0"
-pact = "4.6.17"
+pact = "4.6.18"
 powertools = "2.8.0"
 
 [libraries]


### PR DESCRIPTION
## Proposed changes
### What changed

- manually update pact libraries to 4.6.18

### Why did it change

The v4.6.18 pact libraries should be using the patched versions marked vulnerable dependencies:
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/65
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/42
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/68
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/45

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8804](https://govukverify.atlassian.net/browse/PYIC-8804)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8804]: https://govukverify.atlassian.net/browse/PYIC-8804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ