### PR TITLE
Pyic 8784 mitigation error routing

### DIFF
--- a/api-tests/features/cimit/p2-alternate-doc.feature
+++ b/api-tests/features/cimit/p2-alternate-doc.feature
@@ -15,13 +15,13 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'page-multiple-doc-check' page response
 
     Scenario Outline: Alternate doc mitigation via passport or DL
-      When I submit an <initialCri> event
-      Then I get a <initialCri> CRI response
-      When I submit <initialInvalidDoc> details to the CRI stub
-      Then I get a <noMatchPage> page response
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
       When I submit a 'next' event
-      Then I get a <mitigatingCri> CRI response
-      When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
@@ -41,26 +41,26 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'P2' identity
 
       Examples:
-        | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
-        | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
-        | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport    | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence| kenneth-driving-permit-valid |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - separate session
-      When I submit an <initialCri> event
-      Then I get a <initialCri> CRI response
-      When I submit <initialInvalidDoc> details to the CRI stub
-      Then I get a <noMatchPage> page response
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
       When I submit a 'next' event
-      Then I get a <mitigatingCri> CRI response
+      Then I get a '<mitigatingCri>' CRI response
 
       # User drops out of previous CRI without mitigating and starts a new journey
       Given I start a new 'medium-confidence' journey
-      Then I get a <separateSessionNoMatch> page response
+      Then I get a '<separateSessionNoMatch>' page response
       When I submit a 'next' event
-      Then I get a <mitigationStart> page response
+      Then I get a '<mitigationStart>' page response
       When I submit a 'next' event
-      Then I get a <mitigatingCri> CRI response
-      When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
@@ -80,19 +80,19 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'P2' identity
 
       Examples:
-        | initialCri          | initialInvalidDoc                            | noMatchPage                                | separateSessionNoMatch         | mitigationStart                     |mitigatingCri   | mitigatingDoc                  |
-        | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'pyi-driving-licence-no-match' | 'pyi-continue-with-passport'        | 'ukPassport'    | 'kenneth-passport-valid'       |
-        | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'pyi-passport-no-match'        | 'pyi-continue-with-driving-licence' |'drivingLicence'| 'kenneth-driving-permit-valid' |
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | separateSessionNoMatch       | mitigationStart                   |mitigatingCri   | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | pyi-driving-licence-no-match | pyi-continue-with-passport        | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | pyi-passport-no-match        | pyi-continue-with-driving-licence | drivingLicence | kenneth-driving-permit-valid |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV
       Given I activate the 'dwpKbvTest' feature set
-      When I submit an <initialCri> event
-      Then I get a <initialCri> CRI response
-      When I submit <initialInvalidDoc> details to the CRI stub
-      Then I get a <noMatchPage> page response
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
       When I submit a 'next' event
-      Then I get a <mitigatingCri> CRI response
-      When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
@@ -114,9 +114,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'P2' identity
 
       Examples:
-        | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
-        | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
-        | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
 
     Scenario Outline: Alternate doc mitigation user drops out of DWP KBV CRI via thin file
       Given I activate the 'dwpKbvTest' feature set
@@ -128,13 +128,13 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'dcmaw' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error
       Then I get a 'page-multiple-doc-check' page response
-      When I submit an <initialCri> event
-      Then I get a <initialCri> CRI response
-      When I submit <initialInvalidDoc> details to the CRI stub
-      Then I get a <noMatchPage> page response
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
       When I submit a 'next' event
-      Then I get a <mitigatingCri> CRI response
-      When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
@@ -164,9 +164,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'P2' identity
 
       Examples:
-        | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
-        | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
-        | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV PIP page dropout
       Given I activate the 'dwpKbvTest' feature set
@@ -178,13 +178,13 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'dcmaw' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error
       Then I get a 'page-multiple-doc-check' page response
-      When I submit an <initialCri> event
-      Then I get a <initialCri> CRI response
-      When I submit <initialInvalidDoc> details to the CRI stub
-      Then I get a <noMatchPage> page response
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
       When I submit a 'next' event
-      Then I get a <mitigatingCri> CRI response
-      When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
@@ -206,9 +206,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'P2' identity
 
       Examples:
-        | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
-        | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
-        | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
 
     Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV transition page dropout
       Given I activate the 'dwpKbvTest' feature set
@@ -220,13 +220,13 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'dcmaw' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error
       Then I get a 'page-multiple-doc-check' page response
-      When I submit an <initialCri> event
-      Then I get a <initialCri> CRI response
-      When I submit <initialInvalidDoc> details to the CRI stub
-      Then I get a <noMatchPage> page response
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
       When I submit a 'next' event
-      Then I get a <mitigatingCri> CRI response
-      When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
@@ -244,9 +244,9 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'P0' identity
 
       Examples:
-        | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
-        | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
-        | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
 
     Scenario Outline: Mitigation of alternate-doc CI via <mitigating-cri> when user initially drops out of <mitigating-cri>
       When I submit a '<initial-cri>' event
@@ -355,13 +355,13 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'dcmaw' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error
       Then I get a 'page-multiple-doc-check' page response
-      When I submit an <initialCri> event
-      Then I get a <initialCri> CRI response
-      When I submit <initialInvalidDoc> details to the CRI stub
-      Then I get a <noMatchPage> page response
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
       When I submit a 'next' event
-      Then I get a <mitigatingCri> CRI response
-      When I submit <mitigatingDoc> details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
@@ -381,6 +381,6 @@ Feature: P2 CIMIT - Alternate doc
       Then I get a 'P2' identity
 
       Examples:
-        | initialCri          | initialInvalidDoc                            | noMatchPage                                | mitigatingCri   | mitigatingDoc                  |
-        | 'drivingLicence'    | 'kenneth-driving-permit-needs-alternate-doc' | 'pyi-driving-licence-no-match-another-way' | 'ukPassport'    | 'kenneth-passport-valid'       |
-        | 'ukPassport'        | 'kenneth-passport-needs-alternate-doc'       | 'pyi-passport-no-match-another-way'        | 'drivingLicence'| 'kenneth-driving-permit-valid' |
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -170,6 +170,53 @@ Feature: Handling unexpected CRI errors
         | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
         | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
 
+    Scenario Outline: CI from <ci_cri> then separate session unexpected error twice from <mitigating_cri> before success
+      When I submit a '<ci_cri>' event
+      Then I get a '<ci_cri>' CRI response
+      When I submit '<ci_details>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigating_cri>' CRI response
+
+      # User drops out of previous CRI without mitigating and starts a new journey
+      Given I start a new 'medium-confidence' journey
+      Then I get a '<separateSessionNoMatch>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigationStart>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigating_cri>' CRI response
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response with context 'dlOrPassportMitigation'
+      When I submit a 'tryAgain' event
+      Then I get a '<mitigating_cri>' CRI response
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response with context 'dlOrPassportMitigation'
+      When I submit a 'tryAgain' event
+      Then I get a '<mitigating_cri>' CRI response
+      When I submit '<mitigating_details>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+      Examples:
+        | ci_cri            | ci_details                                 | noMatchPage                              | separateSessionNoMatch       | mitigationStart                   | mitigating_cri | mitigating_details           |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | pyi-passport-no-match        | pyi-continue-with-driving-licence | drivingLicence | kenneth-driving-permit-valid |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | pyi-driving-licence-no-match | pyi-continue-with-passport        | ukPassport     | kenneth-passport-valid       |
+
     Scenario Outline: CI from <ci_cri> then unexpected error from <mitigating_cri> and return to RP
       When I submit a '<ci_cri>' event
       Then I get a '<ci_cri>' CRI response

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
@@ -44,6 +44,9 @@ nestedJourneyStates:
         checkFeatureFlag:
           sorryTechnicalErrorEnabled:
             targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_UK_PASSPORT
+            checkMitigation:
+              alternate-doc-invalid-dl:
+                targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_MITIGATION_UK_PASSPORT
   SORRY_CRI_TECHNICAL_PROBLEM_CRI_UK_PASSPORT:
     response:
       type: page
@@ -55,6 +58,16 @@ nestedJourneyStates:
         exitEventToEmit: try-again-app
       postOffice:
         exitEventToEmit: try-again-post-office
+      returnToRp:
+        exitEventToEmit: return-to-rp-cri-error
+  SORRY_CRI_TECHNICAL_PROBLEM_CRI_MITIGATION_UK_PASSPORT:
+    response:
+      type: page
+      pageId: sorry-technical-problem
+      context: dlOrPassportMitigation
+    events:
+      tryAgain:
+        targetState: CRI_UK_PASSPORT
       returnToRp:
         exitEventToEmit: return-to-rp-cri-error
   ADDRESS_AND_FRAUD_AFTER_PASSPORT:
@@ -106,6 +119,9 @@ nestedJourneyStates:
         checkFeatureFlag:
           sorryTechnicalErrorEnabled:
             targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_DRIVING_LICENCE
+            checkMitigation:
+              alternate-doc-invalid-passport:
+                targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_MITIGATION_DRIVING_LICENCE
   SORRY_CRI_TECHNICAL_PROBLEM_CRI_DRIVING_LICENCE:
     response:
       type: page
@@ -117,6 +133,16 @@ nestedJourneyStates:
         exitEventToEmit: try-again-app
       postOffice:
         exitEventToEmit: try-again-post-office
+      returnToRp:
+        exitEventToEmit: return-to-rp-cri-error
+  SORRY_CRI_TECHNICAL_PROBLEM_CRI_MITIGATION_DRIVING_LICENCE:
+    response:
+      type: page
+      pageId: sorry-technical-problem
+      context: dlOrPassportMitigation
+    events:
+      tryAgain:
+        targetState: CRI_DRIVING_LICENCE
       returnToRp:
         exitEventToEmit: return-to-rp-cri-error
   ADDRESS_AND_FRAUD_AFTER_DL:


### PR DESCRIPTION
## Proposed changes
### What changed

Added routing for new error page when mitigating invalid documents

### Why did it change

To stop users going down routes that are guaranteed to fail

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8784](https://govukverify.atlassian.net/browse/PYIC-8784)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated


[PYIC-8784]: https://govukverify.atlassian.net/browse/PYIC-8784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ