### PR TITLE
PYIC-8806: Downgrade noisy error logs

### DIFF
--- a/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
+++ b/lambdas/check-mobile-app-vc-receipt/src/main/java/uk/gov/di/ipv/core/checkmobileappvcreceipt/CheckMobileAppVcReceiptHandler.java
@@ -126,6 +126,10 @@ public class CheckMobileAppVcReceiptHandler
                 return buildErrorResponse(
                         e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.INFO);
             }
+            if (ErrorResponse.MISSING_IPV_SESSION_ID.equals(e.getErrorResponse())) {
+                return buildErrorResponse(
+                        e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.WARN);
+            }
             return buildErrorResponse(e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse());
         } catch (IpvSessionNotFoundException e) {
             return buildErrorResponse(
@@ -134,6 +138,10 @@ public class CheckMobileAppVcReceiptHandler
             return buildErrorResponse(
                     e, HttpStatusCode.BAD_REQUEST, ErrorResponse.IPV_SESSION_ITEM_EXPIRED);
         } catch (InvalidCriResponseException e) {
+            if (ErrorResponse.CRI_RESPONSE_ITEM_NOT_FOUND.equals(e.getErrorResponse())) {
+                return buildErrorResponse(
+                        e, HttpStatusCode.INTERNAL_SERVER_ERROR, e.getErrorResponse(), Level.WARN);
+            }
             return buildErrorResponse(
                     e, HttpStatusCode.INTERNAL_SERVER_ERROR, e.getErrorResponse());
         } catch (CredentialParseException e) {

--- a/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
+++ b/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
@@ -98,7 +98,10 @@ public class ProcessMobileAppCallbackHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.OK, Objects.requireNonNullElse(response, JOURNEY_NEXT));
         } catch (InvalidMobileAppCallbackRequestException e) {
-            if (Set.of(ErrorResponse.INVALID_OAUTH_STATE, ErrorResponse.MISSING_IPV_SESSION_ID)
+            if (Set.of(
+                            ErrorResponse.INVALID_OAUTH_STATE,
+                            ErrorResponse.MISSING_IPV_SESSION_ID,
+                            ErrorResponse.CRI_RESPONSE_ITEM_NOT_FOUND)
                     .contains(e.getErrorResponse())) {
                 return buildErrorResponse(
                         e, HttpStatusCode.BAD_REQUEST, e.getErrorResponse(), Level.WARN);


### PR DESCRIPTION
## Proposed changes
### What changed

- Downgrade the following noisy error logs:

- uk.gov.di.ipv.core.library.criresponse.exception.InvalidCriResponseException: CRI response item cannot be found
- uk.gov.di.ipv.core.processmobileappcallback.exception.InvalidMobileAppCallbackRequestException: CRI response item cannot be found
- uk.gov.di.ipv.core.checkmobileappvcreceipt.exception.InvalidCheckMobileAppVcReceiptRequestException: Missing ipv session id header

### Why did it change

- These are symptoms of the v2 app cross-browser callback when a user returns from the app without a session or CRI response item. These are expected in normal operation of the service so we should downgrade these to WARN level.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8806](https://govukverify.atlassian.net/browse/PYIC-8806)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8806]: https://govukverify.atlassian.net/browse/PYIC-8806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ