### PR TITLE
PYIC-8628: Toggle on sisVerification in local running and fix api test.

### DIFF
--- a/api-tests/data/audit-events/update-name-and-address-journey.json
+++ b/api-tests/data/audit-events/update-name-and-address-journey.json
@@ -122,6 +122,23 @@
     }
   },
   {
+    "event_name": "IPV_STORED_IDENTITY_CHECKED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "max_vot": "P2",
+      "reconstructed_vot": "P2",
+      "reconstructed_max_vot": "P2",
+      "is_valid": true,
+      "verification_outcome": "SUCCESS",
+      "vot": "P2",
+      "expired": false
+    },
+    "restricted": {
+      "reconstructedSignatures": {},
+      "sisSignatures": {}
+    }
+  },
+  {
     "event_name": "IPV_IDENTITY_REUSE_COMPLETE",
     "component_id": "https://identity.local.account.gov.uk",
     "extensions": {

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -92,7 +92,7 @@ Feature: Audit Events
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
-    And I activate the 'storedIdentityService,sisVerification' feature sets
+    And I activate the 'storedIdentityService' feature sets
     And I have an existing stored identity record with a 'P2' vot
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -92,7 +92,6 @@ Feature: Audit Events
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
-    And I activate the 'storedIdentityService' feature sets
     And I have an existing stored identity record with a 'P2' vot
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -271,11 +271,11 @@ class AppConfigServiceTest {
     @Test
     void featureSetsOverrideConfigurationInCorrectOrder() {
         // Act & Assert
-        configService.setFeatureSet(List.of("accountInterventions", "disableAccountInterventions"));
-        assertFalse(configService.enabled("accountInterventionsEnabled"));
+        configService.setFeatureSet(List.of("disableTestFeatureFlag", "enableTestFeatureFlag"));
+        assertTrue(configService.enabled("testFeatureFlag"));
 
-        configService.setFeatureSet(List.of("disableAccountInterventions", "accountInterventions"));
-        assertTrue(configService.enabled("accountInterventionsEnabled"));
+        configService.setFeatureSet(List.of("enableTestFeatureFlag", "disableTestFeatureFlag"));
+        assertFalse(configService.enabled("testFeatureFlag"));
     }
 
     @Test
@@ -297,8 +297,8 @@ class AppConfigServiceTest {
 
     @Test
     void enabledTrueIfFeatureFlagSetEnabled() {
-        configService.setFeatureSet(List.of("accountInterventions"));
-        assertTrue(configService.enabled("accountInterventionsEnabled"));
+        configService.setFeatureSet(List.of("enableTestFeatureFlag"));
+        assertTrue(configService.enabled("testFeatureFlag"));
     }
 
     @Test

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -357,7 +357,7 @@ core:
     drivingLicenceAuthCheck: true
     sorryTechnicalErrorEnabled: false
     storedIdentityServiceEnabled: false
-    sisVerificationEnabled: false
+    sisVerificationEnabled: true
     accountInterventionsEnabled: true
   features:
     testFeature:
@@ -372,9 +372,6 @@ core:
     storedIdentityService:
       featureFlags:
         storedIdentityServiceEnabled: true
-    sisVerification:
-      featureFlags:
-        sisVerificationEnabled: true
     clearUsersIdentity:
       featureFlags:
         resetIdentity: true

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -358,7 +358,17 @@ core:
     sorryTechnicalErrorEnabled: false
     storedIdentityServiceEnabled: true
     sisVerificationEnabled: true
+    testFeatureFlag: false
   features:
+    testFeature:
+      self:
+        componentId: alternate-component-id
+    enableTestFeatureFlag:
+      featureFlags:
+        testFeatureFlag: true
+    disableTestFeatureFlag:
+      featureFlags:
+        testFeatureFlag: false
     storedIdentityService:
       featureFlags:
         storedIdentityServiceEnabled: true

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -356,19 +356,9 @@ core:
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: true
     sorryTechnicalErrorEnabled: false
-    storedIdentityServiceEnabled: false
+    storedIdentityServiceEnabled: true
     sisVerificationEnabled: true
-    accountInterventionsEnabled: true
   features:
-    testFeature:
-      self:
-        componentId: alternate-component-id
-    accountInterventions:
-      featureFlags:
-        accountInterventionsEnabled: true
-    disableAccountInterventions:
-      featureFlags:
-        accountInterventionsEnabled: false
     storedIdentityService:
       featureFlags:
         storedIdentityServiceEnabled: true

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -360,15 +360,12 @@ core:
     drivingLicenceAuthCheck: true
     sorryTechnicalErrorEnabled: false
     storedIdentityServiceEnabled: true
-    sisVerificationEnabled: false
+    sisVerificationEnabled: true
 
   features:
     storedIdentityService:
       featureFlags:
         storedIdentityServiceEnabled: true
-    sisVerification:
-      featureFlags:
-        sisVerificationEnabled: true
     clearUsersIdentity:
       featureFlags:
         resetIdentity: true


### PR DESCRIPTION
DO NOT MERGE UNTIL WE GO LIVE - PLANNED ON THURSDAY

## Proposed changes
### What changed

- Changed sisVerification feature flag to true
- Adjusted api tests
- Adjusted tests fixtures

### Why did it change

- We are turning on SIS Phase 2 on Thursday. 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8628](https://govukverify.atlassian.net/browse/PYIC-8628)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8628]: https://govukverify.atlassian.net/browse/PYIC-8628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ