### PR TITLE
PYIC-8776: update process app callback to return problem-different-browser journey event

### DIFF
--- a/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
+++ b/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
@@ -47,6 +47,10 @@
   {
     "event_name": "IPV_ASYNC_CRI_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": null
+    },
     "extensions": {
       "iss": "https://dcmaw-async.stubs.account.gov.uk",
       "credential_issuer_id": "dcmawAsync",
@@ -75,7 +79,32 @@
   {
     "event_name": "IPV_ASYNC_CRI_VC_CONSUMED",
     "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": null
+    },
     "extensions": {
+      "iss": "https://dcmaw-async.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "checkDetails": [
+            {
+              "checkMethod": "vcrypt",
+              "identityCheckPolicy": "published"
+            },
+            {
+              "biometricVerificationProcessLevel": 3,
+              "checkMethod": "bvr"
+            }
+          ],
+          "strengthScore": 4,
+          "type": "IdentityCheck",
+          "validityScore": 3
+        }
+      ],
+      "successful": true,
+      "isUkIssued": true,
+      "age": "type[number]",
       "credential_issuer_id": "dcmawAsync"
     },
     "restricted": {
@@ -109,6 +138,9 @@
   {
     "event_name": "IPV_APP_SESSION_RECOVERED",
     "component_id": "https://identity.local.account.gov.uk",
+    "extensions": {
+      "previous_ipv_session_id": "type[string]"
+    },
     "restricted": {
       "device_information": {}
     }
@@ -248,6 +280,18 @@
       "newBirthDate": [
         {
           "value": "1965-07-08"
+        }
+      ],
+      "newAddress": [
+        {
+          "addressCountry": "GB",
+          "addressLocality": "BATH",
+          "buildingName": "",
+          "buildingNumber": "8",
+          "postalCode": "BA2 5AA",
+          "streetName": "HADLEY ROAD",
+          "subBuildingName": "",
+          "validFrom": "1000-01-01"
         }
       ],
       "device_information": {}

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -343,6 +343,10 @@ Feature: Audit Events
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session
+    Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+    When I submit a 'build-client-oauth-response' event in a separate session
     Then I get an OAuth response with error code 'access_denied'
     # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
     # has managed to log back in to the site.

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -343,8 +343,8 @@ Feature: Audit Events
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session
-    Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+    Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
     When I submit a 'build-client-oauth-response' event in a separate session
     Then I get an OAuth response with error code 'access_denied'

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -205,6 +205,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -241,6 +245,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -261,6 +269,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -285,6 +297,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -314,6 +330,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -334,6 +354,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -205,8 +205,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -245,8 +245,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -269,8 +269,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -297,8 +297,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -330,8 +330,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -354,8 +354,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
@@ -17,6 +17,10 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
     When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session
+    Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+    When I submit a 'build-client-oauth-response' event in a separate session
     Then I get an OAuth response with error code 'access_denied'
     # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
     # has managed to log back in to the site.

--- a/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app-dl-auth-source-check.feature
@@ -17,8 +17,8 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
     When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session
-    Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+    Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
     When I submit a 'build-client-oauth-response' event in a separate session
     Then I get an OAuth response with error code 'access_denied'

--- a/api-tests/features/strategic-app/p1-strategic-app.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app.feature
@@ -46,8 +46,8 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -79,8 +79,8 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -120,8 +120,8 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'

--- a/api-tests/features/strategic-app/p1-strategic-app.feature
+++ b/api-tests/features/strategic-app/p1-strategic-app.feature
@@ -46,6 +46,10 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -75,6 +79,10 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -112,6 +120,10 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -206,8 +206,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -246,8 +246,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -270,8 +270,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -298,8 +298,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -331,8 +331,8 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check-enhanced-verification-mitigation.feature
@@ -206,6 +206,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -242,6 +246,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -262,6 +270,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -286,6 +298,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -315,6 +331,10 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
@@ -17,6 +17,10 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
     When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session
+    Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+    When I submit a 'build-client-oauth-response' event in a separate session
     Then I get an OAuth response with error code 'access_denied'
     # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
     # has managed to log back in to the site.

--- a/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app-dl-auth-source-check.feature
@@ -17,8 +17,8 @@ Feature: M2B Strategic App Journeys with DL authoritative source check
     When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session
-    Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+    Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
     When I submit a 'build-client-oauth-response' event in a separate session
     Then I get an OAuth response with error code 'access_denied'

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -99,6 +99,10 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -130,6 +134,10 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.
@@ -167,6 +175,10 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
+      Then I get a 'cross-browser-problem' page response
+      # This simulates the user clicking continue on the cross-browser-problem
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
       # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
       # has managed to log back in to the site.

--- a/api-tests/features/strategic-app/p2-strategic-app.feature
+++ b/api-tests/features/strategic-app/p2-strategic-app.feature
@@ -99,8 +99,8 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -134,8 +134,8 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'
@@ -175,8 +175,8 @@ Feature: M2B Strategic App Journeys
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
-      Then I get a 'cross-browser-problem' page response
-      # This simulates the user clicking continue on the cross-browser-problem
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
       # page which sends a 'build-client-oauth-response' event to the journey engine
       When I submit a 'build-client-oauth-response' event in a separate session
       Then I get an OAuth response with error code 'access_denied'

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -536,9 +536,8 @@ When(
     }
 
     this.lastJourneyEngineResponse = await callbackFromStrategicApp(
-      this.oauthState,
+      this,
       separateSession ? undefined : this.ipvSessionId,
-      this.featureSet,
     );
   },
 );

--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -275,11 +275,15 @@ Then(
 );
 
 When(
-  "I submit a(n) {string} event",
-  async function (this: World, event: string): Promise<void> {
+  /I submit an? '([\w-]+)' event( in a separate session)?/,
+  async function (
+    this: World,
+    event: string,
+    separateSession: " in a separate session" | undefined,
+  ): Promise<void> {
     this.lastJourneyEngineResponse = await internalClient.sendJourneyEvent(
       event,
-      this.ipvSessionId,
+      separateSession ? undefined : this.ipvSessionId,
       this.featureSet,
       this.clientOAuthSessionId,
     );

--- a/api-tests/src/types/internal-api.ts
+++ b/api-tests/src/types/internal-api.ts
@@ -21,6 +21,7 @@ export type JourneyEngineResponse =
 
 export interface JourneyResponse {
   journey: string;
+  clientOAuthSessionId?: string;
 }
 
 export const isJourneyResponse = (

--- a/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
+++ b/lambdas/process-mobile-app-callback/src/main/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandler.java
@@ -41,7 +41,7 @@ import java.io.UncheckedIOException;
 import java.util.Objects;
 import java.util.Set;
 
-import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_CROSS_BROWSER_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_NEXT_PATH;
 
@@ -209,8 +209,7 @@ public class ProcessMobileAppCallbackHandler
                             new AuditRestrictedDeviceInformation(
                                     callbackRequest.getDeviceInformation())));
 
-            return new JourneyResponse(
-                    JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE_PATH, clientOAuthSessionId);
+            return new JourneyResponse(JOURNEY_CROSS_BROWSER_PATH, clientOAuthSessionId);
         }
 
         // Validate cri response item

--- a/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
+++ b/lambdas/process-mobile-app-callback/src/test/java/uk/gov/di/ipv/core/processmobileappcallback/ProcessMobileAppCallbackHandlerTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_CROSS_BROWSER_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_NEXT_PATH;
 
@@ -122,8 +122,7 @@ class ProcessMobileAppCallbackHandlerTest {
         var journeyResponse =
                 OBJECT_MAPPER.readValue(lambdaResponse.getBody(), JourneyResponse.class);
         assertEquals(
-                new JourneyResponse(
-                        JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE_PATH, TEST_CLIENT_OAUTH_SESSION_ID),
+                new JourneyResponse(JOURNEY_CROSS_BROWSER_PATH, TEST_CLIENT_OAUTH_SESSION_ID),
                 journeyResponse);
         verify(auditService).sendAuditEvent(auditEventArgumentCaptor.capture());
         assertEquals(
@@ -167,8 +166,7 @@ class ProcessMobileAppCallbackHandlerTest {
         var journeyResponse =
                 OBJECT_MAPPER.readValue(lambdaResponse.getBody(), JourneyResponse.class);
         assertEquals(
-                new JourneyResponse(
-                        JOURNEY_BUILD_CLIENT_OAUTH_RESPONSE_PATH, TEST_CLIENT_OAUTH_SESSION_ID),
+                new JourneyResponse(JOURNEY_CROSS_BROWSER_PATH, TEST_CLIENT_OAUTH_SESSION_ID),
                 journeyResponse);
         verify(auditService).sendAuditEvent(auditEventArgumentCaptor.capture());
         assertEquals(


### PR DESCRIPTION
❗ Note: this needs to be merged in after the change to update `process-journey-event` to support the new journey event (done as part of this [PR](https://github.com/govuk-one-login/ipv-core-back/pull/3598)). This is so that, during canary deployment, when a "new" version of `process-mobile-app-callback` returns the new cross-browser event and core-front uses an "old" version of the `process-journey-event` lambda, the new cross-browser event is already supported and so won't break a user's journey.

## Proposed changes
### What changed

- updates `process-mobile-app-callback` lambda to return the new `problem-different-browser` journey event
- updated api tests
- updated the fields in the `strategic-app-cross-browser-journey.json` so that we're checking for more fields 

### Why did it change

- When core-front receives this event and sends it to the journey engine, the journey engine will direct the user straight to the new `cross-browser-problem` page.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8776](https://govukverify.atlassian.net/browse/PYIC-8776)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8776]: https://govukverify.atlassian.net/browse/PYIC-8776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ