### PR TITLE
PYIC-8800: Update F2F error routing for mitigation paths

### DIFF
--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -516,3 +516,79 @@ Feature: Handling unexpected CRI errors
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P1' identity
+
+  Rule: F2F CRI mitigation via Experian KBV
+    Background: Route to sorry-technical-problem F2F mitigation error page
+      Given I activate the 'sorryTechnicalError' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When I submit a 'preferNoApp' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-security-questions-find-another-way' page response
+
+    Scenario: Mitigation via F2F – switch to app after error
+      When I submit a 'f2f' event
+      Then I get a 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'sorry-technical-problem' page response with context 'kbvMitigation'
+      When I submit a 'app' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit a 'appTriage' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+
+    Scenario: Separate session F2F enhanced verification mitigation - user fails KBV - mitigate via F2F
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-identity-document-start' page response
+      When I submit a 'appTriage' event
+      Then I get a 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -553,7 +553,20 @@ Feature: Handling unexpected CRI errors
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
       Then I get a 'photo-id-security-questions-find-another-way' page response
 
-    Scenario: Mitigation via F2F – switch to app after error
+    Scenario: Same session mitigation via F2F - return to RP
+      When I submit a 'f2f' event
+      Then I get a 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'sorry-technical-problem' page response with context 'kbvMitigation'
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+
+    Scenario: Same session mitigation via F2F - switch to app after error
       When I submit a 'f2f' event
       Then I get a 'f2f' CRI response
       When I call the CRI stub with attributes and get a 'server_error' OAuth error
@@ -561,34 +574,64 @@ Feature: Handling unexpected CRI errors
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
       Then I get a 'sorry-technical-problem' page response with context 'kbvMitigation'
       When I submit a 'app' event
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit a 'appTriage' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
-        # And the user returns from the app to core-front
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
       When I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
 
     Scenario: Separate session F2F enhanced verification mitigation - user fails KBV - mitigate via F2F
       # Return journey
       When I start new 'medium-confidence' journeys until I get a 'page-ipv-identity-document-start' page response
-      When I submit a 'appTriage' event
-      Then I get a 'identify-device' page response
+      And I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'sorry-technical-problem' page response with context 'kbvMitigation'
+      When I submit a 'app' event
+      Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
       Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
       When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
-        # And the user returns from the app to core-front
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
       When I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
-      Then I get a 'page-dcmaw-success' page response
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -104,6 +104,9 @@ states:
         checkFeatureFlag:
           sorryTechnicalErrorEnabled:
             targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_F2F
+            checkMitigation:
+              enhanced-mitigation:
+                targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_MITIGATION_F2F
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
@@ -117,19 +120,30 @@ states:
       tryAgain:
         targetState: CRI_F2F
       app:
-        checkMitigation:
-          enhanced-verification:
-            targetJourney: NEW_P2_IDENTITY
-            targetState: APP_DOC_CHECK_PYI_ESCAPE
-            targetEntryEvent: next
         targetState: RESET_SESSION_BEFORE_IDENTITY_DOCUMENT_START
       webRoute:
-        checkMitigation:
-          enhanced-verification:
+        targetState: RESET_SESSION_BEFORE_DCMAW_ASYNC_ANOTHER_WAY
+      returnToRp:
+        targetState: RETURN_TO_RP
+
+  SORRY_CRI_TECHNICAL_PROBLEM_CRI_MITIGATION_F2F:
+    response:
+      type: page
+      pageId: sorry-technical-problem
+      context: kbvMitigation
+    events:
+      tryAgain:
+        targetState: CRI_F2F
+      app:
+        checkJourneyContext:
+          medium-confidence:
             targetJourney: NEW_P2_IDENTITY
             targetState: APP_DOC_CHECK_PYI_ESCAPE
             targetEntryEvent: next
-        targetState: RESET_SESSION_BEFORE_DCMAW_ASYNC_ANOTHER_WAY
+          low-confidence:
+            targetJourney: NEW_P1_IDENTITY
+            targetState: APP_DOC_CHECK_PYI_ESCAPE
+            targetEntryEvent: next
       returnToRp:
         targetState: RETURN_TO_RP
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -117,8 +117,18 @@ states:
       tryAgain:
         targetState: CRI_F2F
       app:
+        checkMitigation:
+          enhanced-verification:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: APP_DOC_CHECK_PYI_ESCAPE
+            targetEntryEvent: next
         targetState: RESET_SESSION_BEFORE_IDENTITY_DOCUMENT_START
       webRoute:
+        checkMitigation:
+          enhanced-verification:
+            targetJourney: NEW_P2_IDENTITY
+            targetState: APP_DOC_CHECK_PYI_ESCAPE
+            targetEntryEvent: next
         targetState: RESET_SESSION_BEFORE_DCMAW_ASYNC_ANOTHER_WAY
       returnToRp:
         targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -140,10 +140,10 @@ states:
         checkJourneyContext:
           mediumConfidence:
             targetJourney: NEW_P2_IDENTITY
-            targetState: START
+            targetState: KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD
           lowConfidence:
             targetJourney: NEW_P1_IDENTITY
-            targetState: START
+            targetState: KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD
       returnToRp:
         targetState: RETURN_TO_RP
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -105,7 +105,7 @@ states:
           sorryTechnicalErrorEnabled:
             targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_F2F
             checkMitigation:
-              enhanced-mitigation:
+              enhanced-verification:
                 targetState: SORRY_CRI_TECHNICAL_PROBLEM_CRI_MITIGATION_F2F
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
@@ -135,15 +135,15 @@ states:
       tryAgain:
         targetState: CRI_F2F
       app:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
         checkJourneyContext:
-          medium-confidence:
+          mediumConfidence:
             targetJourney: NEW_P2_IDENTITY
-            targetState: APP_DOC_CHECK_PYI_ESCAPE
-            targetEntryEvent: next
-          low-confidence:
+            targetState: START
+          lowConfidence:
             targetJourney: NEW_P1_IDENTITY
-            targetState: APP_DOC_CHECK_PYI_ESCAPE
-            targetEntryEvent: next
+            targetState: START
       returnToRp:
         targetState: RETURN_TO_RP
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -24,6 +24,20 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
+  KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
+    events:
+      next:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+            targetEntryEvent: appTriage
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
   DCMAW_ASYNC_ANOTHER_WAY:
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -24,6 +24,20 @@ states:
             auditContext:
               mitigationType: enhanced-verification
 
+  KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
+    events:
+      next:
+        targetState: APP_DOC_CHECK_PYI_ESCAPE
+        targetEntryEvent: next
+        checkFeatureFlag:
+          strategicAppEnabled:
+            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+            targetEntryEvent: appTriage
+        checkIfDisabled:
+          dcmaw:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
   DCMAW_ASYNC_ANOTHER_WAY:
     events:
       next:


### PR DESCRIPTION
## Proposed changes
### What changed

- Update F2F error routing for mitigation paths
- Route V03 F2F errors via sorryTechnicalErrorEnabled mitigation flow

### Why did it change

- We have new error screens and routing for handling unexpected outages for the Passport, Driving Licence, KBV and F2F CRIs. However, the current routing allows for users to go down unnecessary routes when on a mitigation journey.

For example, this user flow:
User starts IPV through the web route via Passport CRI → gets a ...
User redirected to DL CRI → CRI server_errors
User shown new sorry-technical-problem page - shown options to go through the app or post office

Neither of these options allow mitigating the ... from the passport CRI and so will fail regardless of the documents the user re-submits, sending them down unnecessary journeys.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8800](https://govukverify.atlassian.net/browse/PYIC-8800)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8800]: https://govukverify.atlassian.net/browse/PYIC-8800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ