### PR TITLE
PYIC-8824: update generateUserIdentity to only include successful and…

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -7,7 +7,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     SQS_ASYNC("sqsAsync"),
     DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
     STORED_IDENTITY_SERVICE("storedIdentityServiceEnabled"),
-    SIS_VERIFICATION("sisVerificationEnabled");
+    SIS_VERIFICATION("sisVerificationEnabled"),
+    FILTER_FAILED_VCS_FROM_CREDENTIAL_CLAIM("filterFailedVcsFromCredentialsClaim");
 
     private final String name;
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -463,6 +463,16 @@ public interface VcFixtures {
         return vcClaim;
     }
 
+    static IdentityCheckCredential vcClaimDcmawPassportFailedNoBirthDate() {
+        var vcClaim = vcClaimDcmawDrivingPermitDva();
+        vcClaim.getCredentialSubject().setDrivingPermit(null);
+        vcClaim.getCredentialSubject().setBirthDate(null);
+        vcClaim.getCredentialSubject().setPassport(passportDetails());
+        vcClaim.getEvidence().getFirst().setStrengthScore(0);
+
+        return vcClaim;
+    }
+
     private static IdentityCheckCredential vcClaimF2fPassportPhoto() {
         return IdentityCheckCredential.builder()
                 .withType(
@@ -1255,6 +1265,15 @@ public interface VcFixtures {
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
                 DCMAW,
                 vcClaimDcmawPassport(),
+                DCMAW_ISSUER_STAGING,
+                Instant.ofEpochSecond(1705986521));
+    }
+
+    static VerifiableCredential vcDcmawFailedPassport() {
+        return generateVerifiableCredential(
+                "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
+                DCMAW,
+                vcClaimDcmawPassportFailedNoBirthDate(),
                 DCMAW_ISSUER_STAGING,
                 Instant.ofEpochSecond(1705986521));
     }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -74,7 +74,15 @@ public class UserIdentityService {
             Vot targetVot,
             List<ContraIndicator> contraIndicators)
             throws HttpResponseExceptionWithErrorBody, UnrecognisedCiException {
-        var vcJwts = vcs.stream().map(VerifiableCredential::getVcString).toList();
+        var vcJwts =
+                vcs.stream()
+                        .filter(
+                                vc ->
+                                        VcHelper.isSuccessfulVc(vc)
+                                                || VcHelper.hasUnavailableOrNotApplicableFraudCheck(
+                                                        List.of(vc)))
+                        .map(VerifiableCredential::getVcString)
+                        .toList();
 
         var vtm = configService.getCoreVtmClaim();
 

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
@@ -69,7 +69,10 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcAddressNoCredenti
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcAddressOne;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcAddressTwo;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawDrivingPermitDvaM1b;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawFailedPassport;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawPassport;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudApplicableAuthoritativeSourceFailed;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudAvailableAuthoritativeFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudMissingName;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreOne;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreTwo;
@@ -1415,6 +1418,41 @@ class UserIdentityServiceTest {
 
         // Assert
         assertNull(credentials.getDrivingPermitClaim());
+    }
+
+    @Test
+    void generateUSerIdentityShouldReturnOnlySuccessfulVcsAndValidFraudVcs() throws Exception {
+        // Arrange
+        var validDrivingPermit = vcWebDrivingPermitDvaValid();
+        var failedPassport = vcDcmawFailedPassport();
+        var validAddress = vcAddressOne();
+        var validFraudApplicableAuthoritativeSource =
+                vcExperianFraudApplicableAuthoritativeSourceFailed();
+        var validFraudAvailableAuthoritativeSource = vcExperianFraudAvailableAuthoritativeFailed();
+        var vcs =
+                List.of(
+                        validDrivingPermit,
+                        failedPassport,
+                        validAddress,
+                        validFraudApplicableAuthoritativeSource,
+                        validFraudAvailableAuthoritativeSource);
+
+        useP2Defaults();
+
+        // Act
+        var credentials =
+                userIdentityService.generateUserIdentity(
+                        vcs, "test-sub", Vot.P2, Vot.P2, emptyContraIndicators);
+
+        // Assert
+        assertEquals(4, credentials.getVcs().size());
+        assertEquals(
+                List.of(
+                        validDrivingPermit.getVcString(),
+                        validAddress.getVcString(),
+                        validFraudApplicableAuthoritativeSource.getVcString(),
+                        validFraudAvailableAuthoritativeSource.getVcString()),
+                credentials.getVcs());
     }
 
     @Test

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
@@ -59,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.quality.Strictness.LENIENT;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.FILTER_FAILED_VCS_FROM_CREDENTIAL_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.Cri.BAV;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
@@ -1437,6 +1438,7 @@ class UserIdentityServiceTest {
                         validFraudApplicableAuthoritativeSource,
                         validFraudAvailableAuthoritativeSource);
 
+        when(mockConfigService.enabled(FILTER_FAILED_VCS_FROM_CREDENTIAL_CLAIM)).thenReturn(true);
         useP2Defaults();
 
         // Act


### PR DESCRIPTION
… M1C fraud VCs in the user identity vcs claim

## Proposed changes
### What changed

- generateUserIdentiy filters the vcs (used for the vc claim) to only use successful (non-zero scoring) vcs and the M1C fraud vcs

### Why did it change

- SPOT is rejecting users with no birthdate claim in their VCs. These VCs they get from the user identity bundle that core sends to orch. This appears on zero-scoring VCs e.g. failing the app and switching to the web route.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8824](https://govukverify.atlassian.net/browse/PYIC-8824)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8824]: https://govukverify.atlassian.net/browse/PYIC-8824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ