### PR TITLE
PYIC-8797: record high resolution identityReuse and identityProving metrics

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -359,6 +359,7 @@ public class CheckExistingIdentityHandler
             // journey
             if (isReproveIdentity && !isReprovingWithF2f(asyncCriStatus, credentialBundle)
                     || configService.enabled(RESET_IDENTITY)) {
+                EmbeddedMetricHelper.identityProving();
                 if (targetVot == Vot.P1) {
                     LOGGER.info(LogHelper.buildLogMessage("Reproving P1 identity"));
                     return JOURNEY_REPROVE_IDENTITY_GPG45_LOW;
@@ -621,6 +622,7 @@ public class CheckExistingIdentityHandler
                     auditEventUser.getSessionId(),
                     false);
 
+            EmbeddedMetricHelper.identityProving();
             return JOURNEY_REPEAT_FRAUD_CHECK;
         }
 
@@ -645,6 +647,7 @@ public class CheckExistingIdentityHandler
 
     private JourneyResponse getNewIdentityJourney(Vot preferredNewIdentityLevel)
             throws HttpResponseExceptionWithErrorBody {
+        EmbeddedMetricHelper.identityProving();
         switch (preferredNewIdentityLevel) {
             case P1 -> {
                 LOGGER.info(LogHelper.buildLogMessage("New P1 IPV journey required"));

--- a/lambdas/check-reverification-identity/src/main/java/uk/gov/di/ipv/core/checkreverificationidentity/CheckReverificationIdentityHandler.java
+++ b/lambdas/check-reverification-identity/src/main/java/uk/gov/di/ipv/core/checkreverificationidentity/CheckReverificationIdentityHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45ProfileEvaluator;
+import uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.service.CimitUtilityService;
@@ -122,6 +123,7 @@ public class CheckReverificationIdentityHandler
                 return NOT_FOUND_RESPONSE;
             }
 
+            EmbeddedMetricHelper.identityProving();
             return FOUND_RESPONSE;
 
         } catch (HttpResponseExceptionWithErrorBody | EvcsServiceException e) {

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -39,6 +39,9 @@ states:
       eventWithUnsetJourneyContext:
         targetState: ANOTHER_PAGE_STATE
         journeyContextToUnset: someContext
+      eventToTransitionToUpdateSubJourney:
+        targetJourney: UPDATE_NAME
+        targetState: START
 
   CRI_STATE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/update-name.yaml
@@ -1,0 +1,15 @@
+name: Update Name
+
+states:
+  START:
+    events:
+      next:
+        targetState: UPDATE_NAME_PAGE
+
+  UPDATE_NAME_PAGE:
+    response:
+      type: page
+      pageId: update-name
+    events:
+      next:
+        targetState: PROCESS_STATE

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -15,6 +15,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
@@ -31,6 +32,7 @@ import uk.gov.di.ipv.core.library.domain.ScopeConstants;
 import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.exceptions.IpvSessionNotFoundException;
+import uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
@@ -58,6 +60,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -67,6 +71,7 @@ import static uk.gov.di.ipv.core.library.auditing.AuditEventTypes.IPV_NO_PHOTO_I
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.INITIAL_JOURNEY_SELECTION;
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.SESSION_TIMEOUT;
 import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.TECHNICAL_ERROR;
+import static uk.gov.di.ipv.core.library.domain.IpvJourneyTypes.UPDATE_NAME;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.SIGNED_CONTRA_INDICATOR_VC_1;
 
 @ExtendWith(MockitoExtension.class)
@@ -1314,6 +1319,55 @@ class ProcessJourneyEventHandlerTest {
         assertThat(logMessage, containsString("Test error"));
     }
 
+    @Test
+    void shouldRecordIdentityProvingMetricIfTransitioningToAnUpdateJourney() throws Exception {
+        var spyIpvSessionItem = mockIpvSessionItemAndTimeout("PAGE_STATE");
+        spyIpvSessionItem.setJourneyContext("someContext");
+
+        var input =
+                JourneyRequest.builder()
+                        .ipAddress(TEST_IP)
+                        .journey("eventToTransitionToUpdateSubJourney")
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .build();
+
+        var processJourneyEventHandler =
+                getProcessJourneyStepHandler(StateMachineInitializerMode.TEST);
+
+        try (MockedStatic<EmbeddedMetricHelper> mockEmbeddedMetricHelper =
+                mockStatic(EmbeddedMetricHelper.class)) {
+            var output = processJourneyEventHandler.handleRequest(input, mockContext);
+
+            mockEmbeddedMetricHelper.verify(EmbeddedMetricHelper::identityProving);
+            assertEquals("update-name", output.get("page"));
+        }
+    }
+
+    @Test
+    void shouldNotRecordIdentityProvingMetricIfTransitioningToAnUpdateJourneyDuringRfc()
+            throws Exception {
+        var spyIpvSessionItem = mockIpvSessionItemAndTimeout("PAGE_STATE");
+        spyIpvSessionItem.setJourneyContext("rfc");
+
+        var input =
+                JourneyRequest.builder()
+                        .ipAddress(TEST_IP)
+                        .journey("eventToTransitionToUpdateSubJourney")
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .build();
+
+        var processJourneyEventHandler =
+                getProcessJourneyStepHandler(StateMachineInitializerMode.TEST);
+
+        try (MockedStatic<EmbeddedMetricHelper> mockEmbeddedMetricHelper =
+                mockStatic(EmbeddedMetricHelper.class)) {
+            var output = processJourneyEventHandler.handleRequest(input, mockContext);
+
+            mockEmbeddedMetricHelper.verify(EmbeddedMetricHelper::identityProving, never());
+            assertEquals("update-name", output.get("page"));
+        }
+    }
+
     private IpvSessionItem mockIpvSessionItemAndTimeout(String userState) throws Exception {
         IpvSessionItem ipvSessionItem = spy(IpvSessionItem.class);
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
@@ -1350,7 +1404,7 @@ class ProcessJourneyEventHandlerTest {
 
         var journeyTypes =
                 stateMachineInitializerMode.equals(StateMachineInitializerMode.TEST)
-                        ? List.of(INITIAL_JOURNEY_SELECTION, TECHNICAL_ERROR)
+                        ? List.of(INITIAL_JOURNEY_SELECTION, TECHNICAL_ERROR, UPDATE_NAME)
                         : List.of(IpvJourneyTypes.values());
 
         var nestedJourneyTypes =

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/EmbeddedMetricHelper.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/helpers/EmbeddedMetricHelper.java
@@ -30,6 +30,7 @@ import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.CRI
 import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.IDENTITY_ISSUED;
 import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.IDENTITY_JOURNEY_COMPLETE;
 import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.IDENTITY_JOURNEY_START;
+import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.IDENTITY_PROVING;
 import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.IDENTITY_REUSE;
 import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.PROFILE_MATCH;
 import static uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper.Metric.REVERIFY_JOURNEY_COMPLETE;
@@ -51,6 +52,7 @@ public class EmbeddedMetricHelper {
         IDENTITY_ISSUED("identityIssued"),
         IDENTITY_JOURNEY_START("identityJourneyStart"),
         IDENTITY_JOURNEY_COMPLETE("identityJourneyComplete"),
+        IDENTITY_PROVING("identityProving"),
         IDENTITY_REUSE("identityReuse"),
         PROFILE_MATCH("profileMatch"),
         REVERIFY_JOURNEY_START("reverifyJourneyStart"),
@@ -109,6 +111,10 @@ public class EmbeddedMetricHelper {
 
     public static void identityReuse() {
         recordHighResolutionMetric(Map.of(), Map.of(IDENTITY_REUSE, 1.0));
+    }
+
+    public static void identityProving() {
+        recordHighResolutionMetric(Map.of(), Map.of(IDENTITY_PROVING, 1.0));
     }
 
     public static void profileMatch(Gpg45Profile matchedProfile) {


### PR DESCRIPTION
## Proposed changes
### What changed

- record the existing `identityReuse` at high resolution*. This is recorded only for reuse journeys.
- add new `identityProving` high resolution metric. This is recorded for the following journeys:
  - new identity proving
  - separate session mitigations
  - repeat fraud check
  - update journeys
  - reprove identity
  - mfa reset (if they have an identity, as they require an identity to go through the identity proving part of mfa reset)

Notes:
*high resolution metrics are data with granularity of one second
- we don't record identityProving for DCMAW async recovery scenarios (ie an app user experiences cross-broswer issue) since then we'd be counting twice for a single proving journey

### Why did it change

- We want to report more granularly on journeys/second and be able to break this down by reuse and proving.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8797](https://govukverify.atlassian.net/browse/PYIC-8797)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8797]: https://govukverify.atlassian.net/browse/PYIC-8797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ