### PR TITLE
PYIC-8845: Add relevant paths to path-ignore in secure-post-merge GHA.

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**/README.md'
+      # If you are adding or removing from this list, also update 'files_ignore' in check-if-deploy-needed job
+      - '**/*.md'
       - 'lambdas/*/src/test/**'
+      - 'libs/*/src/test/**'
+      - 'libs/test-data/**'
+      - 'libs/test-helpers/**'
       - 'journey-map/**'
+      - 'local-running/**'
   workflow_dispatch:
 
 jobs:
@@ -49,9 +54,38 @@ jobs:
       packages: read
       contents: read
 
+  check-if-deploy-needed:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy-needed: ${{ steps.check-if-should-deploy.outputs.any_changed }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get relevant changed files
+        id: check-if-should-deploy
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
+        with:
+          files: |
+            **
+          # We want to skip api-tests folder here as we don't want it to trigger deployment.
+          files_ignore: |
+            api-tests/**
+            **/*.md
+            lambdas/*/src/test/**
+            libs/*/src/test/**
+            libs/test-data/**
+            libs/test-helpers/**
+            journey-map/**
+            local-running/**
+
   deploy:
-    needs: build-test-images-if-needed
-    if: '!failure()'
+    needs:
+      - build-test-images-if-needed
+      - check-if-deploy-needed
+    if: ${{ needs.check-if-deploy-needed.outputs.deploy-needed == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Proposed changes
### What changed

- Add to path-ignore to GHA (secure-post-merge.yml‎):
      - '\*\*/\*.md'
      - 'lambdas/\*/src/test/\*\*'
      - 'libs/\*/src/test/\*\*'
      - 'libs/test-data/\*\*'
      - 'libs/test-helpers/\*\*'
      - 'journey-map/\*\*'
      - 'local-running/\*\*'

- Add check-if-deploy-needed to trigger deployment if relevant files was changed.

### Why did it change

- To avoid unnecessary core-back deployment

Currently, the deployment of the API test image is tied to secure-post-merge.yml in GitHub Actions. We want to ensure that the API test image is deployed even when changes do not include the 'production' code.

Adding API tests to ignored paths is not feasible, as it would prevent the deployment of the test image when only those tests are modified.

Splitting the GitHub Actions workflow is also challenging, because we want the API test image to always be deployed before deploying the core-back application. Using the changed-files action provides a convenient solution to achieve this behaviour.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8845](https://govukverify.atlassian.net/browse/PYIC-8845)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8845]: https://govukverify.atlassian.net/browse/PYIC-8845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ