### PR TITLE
PYIC-8824: remove use of filterFailedVcsFromCredentialsClaim feature set

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -7,8 +7,7 @@ public enum CoreFeatureFlag implements FeatureFlag {
     SQS_ASYNC("sqsAsync"),
     DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
     STORED_IDENTITY_SERVICE("storedIdentityServiceEnabled"),
-    SIS_VERIFICATION("sisVerificationEnabled"),
-    FILTER_FAILED_VCS_FROM_CREDENTIAL_CLAIM("filterFailedVcsFromCredentialsClaim");
+    SIS_VERIFICATION("sisVerificationEnabled");
 
     private final String name;
 

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -45,7 +45,6 @@ import java.util.stream.Collectors;
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_SERVER_ERROR;
 import static java.util.Objects.requireNonNullElse;
 import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.FILTER_FAILED_VCS_FROM_CREDENTIAL_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.VocabConstants.VOT_CLAIM_NAME;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_BIRTH_DATE;
@@ -76,16 +75,15 @@ public class UserIdentityService {
             List<ContraIndicator> contraIndicators)
             throws HttpResponseExceptionWithErrorBody, UnrecognisedCiException {
 
-        var vcJwtsStream = vcs.stream();
-        if (configService.enabled(FILTER_FAILED_VCS_FROM_CREDENTIAL_CLAIM)) {
-            vcJwtsStream =
-                    vcJwtsStream.filter(
-                            vc ->
-                                    VcHelper.isSuccessfulVc(vc)
-                                            || VcHelper.hasUnavailableOrNotApplicableFraudCheck(
-                                                    List.of(vc)));
-        }
-        var vcJwts = vcJwtsStream.map(VerifiableCredential::getVcString).toList();
+        var vcJwts =
+                vcs.stream()
+                        .filter(
+                                vc ->
+                                        VcHelper.isSuccessfulVc(vc)
+                                                || VcHelper.hasUnavailableOrNotApplicableFraudCheck(
+                                                        List.of(vc)))
+                        .map(VerifiableCredential::getVcString)
+                        .toList();
 
         var vtm = configService.getCoreVtmClaim();
 

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
@@ -59,7 +59,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.quality.Strictness.LENIENT;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.FILTER_FAILED_VCS_FROM_CREDENTIAL_CLAIM;
 import static uk.gov.di.ipv.core.library.domain.Cri.ADDRESS;
 import static uk.gov.di.ipv.core.library.domain.Cri.BAV;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
@@ -1422,7 +1421,7 @@ class UserIdentityServiceTest {
     }
 
     @Test
-    void generateUSerIdentityShouldReturnOnlySuccessfulVcsAndValidFraudVcs() throws Exception {
+    void generateUserIdentityShouldReturnOnlySuccessfulVcsAndValidFraudVcs() throws Exception {
         // Arrange
         var validDrivingPermit = vcWebDrivingPermitDvaValid();
         var failedPassport = vcDcmawFailedPassport();
@@ -1438,7 +1437,6 @@ class UserIdentityServiceTest {
                         validFraudApplicableAuthoritativeSource,
                         validFraudAvailableAuthoritativeSource);
 
-        when(mockConfigService.enabled(FILTER_FAILED_VCS_FROM_CREDENTIAL_CLAIM)).thenReturn(true);
         useP2Defaults();
 
         // Act


### PR DESCRIPTION
❗ This needs to be merged before the core-common-infra PR: https://github.com/govuk-one-login/ipv-core-common-infra/pull/1443

## Proposed changes
### What changed

- remove use of filterFailedVcsFromCredentialsClaim feature set

### Why did it change

- This was being used to hide VC filtering when generating the user's credential bundle so it could be tested in staging. This has been enabled in prod now so we don't need it anymore.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8824](https://govukverify.atlassian.net/browse/PYIC-8824)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8824]: https://govukverify.atlassian.net/browse/PYIC-8824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ