### PR TITLE
PYIC-8843: Exclude vulnerable module tika-parser-pdf-module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,13 @@ subprojects {
 }
 
 allprojects {
+    configurations.configureEach {
+        resolutionStrategy {
+            // Remove once pact pulls in this or a newer version
+            force 'org.apache.tika:tika-core:3.2.3'
+        }
+    }
+
 	plugins.withType(JavaPlugin).whenPluginAdded {
 		dependencies {
 			constraints {

--- a/build.gradle
+++ b/build.gradle
@@ -48,12 +48,12 @@ subprojects {
 }
 
 allprojects {
-    configurations.configureEach {
-        resolutionStrategy {
-            // Remove once pact pulls in this or a newer version
-            force 'org.apache.tika:tika-core:3.2.3'
-        }
-    }
+	configurations.configureEach {
+		resolutionStrategy {
+			// Remove once pact pulls in this or a newer version
+			force 'org.apache.tika:tika-core:3.2.3'
+		}
+	}
 
 	plugins.withType(JavaPlugin).whenPluginAdded {
 		dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -49,10 +49,7 @@ subprojects {
 
 allprojects {
 	configurations.configureEach {
-		resolutionStrategy {
-			// Remove once pact pulls in this or a newer version
-			force 'org.apache.tika:tika-core:3.2.3'
-		}
+		exclude group: 'org.apache.tika', module: 'tika-parser-pdf-module'
 	}
 
 	plugins.withType(JavaPlugin).whenPluginAdded {

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/TokenTests.java
@@ -70,11 +70,6 @@ class TokenTests {
                 .uponReceiving("Valid auth code")
                 .path("/token")
                 .method("POST")
-                .headers(
-                        "x-api-key",
-                        PRIVATE_API_KEY,
-                        "Content-Type",
-                        "application/x-www-form-urlencoded; charset=UTF-8")
                 .body(
                         "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=dummyAuthCode&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fidentity.staging.account.gov.uk%2Fcredential-issuer%2Fcallback%3Fid%3Daddress&client_assertion="
                                 + CLIENT_ASSERTION_HEADER
@@ -82,6 +77,11 @@ class TokenTests {
                                 + CLIENT_ASSERTION_BODY
                                 + "."
                                 + CLIENT_ASSERTION_SIGNATURE)
+                .headers(
+                        "x-api-key",
+                        PRIVATE_API_KEY,
+                        "Content-Type",
+                        "application/x-www-form-urlencoded; charset=UTF-8")
                 .willRespondWith()
                 .status(200)
                 .body(

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/TokenTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/TokenTests.java
@@ -70,6 +70,11 @@ class TokenTests {
                 .uponReceiving("Valid auth code")
                 .path("/token")
                 .method("POST")
+                .headers(
+                        "x-api-key",
+                        PRIVATE_API_KEY,
+                        "Content-Type",
+                        "application/x-www-form-urlencoded; charset=UTF-8")
                 .body(
                         "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&code=dummyAuthCode&grant_type=authorization_code&redirect_uri=https%3A%2F%2Fidentity.staging.account.gov.uk%2Fcredential-issuer%2Fcallback%3Fid%3Daddress&client_assertion="
                                 + CLIENT_ASSERTION_HEADER
@@ -77,11 +82,6 @@ class TokenTests {
                                 + CLIENT_ASSERTION_BODY
                                 + "."
                                 + CLIENT_ASSERTION_SIGNATURE)
-                .headers(
-                        "x-api-key",
-                        PRIVATE_API_KEY,
-                        "Content-Type",
-                        "application/x-www-form-urlencoded; charset=UTF-8")
                 .willRespondWith()
                 .status(200)
                 .body(


### PR DESCRIPTION
Versions up to and including 3.2.1 are vulnerable to attack (although not in code that we use)

## Proposed changes
### What changed

Exclude tika-parser-pdf-module

### Why did it change

It is the entry point for a critical vulnerability (that we are probably not exposed to) and we cannot currently update Tika as it is a transitive dependency brought in by PACT

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8843](https://govukverify.atlassian.net/browse/PYIC-8843)


[PYIC-8843]: https://govukverify.atlassian.net/browse/PYIC-8843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ