### PR TITLE
BAU Forward async VC message journey ids to CIMIT

### DIFF
--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -229,12 +229,14 @@ public class ProcessAsyncCriCredentialHandler
                         oauthCriConfig.getSigningKey(),
                         oauthCriConfig.getComponentId());
 
+        var journeyId = extractJourneyIdFromSqsMessage(successAsyncCriResponse).orElse(null);
+
         for (var vc : vcs) {
             var auditEventUser = new AuditEventUser(userId, null, null, null);
             sendIpvVcReceivedAuditEvent(auditEventUser, vc, cri, VcHelper.isSuccessfulVc(vc));
 
-            submitVcToCiStorage(vc);
-            postMitigatingVc(vc);
+            submitVcToCiStorage(vc, journeyId);
+            postMitigatingVc(vc, journeyId);
             evcsService.storePendingVc(vc);
             sendIpvVcConsumedAuditEvent(auditEventUser, vc, cri, VcHelper.isSuccessfulVc(vc));
         }
@@ -329,12 +331,14 @@ public class ProcessAsyncCriCredentialHandler
         auditService.sendAuditEvent(auditEvent);
     }
 
-    private void submitVcToCiStorage(VerifiableCredential vc) throws CiPutException {
-        cimitService.submitVC(vc, null, null);
+    private void submitVcToCiStorage(VerifiableCredential vc, String journeyId)
+            throws CiPutException {
+        cimitService.submitVC(vc, journeyId, null);
     }
 
-    private void postMitigatingVc(VerifiableCredential vc) throws CiPostMitigationsException {
-        cimitService.submitMitigatingVcList(List.of(vc), null, null);
+    private void postMitigatingVc(VerifiableCredential vc, String journeyId)
+            throws CiPostMitigationsException {
+        cimitService.submitMitigatingVcList(List.of(vc), journeyId, null);
     }
 
     private String extractQueueName(SQSEvent event) {

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -227,7 +227,7 @@ class ProcessAsyncCriCredentialHandlerTest {
 
         doThrow(new CiPutException("Lambda execution failed"))
                 .when(cimitService)
-                .submitVC(any(VerifiableCredential.class), eq(null), eq(null));
+                .submitVC(any(VerifiableCredential.class), any(), eq(null));
 
         final SQSBatchResponse batchResponse = handler.handleRequest(testEvent, null);
 
@@ -258,7 +258,7 @@ class ProcessAsyncCriCredentialHandlerTest {
 
         doThrow(new CiPostMitigationsException("Lambda execution failed"))
                 .when(cimitService)
-                .submitMitigatingVcList(anyList(), eq(null), eq(null));
+                .submitMitigatingVcList(anyList(), any(), eq(null));
 
         final SQSBatchResponse batchResponse = handler.handleRequest(testEvent, null);
 
@@ -364,7 +364,7 @@ class ProcessAsyncCriCredentialHandlerTest {
 
         var ciJourneyIds = govukSigninJourneyIdCaptor.getAllValues();
         assertEquals(1, ciJourneyIds.size());
-        assertNull(ciJourneyIds.get(0));
+        assertEquals(TEST_JOURNEY_ID, ciJourneyIds.get(0));
 
         var ciIpAddresses = ipAddressCaptor.getAllValues();
         assertEquals(1, ciIpAddresses.size());
@@ -390,7 +390,7 @@ class ProcessAsyncCriCredentialHandlerTest {
 
         var ciJourneyIds = govukSigninJourneyIdCaptor.getAllValues();
         assertEquals(1, ciJourneyIds.size());
-        assertNull(ciJourneyIds.get(0));
+        assertEquals(TEST_JOURNEY_ID, ciJourneyIds.get(0));
 
         var ciIpAddresses = ipAddressCaptor.getAllValues();
         assertEquals(1, ciIpAddresses.size());


### PR DESCRIPTION
## Proposed changes
### What changed

An async VC queue message may include a journey id (currently DCMAW includes one but F2F does not) and we are currently attaching this to our logs, but we are not including it in async VC requests to the CIMIT API. This corrects that (if not null it'll be populated in a header which CIMIT can consume to add it to their logs).

### Why did it change

In debugging some CIMIT errors we noticed this was missing.

