### PR TITLE
PYIC-8791: greater logging granularity on correlation failure types

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -122,7 +122,7 @@ public enum ErrorResponse {
     FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS(1108, "Failed to create stored identity for EVCS"),
     ERROR_CALLING_AIS_API(1109, "Error when calling AIS API"),
     IPV_SESSION_ITEM_EXPIRED(1110, "Session expired."),
-    FAILED_NAME_AND_DOB_CORRELATION(1111, "Failed name and DOB correlation");
+    FAILED_NAME_AND_DOB_CORRELATION(1111, "Failed to correlate gathered names and DOB");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/ErrorResponse.java
@@ -121,7 +121,8 @@ public enum ErrorResponse {
     MISSING_SECURITY_CHECK_CREDENTIAL(1107, "Missing security check credential"),
     FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS(1108, "Failed to create stored identity for EVCS"),
     ERROR_CALLING_AIS_API(1109, "Error when calling AIS API"),
-    IPV_SESSION_ITEM_EXPIRED(1110, "Session expired.");
+    IPV_SESSION_ITEM_EXPIRED(1110, "Session expired."),
+    FAILED_NAME_AND_DOB_CORRELATION(1111, "Failed name and DOB correlation");
 
     private static final String ERROR = "error";
     private static final String ERROR_DESCRIPTION = "error_description";

--- a/libs/test-helpers/src/main/java/uk/gov/di/ipv/core/library/testhelpers/unit/LogCollector.java
+++ b/libs/test-helpers/src/main/java/uk/gov/di/ipv/core/library/testhelpers/unit/LogCollector.java
@@ -24,9 +24,14 @@ public class LogCollector extends AbstractAppender {
 
     public static LogCollector getLogCollectorFor(Class<?> clazz) {
         var logCollector = new LogCollector();
+        logCollector.start();
         var logger = (Logger) LogManager.getLogger(clazz);
         logger.get().addAppender(logCollector, Level.ALL, null);
 
         return logCollector;
+    }
+
+    public void reset() {
+        logMessages.clear();
     }
 }

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -169,16 +169,20 @@ public class UserIdentityService {
             throws HttpResponseExceptionWithErrorBody {
         var successfulVcs = getSuccessfulVcs(vcs);
 
-        if (!checkNameAndFamilyNameCorrelationInCredentials(successfulVcs)) {
-            LOGGER.info(LogHelper.buildErrorMessage(ErrorResponse.FAILED_NAME_CORRELATION));
-            return false;
+        var successfulNameCorrelation =
+                checkNameAndFamilyNameCorrelationInCredentials(successfulVcs);
+        var successfulDobCorrelation = checkBirthDateCorrelationInCredentials(successfulVcs);
+
+        if (!successfulDobCorrelation && !successfulNameCorrelation) {
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(ErrorResponse.FAILED_NAME_AND_DOB_CORRELATION));
+        } else if (!successfulDobCorrelation) {
+            LOGGER.error(LogHelper.buildErrorMessage(ErrorResponse.FAILED_BIRTHDATE_CORRELATION));
+        } else if (!successfulNameCorrelation) {
+            LOGGER.error(LogHelper.buildErrorMessage(ErrorResponse.FAILED_NAME_CORRELATION));
         }
 
-        if (!checkBirthDateCorrelationInCredentials(successfulVcs)) {
-            LOGGER.error(LogHelper.buildErrorMessage(ErrorResponse.FAILED_BIRTHDATE_CORRELATION));
-            return false;
-        }
-        return true;
+        return successfulDobCorrelation && successfulNameCorrelation;
     }
 
     public boolean areNamesAndDobCorrelated(List<VerifiableCredential> vcs)

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
@@ -294,11 +294,32 @@ class UserIdentityServiceTest {
                                 USER_ID_1,
                                 BAV,
                                 createCredentialWithNameAndBirthDate(
-                                        "Jimmy", "Jones",
-                                        ""))); // BAV cri doesn't provide birthdate
+                                        "Jimmy", "Jones", "1000-01-01")));
 
         // Act & Assert
         assertFalse(userIdentityService.areVcsCorrelated(vcs));
+    }
+
+    @Test
+    void areVcsCorrelatedShouldThrowIfMissingBirthDateFromIdentityCredential() {
+        //  Arrange
+        var vcs =
+                List.of(
+                        generateVerifiableCredential(
+                                USER_ID_1,
+                                PASSPORT,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones", "1000-01-01")),
+                        generateVerifiableCredential(
+                                USER_ID_1,
+                                BAV,
+                                createCredentialWithNameAndBirthDate(
+                                        "Jimbo", "Jones",
+                                        ""))); // BAV cri doesn't provide birthdate
+        // Act & Assert
+        assertThrows(
+                HttpResponseExceptionWithErrorBody.class,
+                () -> userIdentityService.areVcsCorrelated(vcs));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Proposed changes
### What changed

- We now have logs for when a user fails:
  - name correlation only
  - dob correlation only 
  - name AND dob correlation
- Updated unit test as it was checking testing for more than one thing (name failure and DOB failure) and was only passing because it had a name failure but in reality, we expected it to throw as the VC had a missing DOB despite being an identity credential
- added a reset function to the LoggerCollector to clear all log messages. This is so that a shared log collector can be re-used between tests.

### Why did it change

- KIWI are investigating a new feature and wanted to observe the number of users facing different types of correlation failures in order to inform their decision-making. Previously, the correlation checks were performed one after the other so only the first failure type was logged. They want visibility on the number of users who fail both name and DOB correlation so we need to check for both name and dob correlation and log the failure type appropriately.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8791](https://govukverify.atlassian.net/browse/PYIC-8791)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8791]: https://govukverify.atlassian.net/browse/PYIC-8791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ