### PR TITLE
BAU: print out detected changed files in secure-post-merge GHA and fix deploy job not being triggered when api tests not updated

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -81,6 +81,14 @@ jobs:
             journey-map/**
             local-running/**
 
+      - name: List changed files
+        env:
+          CHANGED_FILES: ${{ steps.check-if-should-deploy.outputs.all_changed_files }}
+        run: |
+          for file in $CHANGED_FILES; do
+            echo "$file was changed"
+          done
+
   deploy:
     needs:
       - build-test-images-if-needed

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -93,7 +93,9 @@ jobs:
     needs:
       - build-test-images-if-needed
       - check-if-deploy-needed
-    if: ${{ needs.check-if-deploy-needed.outputs.deploy-needed == 'true' || github.event_name == 'workflow_dispatch' }}
+    if: |
+      !failure() &&
+      (needs.check-if-deploy-needed.outputs.deploy-needed == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Proposed changes
### What changed

- added a print out step to check all detected files
- add !failure() check to deploy job to fix deploy not being triggered when `build-test-images-if-needed` is skipped
  - without this the `need` condition skips the deploy job 
  ```
  needs evaluation: [GitHub](https://github.com/) checks if all jobs listed in the needs section have successfully completed. If a required job failed or was skipped, the dependent job will not run by default.
  ```

### Why did it change

- Despite functional code being updated, the deploy job is being skipped so the code isn't deployed. This will help debug the issue in post-merge

For some reason, this [PR](https://github.com/govuk-one-login/ipv-core-back/actions/runs/20308932122/job/58343075315) and [a couple others](https://github.com/govuk-one-login/ipv-core-back/commit/9d2929ffbd9b5a286f5d2f4a093aabc3b494a6e5) didn't trigger the deploy job. I've tested in this [draft PR](https://github.com/govuk-one-login/ipv-core-back/pull/3642/changes) that changing functional code should set `needs.check-if-deploy-needed.outputs.deploy-needed` to true and therefore trigger the deploy job and it looks fine so wanted to see if it's a difference in the trigger... 

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
