### PR TITLE
PYIC-8443: Exclude Netty libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ subprojects {
 allprojects {
 	configurations.configureEach {
 		exclude group: 'org.apache.tika', module: 'tika-parser-pdf-module'
+		// Exclude netty in general
+		exclude group: "io.netty", module: "*"
+		exclude group: "io.grpc", module: "grpc-netty"
 	}
 
 	plugins.withType(JavaPlugin).whenPluginAdded {


### PR DESCRIPTION
Netty is used by pact and has some vulnerabilities. This PR stops Netty libraries being used in core-back and so will ensure the vulnerabilities cannot affect us.

If the contract tests fail in this PR then it is likely because of the missing Netty libraries and we may have to close this PR.

## Proposed changes
### What changed

Exclude Netty libraries

### Why did it change

They have some vulnerabilities that are setting of Dependabot's security alerts.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8843](https://govukverify.atlassian.net/browse/PYIC-8843)



[PYIC-8843]: https://govukverify.atlassian.net/browse/PYIC-8843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ