### PR TITLE
PYIC-8843: Exclude just the netty libs causing alerts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,9 @@ subprojects {
 allprojects {
 	configurations.configureEach {
 		exclude group: 'org.apache.tika', module: 'tika-parser-pdf-module'
-		// Exclude netty in general
-		exclude group: "io.netty", module: "*"
-		exclude group: "io.grpc", module: "grpc-netty"
+		// Exclude netty libs with vulnerabilities
+		exclude group: "io.netty", module: "netty-codec-http"
+		exclude group: "io.netty", module: "netty-codec-http2"
 	}
 
 	plugins.withType(JavaPlugin).whenPluginAdded {


### PR DESCRIPTION
It seems like other bits of Netty are used elsewhere in core-back

## Proposed changes
### What changed

Only exclude the exact libs causing alerts

### Why did it change

Other parts of Netty are required

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8843](https://govukverify.atlassian.net/browse/PYIC-8843)



[PYIC-8843]: https://govukverify.atlassian.net/browse/PYIC-8843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ