### PR TITLE
PYIC-8843: Remove Netty exclusions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,6 @@ subprojects {
 allprojects {
 	configurations.configureEach {
 		exclude group: 'org.apache.tika', module: 'tika-parser-pdf-module'
-		// Exclude netty libs with vulnerabilities
-		exclude group: "io.netty", module: "netty-codec-http"
-		exclude group: "io.netty", module: "netty-codec-http2"
 	}
 
 	plugins.withType(JavaPlugin).whenPluginAdded {


### PR DESCRIPTION
We need at least the HTTP2 codec for sending audit events

## Proposed changes
### What changed

Re-instate Netty libs

### Why did it change

We need at least the HTTP2 codec for audit logging

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8843](https://govukverify.atlassian.net/browse/PYIC-8843)



[PYIC-8843]: https://govukverify.atlassian.net/browse/PYIC-8843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ