### PR TITLE
PYIC-8860: Experian outage notification banners. - temporary routes

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -220,6 +220,10 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -230,6 +234,10 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   NINO_START_PAGE:
     response:
@@ -246,6 +254,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   APP_DOC_CHECK:
     nestedJourney: APP_DOC_CHECK
@@ -317,6 +329,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -630,6 +646,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -641,6 +661,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
 
@@ -748,6 +772,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -270,6 +270,10 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -283,6 +287,10 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   BANK_ACCOUNT_START_PAGE:
     response:
@@ -295,6 +303,10 @@ states:
           - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: PYI_ESCAPE_NO_PHOTO_ID
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -310,6 +322,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -686,6 +702,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -697,6 +717,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
   STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
@@ -803,6 +827,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # PYIC-8860 Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # Common Mitigation states - invalid-dl/invalid-passport
 


### PR DESCRIPTION
## Proposed changes
### What changed

- Added temporary routes for links provided in the notification banner messages. It will navigate users to strategic app device sniffing "page". 

Pages screenshots are visible at:
https://github.com/govuk-one-login/ipv-core-common-infra/pull/1445

### Why did it change

All Experian services will be unavailable Sunday Jan 11, 2026 18:30pm - Monday Jan 12, 2026 at 00:00am . The banner is scheduled to appear when the outage is ongoing, so we only show the end time.
So it reads 'This service is unavailable until 11:59pm on Sunday 11 January'.

The only ways users will be able to prove their identity (and to achieve an M1C profile in absence of Fraud checks ) during this period are :
- using the GOV.UK one login app with a chipped biometric passport
- using the GOV.UK  one login app with a chipped BRP

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8860](https://govukverify.atlassian.net/browse/PYIC-8860)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8860]: https://govukverify.atlassian.net/browse/PYIC-8860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ