### PR TITLE
PYIC-8832: Add configuration to control the DL validity period

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
@@ -24,6 +24,7 @@ public class InternalOperationsConfig {
     @NonNull Long maxAllowedAuthClientTtl;
     @NonNull Integer fraudCheckExpiryPeriodHours;
     @NonNull Long dcmawAsyncVcPendingReturnTtl;
+    @NonNull Integer dcmawExpiredDlValidityPeriodDays;
     @NonNull String clientJarKmsEncryptionKeyAliasPrimary;
     @NonNull String clientJarKmsEncryptionKeyAliasSecondary;
     @NonNull URI coreVtmClaim;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -116,6 +116,10 @@ public abstract class ConfigService {
         return getConfiguration().getSelf().getDcmawAsyncVcPendingReturnTtl();
     }
 
+    public Integer getDcmawExpiredDlValidityPeriodDays() {
+        return getConfiguration().getSelf().getDcmawExpiredDlValidityPeriodDays();
+    }
+
     public long getCriResponseTtl() {
         return getConfiguration().getSelf().getCriResponseTtl();
     }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -116,6 +116,11 @@ class AppConfigServiceTest {
     }
 
     @Test
+    void getDcmawExpiredDlValidityPeriodDays() {
+        assertEquals(180, configService.getDcmawExpiredDlValidityPeriodDays());
+    }
+
+    @Test
     void getBackendSessionTimeout_returnsYamlValue() {
         assertEquals(3600L, configService.getBackendSessionTimeout());
     }

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -10,6 +10,7 @@ core:
     maxAllowedAuthClientTtl: 3600
     fraudCheckExpiryPeriodHours: 720
     dcmawAsyncVcPendingReturnTtl: 1800
+    dcmawExpiredDlValidityPeriodDays: 180
     clientJarKmsEncryptionKeyAliasPrimary: "CoreEncryptionKey1"
     clientJarKmsEncryptionKeyAliasSecondary: "CoreEncryptionKey2"
     coreVtmClaim: "https://oidc.local.account.gov.uk/trustmark"

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -13,6 +13,7 @@ core:
     maxAllowedAuthClientTtl: 3600
     fraudCheckExpiryPeriodHours: 720
     dcmawAsyncVcPendingReturnTtl: 1800
+    dcmawExpiredDlValidityPeriodDays: 180
     coreVtmClaim: "https://oidc.local.account.gov.uk/trustmark"
     backendSessionTimeout: 3600
     backendSessionTtl: 3600


### PR DESCRIPTION
## Proposed changes
### What changed

- Add configuration to control the DL validity period
- Subsequent PR: https://github.com/govuk-one-login/ipv-core-common-infra/pull/1448

### Why did it change

- The current policy allows a recently expired UK Driving Licence to support successful identity proofing. The acceptance window may evolve as fraud monitoring and policy mature. Hard-coding the value would create unnecessary delays and deployments for future adjustments.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8832](https://govukverify.atlassian.net/browse/PYIC-8832)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8832]: https://govukverify.atlassian.net/browse/PYIC-8832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ