### PR TITLE
PYIC-8866: Upgrade Mockito to 5.21.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 awsSdk = "2.41.0"
 jackson = "2.20.0"
 log4j = "2.25.3"
-mockito = "5.20.0"
+mockito = "5.21.0"
 pact = "4.6.18"
 powertools = "2.9.0"
 

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/SqsAuditServiceTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/service/SqsAuditServiceTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -398,7 +399,8 @@ class SqsAuditServiceTest {
         var mockAllOfCompletableFuture = mock(CompletableFuture.class);
         when(mockAllOfCompletableFuture.get()).thenThrow(new InterruptedException("Excuse me..."));
 
-        try (var completableFutureMockedStatic = mockStatic(CompletableFuture.class)) {
+        try (var completableFutureMockedStatic =
+                mockStatic(CompletableFuture.class, CALLS_REAL_METHODS)) {
             completableFutureMockedStatic
                     .when(() -> CompletableFuture.allOf(any(CompletableFuture[].class)))
                     .thenReturn(mockAllOfCompletableFuture);


### PR DESCRIPTION
## Proposed changes
### What changed

- Upgraded Mockito to 5.21.0 from 5.20.0
- Added CALLS_REAL_METHODS mocking configuration to SQSAuditService test case.

### Why did it change

Mockito 5.21.0 introduced internal changes that make use of CompletableFuture static method as part of its default answer logic.

In this test we statically mock CompletableFuture and stub only the allOf() method. Without CALLS_REAL_METHODS, all static methods of CompletableFuture are mocked, including those now used internally by Mockito. When Mockito invokes one of these unstubbed static methods internally, it re enters the static mock, leading to an infinite recursive call and eventually a StackOverflowError.

See example behaviour for CALLS_REAL_METHODS:
- Only explicitly stubbed static methods are mocked
- All other static methods delegate to the real JDK implementation
 
 From docs
```  
 Foo mock = mock(Foo.class, CALLS_REAL_METHODS);
 
  // this calls the real implementation of Foo.getSomething()
  value = mock.getSomething();
 
  doReturn(fakeValue).when(mock).getSomething();
 
  // now fakeValue is returned
  value = mock.getSomething();
```


### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8866](https://govukverify.atlassian.net/browse/PYIC-8866)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8866]: https://govukverify.atlassian.net/browse/PYIC-8866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ