### PR TITLE
PYIC-8866: Upgrade com.nimbusds:oauth2-oidc-sdk to 11.31

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ log4jCore = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log
 lombok = "org.projectlombok:lombok:1.18.30"
 mockitoCore = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockitoJunit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
-nimbusdsOauth2OidcSdk = "com.nimbusds:oauth2-oidc-sdk:11.30"
+nimbusdsOauth2OidcSdk = "com.nimbusds:oauth2-oidc-sdk:11.31"
 openTelemetryBom = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.22.0-alpha"
 openTelemetryJavaHttpClient = { module = "io.opentelemetry.instrumentation:opentelemetry-java-http-client" }
 pactConsumerJunit = { module = "au.com.dius.pact.consumer:junit5", version.ref = "pact" }

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
@@ -455,9 +455,7 @@ class JarValidatorTest {
         assertEquals(
                 OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
         assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
-        assertEquals(
-                "JWT audience rejected: [invalid-audience]",
-                thrown.getCause().getCause().getMessage());
+        assertEquals("JWT aud claim rejected", thrown.getCause().getCause().getMessage());
     }
 
     @Test
@@ -482,9 +480,7 @@ class JarValidatorTest {
         assertEquals(
                 OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
         assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
-        assertEquals(
-                "JWT iss claim has value invalid-issuer, must be test-issuer",
-                thrown.getCause().getCause().getMessage());
+        assertEquals("JWT iss claim value rejected", thrown.getCause().getCause().getMessage());
     }
 
     @Test
@@ -510,7 +506,7 @@ class JarValidatorTest {
                 OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
         assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
         assertEquals(
-                "JWT response_type claim has value invalid-response-type, must be code",
+                "JWT response_type claim value rejected",
                 thrown.getCause().getCause().getMessage());
     }
 
@@ -538,8 +534,7 @@ class JarValidatorTest {
                 OAuth2Error.INVALID_GRANT.getHTTPStatusCode(), errorObject.getHTTPStatusCode());
         assertEquals(OAuth2Error.INVALID_GRANT.getCode(), errorObject.getCode());
         assertEquals(
-                "JWT client_id claim has value test-client-id, must be different-client-id",
-                thrown.getCause().getCause().getMessage());
+                "JWT client_id claim value rejected", thrown.getCause().getCause().getMessage());
     }
 
     @Test

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidatorTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/validation/TokenRequestValidatorTest.java
@@ -140,8 +140,7 @@ class TokenRequestValidatorTest {
         assertTrue(
                 exception
                         .getMessage()
-                        .contains(
-                                "Bad / expired JWT claims: JWT audience rejected: [NOT_THE_AUDIENCE_YOU_ARE_LOOKING_FOR]"));
+                        .contains("Bad / expired JWT claims: JWT aud claim rejected"));
     }
 
     @Test

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/validator/VerifiableCredentialValidatorTest.java
@@ -387,7 +387,7 @@ class VerifiableCredentialValidatorTest {
                                 false));
 
         assertEquals(
-                "description=\"JWT sub claim does not match expected\"",
+                "description=\"Verifiable credential claims set not valid\" errorDescription=\"com.nimbusds.jwt.proc.BadJWTException: JWT sub claim value rejected\"",
                 logCollector.getLogMessages().get(0));
     }
 


### PR DESCRIPTION
Thrown causes become less descriptive in new version.

## Proposed changes
### What changed

- Upgraded com.nimbusds:oauth2-oidc-sdk to 11.31
- Fixed failing unit tests

### Why did it change

- Error messages in the new version are less descriptive, causing some unit tests to fail.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8866](https://govukverify.atlassian.net/browse/PYIC-8866)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8866]: https://govukverify.atlassian.net/browse/PYIC-8866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ