### PR TITLE
Revert "PYIC-8860: Experian outage notification banners. - temporary routes"

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -220,10 +220,6 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -234,10 +230,6 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   NINO_START_PAGE:
     response:
@@ -254,10 +246,6 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   APP_DOC_CHECK:
     nestedJourney: APP_DOC_CHECK
@@ -329,10 +317,6 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -646,10 +630,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -661,10 +641,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
 
@@ -772,10 +748,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -270,10 +270,6 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -287,10 +283,6 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   BANK_ACCOUNT_START_PAGE:
     response:
@@ -303,10 +295,6 @@ states:
           - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: PYI_ESCAPE_NO_PHOTO_ID
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -322,10 +310,6 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -702,10 +686,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -717,10 +697,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
   STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
@@ -827,10 +803,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # PYIC-8860 Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   # Common Mitigation states - invalid-dl/invalid-passport
 


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-back#3650