### PR TITLE
Revert "PYIC-8832: make dcmawExpiredDlValidityPeriodDays nullable whilst we add the new config"

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
@@ -24,7 +24,7 @@ public class InternalOperationsConfig {
     @NonNull Long maxAllowedAuthClientTtl;
     @NonNull Integer fraudCheckExpiryPeriodHours;
     @NonNull Long dcmawAsyncVcPendingReturnTtl;
-    Integer dcmawExpiredDlValidityPeriodDays;
+    @NonNull Integer dcmawExpiredDlValidityPeriodDays;
     @NonNull String clientJarKmsEncryptionKeyAliasPrimary;
     @NonNull String clientJarKmsEncryptionKeyAliasSecondary;
     @NonNull URI coreVtmClaim;


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-back#3665