### PR TITLE
PYIC-8866: Bump pact library version to 4.6.19

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ awsSdk = "2.41.0"
 jackson = "2.20.0"
 log4j = "2.25.3"
 mockito = "5.21.0"
-pact = "4.6.18"
+pact = "4.6.19"
 powertools = "2.9.0"
 
 [libraries]


### PR DESCRIPTION
## Proposed changes
### What changed

- Bump pact version to 4.6.19

### Why did it change

- We have security vulnerability with indirect dependency via pact testing library for io.netty:netty-codec-http2 -> tikka core. New version has been released and this PR should resolve the alert.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8866](https://govukverify.atlassian.net/browse/PYIC-8866)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8866]: https://govukverify.atlassian.net/browse/PYIC-8866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ