### PR TITLE
PYIC-8830: Add logic to determine if DCMAW VC has expired

### DIFF
--- a/api-tests/data/cri-stub-requests/dcmawAsync/kenneth-driving-permit-expired/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmawAsync/kenneth-driving-permit-expired/credentialSubject.json
@@ -1,0 +1,36 @@
+{
+  "address": [
+    {
+      "postalCode": "BA2 5AA"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "drivingPermit": [
+    {
+      "expiryDate": "2022-01-18",
+      "issueNumber": "5",
+      "issuedBy": "DVLA",
+      "fullAddress": "8 HADLEY ROAD BATH BA2 5AA",
+      "personalNumber": "DECER607085K9123",
+      "issueDate": "2020-01-18"
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/dcmawAsync/kenneth-driving-permit-expired/evidence.json
+++ b/api-tests/data/cri-stub-requests/dcmawAsync/kenneth-driving-permit-expired/evidence.json
@@ -1,0 +1,16 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "checkMethod": "vri"
+    },
+    {
+      "biometricVerificationProcessLevel": 3,
+      "checkMethod": "bvr"
+    }
+  ],
+  "txn": "RB000117420948",
+  "validityScore": 2,
+  "strengthScore": 3,
+  "type": "IdentityCheck"
+}

--- a/api-tests/features/account-intervention/journey-ending-interventions.feature
+++ b/api-tests/features/account-intervention/journey-ending-interventions.feature
@@ -109,10 +109,10 @@ Feature: Journey ending interventions
 
   Scenario: Blocked intervention at end of update identity journey
     Given the subject already has the following credentials
-      | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
-      | address | kenneth-current              |
-      | fraud   | kenneth-score-2              |
+      | CRI     | scenario               |
+      | dcmaw   | kenneth-passport-valid |
+      | address | kenneth-current        |
+      | fraud   | kenneth-score-2        |
     And The AIS stub will return an 'AIS_NO_INTERVENTION' result
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
@@ -127,7 +127,7 @@ Feature: Journey ending interventions
     When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
     When I submit 'kenneth-score-2' details with attributes to the CRI stub
       | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
+      | evidence_requested | {"identityFraudScore":1} |
     Then I get an OAuth response with error code 'session_invalidated'
 
   Scenario: Blocked intervention at end of initial F2F journey

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -59,14 +59,16 @@ Feature: Audit Events
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
     And audit events for 'new-identity-p2-web-journey' are recorded [local only]
- 
+
   @QualityGateRegressionTest
   Scenario: Reuse journey
-    Given the subject already has the following credentials
-      | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
-      | address | kenneth-current              |
-      | fraud   | kenneth-score-2              |
+    Given the subject already has the following credentials with overridden document expiry date
+      | CRI       | scenario                       | documentType  |
+      | dcmaw     | kenneth-driving-permit-valid   | drivingPermit |
+    And the subject already has the following credentials
+      | CRI     | scenario               |
+      | address | kenneth-current        |
+      | fraud   | kenneth-score-2        |
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'next' event
@@ -77,11 +79,13 @@ Feature: Audit Events
 
   @QualityGateRegressionTest
   Scenario: Reuse journey - identity is stored when SIS is enabled
-    Given the subject already has the following credentials
-      | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
-      | address | kenneth-current              |
-      | fraud   | kenneth-score-2              |
+    Given the subject already has the following credentials with overridden document expiry date
+      | CRI       | scenario                       | documentType  |
+      | dcmaw     | kenneth-driving-permit-valid   | drivingPermit |
+    And the subject already has the following credentials
+      | CRI     | scenario               |
+      | address | kenneth-current        |
+      | fraud   | kenneth-score-2        |
     And I activate the 'storedIdentityService' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
@@ -93,9 +97,11 @@ Feature: Audit Events
 
   @QualityGateRegressionTest
   Scenario: Reuse journey - identity is compared when SIS comparison is enabled
-    Given the subject already has the following credentials
+    Given the subject already has the following credentials with overridden document expiry date
+      | CRI       | scenario                       | documentType  |
+      | dcmaw     | kenneth-driving-permit-valid   | drivingPermit |
+    And the subject already has the following credentials
       | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
     And I have an existing stored identity record with a 'P2' vot
@@ -267,11 +273,13 @@ Feature: Audit Events
 
   @QualityGateRegressionTest
   Scenario: Update name and address journey
-    Given the subject already has the following credentials
-      | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
-      | address | kenneth-current              |
-      | fraud   | kenneth-score-2              |
+    Given the subject already has the following credentials with overridden document expiry date
+      | CRI       | scenario                       | documentType  |
+      | dcmaw     | kenneth-driving-permit-valid   | drivingPermit |
+    And the subject already has the following credentials
+      | CRI     | scenario               |
+      | address | kenneth-current        |
+      | fraud   | kenneth-score-2        |
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'update-details' event

--- a/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
+++ b/api-tests/features/dl-auth-source-checks/dl-auth-source-checks.feature
@@ -258,9 +258,11 @@ Feature: Authoritative source checks with driving licence CRI
 
   Scenario Outline: Change of details journey through DCMAW with driving licence requires auth source check
     Given I activate the 'drivingLicenceAuthCheck' feature set
+    And the subject already has the following credentials with overridden document expiry date
+      | CRI     | scenario                     | documentType  |
+      | dcmaw   | kenneth-driving-permit-valid | drivingPermit |
     And the subject already has the following credentials
       | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
     When I start a new 'medium-confidence' journey
@@ -285,9 +287,11 @@ Feature: Authoritative source checks with driving licence CRI
 
   Scenario Outline: Change of details journey that attracts an invalid doc CI from auth source check
     Given I activate the 'drivingLicenceAuthCheck' feature set
+    And the subject already has the following credentials with overridden document expiry date
+      | CRI     | scenario                     | documentType  |
+      | dcmaw   | kenneth-driving-permit-valid | drivingPermit |
     And the subject already has the following credentials
       | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
       | fraud   | kenneth-score-2              |
     When I start a new 'medium-confidence' journey

--- a/api-tests/features/expired-driving-permit.feature
+++ b/api-tests/features/expired-driving-permit.feature
@@ -1,0 +1,79 @@
+@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
+Feature: Expired DCMAW/Async DCMAW Driving Permits
+  Scenario: An expired DCMAW driving permit and current date is past the grace period should result in identity reprove
+    # This creates a DCMAW Async VC which has nbf 26/07/2022
+    Given the subject already has the following expired credentials
+      | CRI            | scenario                       |
+      | dcmawAsync     | kenneth-driving-permit-expired |
+    And the subject already has the following credentials
+      | CRI            | scenario                       |
+      | drivingLicence | kenneth-driving-permit-valid   |
+      | address        | kenneth-current                |
+      | fraud          | kenneth-score-2                |
+
+    Given I activate the 'disableStrategicApp' feature set
+    And I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get a 'dcmaw' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+  Scenario: An expired DCMAW driving permit but the current date is not past the grace period should result in identity reuse
+    # Initial journey proving with expired driving licence in app
+    Given I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    # This step will enqueue a VC with NBF set to whenever this test is ran. This
+    # means that, at reuse, the test will always be within the grace period.
+    When the async DCMAW CRI produces a 'kenneth-driving-permit-expired' VC
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get a 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+    # New journey
+    When I start a new 'medium-confidence' journey
+    Then I get an 'page-ipv-reuse' page response

--- a/api-tests/features/expired-driving-permit.feature
+++ b/api-tests/features/expired-driving-permit.feature
@@ -13,6 +13,8 @@ Feature: Expired DCMAW/Async DCMAW Driving Permits
 
     Given I activate the 'disableStrategicApp' feature set
     And I start a new 'medium-confidence' journey
+    Then I get a 'reprove-identity-start' page response
+    When I submit a 'next' event
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event
     Then I get a 'page-ipv-identity-document-start' page response

--- a/api-tests/features/expired-driving-permit.feature
+++ b/api-tests/features/expired-driving-permit.feature
@@ -1,10 +1,10 @@
 @Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
 Feature: Expired DCMAW/Async DCMAW Driving Permits
-  Scenario: An expired DCMAW driving permit and current date is past the grace period should result in identity reprove
-    # This creates a DCMAW Async VC which has nbf 26/07/2022
-    Given the subject already has the following expired credentials
-      | CRI            | scenario                       |
-      | dcmawAsync     | kenneth-driving-permit-expired |
+  Scenario: An expired DCMAW driving permit and current date is past the validity period should result in identity reprove
+    # This creates a DCMAW Async VC which has nbf 26/07/2022 and driving permit expiry date set to 180 days before the nbf
+    Given the subject already has the following expired credentials with overridden document expiry date
+      | CRI            | scenario                       | documentType  |
+      | dcmawAsync     | kenneth-driving-permit-valid   | drivingPermit |
     And the subject already has the following credentials
       | CRI            | scenario                       |
       | drivingLicence | kenneth-driving-permit-valid   |
@@ -35,7 +35,7 @@ Feature: Expired DCMAW/Async DCMAW Driving Permits
     When I use the OAuth response to get my identity
     Then I get a 'P2' identity
 
-  Scenario: An expired DCMAW driving permit but the current date is not past the grace period should result in identity reuse
+  Scenario: An expired DCMAW driving permit but the current date is not past the validity period should result in identity reuse
     # Initial journey proving with expired driving licence in app
     Given I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
@@ -49,8 +49,10 @@ Feature: Expired DCMAW/Async DCMAW Driving Permits
     Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
     When I submit an 'iphone' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
-    # This step will enqueue a VC with NBF set to whenever this test is ran. This
-    # means that, at reuse, the test will always be within the grace period.
+    # This step will enqueue a VC with NBF set to whenever this test is ran
+    # but driving permit expiry date set before the nbf (2022-01-18). This
+    # means that, at reuse, the test will trigger the expired DL check but
+    # will always be within the validity period.
     When the async DCMAW CRI produces a 'kenneth-driving-permit-expired' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/p2-reuse-journey.feature
+++ b/api-tests/features/p2-reuse-journey.feature
@@ -11,7 +11,7 @@ Feature: P2 Reuse journey
     Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    When I submit 'kenneth-driving-permit-valid' drivingPermit details to the DCMAW CRI stub with overridden document expiry date
     Then I get a 'drivingLicence' CRI response
     When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
       | Attribute | Values          |
@@ -63,9 +63,11 @@ Feature: P2 Reuse journey
     Then I get a 'P3' identity
 
   Scenario: Reuse journey - credentials meet P2 identity - high-medium confidence journey
-    Given the subject already has the following credentials
+    Given the subject already has the following credentials with overridden document expiry date
+      | CRI            | scenario                     | documentType  |
+      | dcmaw          | kenneth-driving-permit-valid | drivingPermit |
+    And the subject already has the following credentials
       | CRI            | scenario                     |
-      | dcmaw          | kenneth-driving-permit-valid |
       | address        | kenneth-current              |
       | fraud          | kenneth-score-2              |
       | drivingLicence | kenneth-driving-permit-valid |

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -6,9 +6,9 @@ Feature: Repeat fraud check failures
   Rule: Given name change only
     Background:
       Given the subject already has the following credentials
-        | CRI     | scenario                     |
-        | dcmaw   | kenneth-driving-permit-valid |
-        | address | kenneth-current              |
+        | CRI     | scenario               |
+        | dcmaw   | kenneth-passport-valid |
+        | address | kenneth-current        |
       And the subject already has the following expired credentials
         | CRI   | scenario        |
         | fraud | kenneth-score-2 |

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -3,10 +3,10 @@ Feature: Identity reuse update details failures
     Rule: Update given name only
         Background:
             Given the subject already has the following credentials
-                | CRI     | scenario                     |
-                | dcmaw   | kenneth-driving-permit-valid |
-                | address | kenneth-current              |
-                | fraud   | kenneth-score-2              |
+                | CRI     | scenario               |
+                | dcmaw   | kenneth-passport-valid |
+                | address | kenneth-current        |
+                | fraud   | kenneth-score-2        |
             And I activate the 'disableStrategicApp' feature set
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
@@ -60,7 +60,7 @@ Feature: Identity reuse update details failures
             Then I get a 'delete-handover' page response
 
         Scenario: Zero score in fraud CRI - receives old identity (P2)
-            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+            When I submit 'kenneth-changed-given-name-driving-permit-valid' drivingPermit details to the DCMAW CRI stub with overridden document expiry date
             Then I get a 'drivingLicence' CRI response
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details with attributes to the CRI stub
                 | Attribute | Values          |
@@ -80,7 +80,7 @@ Feature: Identity reuse update details failures
             Then I get a 'page-ipv-reuse' page response
 
         Scenario: Breaching CI received from fraud CRI - doesn't receive old identity
-            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+            When I submit 'kenneth-changed-given-name-driving-permit-valid' drivingPermit details to the DCMAW CRI stub with overridden document expiry date
             Then I get a 'drivingLicence' CRI response
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details with attributes to the CRI stub
                 | Attribute | Values          |
@@ -135,7 +135,7 @@ Feature: Identity reuse update details failures
             Then I get a 'page-ipv-reuse' page response
 
         Scenario: Fraud access denied OAuth error - receives old identity (P2)
-            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+            When I submit 'kenneth-changed-given-name-driving-permit-valid' drivingPermit details to the DCMAW CRI stub with overridden document expiry date
             Then I get a 'drivingLicence' CRI response
             When I submit 'kenneth-changed-given-name-driving-permit-valid' details with attributes to the CRI stub
                 | Attribute | Values          |
@@ -157,10 +157,10 @@ Feature: Identity reuse update details failures
     Rule: Update address only
         Background:
             Given the subject already has the following credentials
-                | CRI     | scenario                     |
-                | dcmaw   | kenneth-driving-permit-valid |
-                | address | kenneth-current              |
-                | fraud   | kenneth-score-2              |
+                | CRI     | scenario               |
+                | dcmaw   | kenneth-passport-valid |
+                | address | kenneth-current        |
+                | fraud   | kenneth-score-2        |
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
             When I submit an 'update-details' event

--- a/api-tests/features/stored-identity/failed-update-journeys.feature
+++ b/api-tests/features/stored-identity/failed-update-journeys.feature
@@ -2,9 +2,11 @@
 Feature: Failed update details
   Background: Create user with existing credentials and SI record
     Given I activate the 'storedIdentityService,disableStrategicApp' feature set
+    And the subject already has the following credentials with overridden document expiry date
+      | CRI     | scenario                     | documentType  |
+      | dcmaw   | kenneth-driving-permit-valid | drivingPermit |
     And the subject already has the following credentials
       | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |
 
   Rule: Reuse journey

--- a/api-tests/features/stored-identity/p1-reuse-existing-identity.feature
+++ b/api-tests/features/stored-identity/p1-reuse-existing-identity.feature
@@ -5,9 +5,11 @@ Feature: Stored Identity - Update Existing Identity
 
   Rule: Non-update journey - no existing SI record
     Background: Existing user identity - start low-confidence journey
+      And the subject already has the following credentials with overridden document expiry date
+        | CRI     | scenario                     | documentType  |
+        | dcmaw   | kenneth-driving-permit-valid | drivingPermit |
       And the subject already has the following credentials
         | CRI     | scenario                     |
-        | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
       And I don't have a stored identity in EVCS
@@ -23,9 +25,11 @@ Feature: Stored Identity - Update Existing Identity
 
   Rule: Update journeys - no existing SI record
     Background: Existing identity - continue to update details
+      And the subject already has the following credentials with overridden document expiry date
+        | CRI     | scenario                     | documentType  |
+        | dcmaw   | kenneth-driving-permit-valid | drivingPermit |
       And the subject already has the following credentials
         | CRI     | scenario                     |
-        | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
 
@@ -108,9 +112,11 @@ Feature: Stored Identity - Update Existing Identity
 
   Rule: Update journey - existing SI record
     Scenario: Existing P2 identity - reuse P1 journey with update
-      Given the subject already has the following credentials
+      Given the subject already has the following credentials with overridden document expiry date
+        | CRI     | scenario                     | documentType  |
+        | dcmaw   | kenneth-driving-permit-valid | drivingPermit |
+      And the subject already has the following credentials
         | CRI     | scenario                     |
-        | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
       And I have an existing stored identity record with a 'P2' vot
@@ -141,9 +147,11 @@ Feature: Stored Identity - Update Existing Identity
       And I have a GPG45 stored identity record type with a 'P3' vot that is 'valid'
 
     Scenario: Existing P1 credentials - details used for update meet P2
-      Given the subject already has the following credentials
+      Given the subject already has the following credentials with overridden document expiry date
+        | CRI     | scenario                     | documentType  |
+        | dcmaw   | kenneth-driving-permit-valid | drivingPermit |
+      And the subject already has the following credentials
         | CRI     | scenario                     |
-        | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-1              |
       And I have an existing stored identity record with a 'P1' vot

--- a/api-tests/features/stored-identity/p2-reuse-existing-identity.feature
+++ b/api-tests/features/stored-identity/p2-reuse-existing-identity.feature
@@ -105,9 +105,11 @@ Feature: P2 reuse journeys
 
     Rule: Existing credentials that meets P2
       Background: User has existing identity that meets P2 identity
-        Given the subject already has the following credentials
+        Given the subject already has the following credentials with overridden document expiry date
+          | CRI     | scenario                     | documentType  |
+          | dcmaw   | kenneth-driving-permit-valid | drivingPermit |
+        And the subject already has the following credentials
           | CRI     | scenario                     |
-          | dcmaw   | kenneth-driving-permit-valid |
           | address | kenneth-current              |
           | fraud   | kenneth-score-2              |
         And I have an existing stored identity record with a 'P2' vot

--- a/api-tests/features/stored-identity/reprove-identity-journeys.feature
+++ b/api-tests/features/stored-identity/reprove-identity-journeys.feature
@@ -6,10 +6,10 @@ Feature: Reprove Identity Journey
   Rule: P2 Journeys
     Background:
       Given the subject already has the following credentials
-        | CRI     | scenario                     |
-        | dcmaw   | kenneth-driving-permit-valid |
-        | address | kenneth-current              |
-        | fraud   | kenneth-score-2              |
+        | CRI     | scenario               |
+        | dcmaw   | kenneth-passport-valid |
+        | address | kenneth-current        |
+        | fraud   | kenneth-score-2        |
       And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
       When I start a new 'medium-confidence' journey
       Then I get a 'reprove-identity-start' page response
@@ -66,9 +66,11 @@ Feature: Reprove Identity Journey
 
   Rule: P1 Journeys
     Background:
-      Given the subject already has the following credentials
+      Given the subject already has the following credentials with overridden document expiry date
+        | CRI     | scenario                     | documentType  |
+        | dcmaw   | kenneth-driving-permit-valid | drivingPermit |
+      And the subject already has the following credentials
         | CRI     | scenario                     |
-        | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
       And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result

--- a/api-tests/features/strategic-app/strategic-app-dl-auth-source-check-reuse-update-details.feature
+++ b/api-tests/features/strategic-app/strategic-app-dl-auth-source-check-reuse-update-details.feature
@@ -3,10 +3,10 @@ Feature: Identity reuse update details with Strategic App
     Rule: Successful journeys
         Background:
             Given the subject already has the following credentials
-                | CRI           | scenario                     |
-                | dcmawAsync    | kenneth-driving-permit-valid |
-                | address       | kenneth-current              |
-                | fraud         | kenneth-score-2              |
+                | CRI           | scenario               |
+                | dcmawAsync    | kenneth-passport-valid |
+                | address       | kenneth-current        |
+                | fraud         | kenneth-score-2        |
             When I activate the 'strategicApp,drivingLicenceAuthCheck' feature set
             And I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
@@ -133,10 +133,10 @@ Feature: Identity reuse update details with Strategic App
     Rule: Unsuccessful journeys
         Background:
             Given the subject already has the following credentials
-                | CRI           | scenario                     |
-                | dcmawAsync    | kenneth-driving-permit-valid |
-                | address       | kenneth-current              |
-                | fraud         | kenneth-score-2              |
+                | CRI           | scenario               |
+                | dcmawAsync    | kenneth-passport-valid |
+                | address       | kenneth-current        |
+                | fraud         | kenneth-score-2        |
             When I activate the 'strategicApp,drivingLicenceAuthCheck' feature set
             And I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response

--- a/api-tests/features/ticf/ticf-successful-responses.feature
+++ b/api-tests/features/ticf/ticf-successful-responses.feature
@@ -64,10 +64,10 @@ Feature: TICF successful responses
 
     Scenario: TICF request returns a CI on reuse journey
       Given the subject already has the following credentials
-        | CRI     | scenario                     |
-        | dcmaw   | kenneth-driving-permit-valid |
-        | address | kenneth-current              |
-        | fraud   | kenneth-score-2              |
+        | CRI     | scenario               |
+        | dcmaw   | kenneth-passport-valid |
+        | address | kenneth-current        |
+        | fraud   | kenneth-score-2        |
       And TICF CRI will respond with default parameters and
         | cis     | BREACHING                    |
       When I start a new 'medium-confidence' journey

--- a/api-tests/src/utils/dates.ts
+++ b/api-tests/src/utils/dates.ts
@@ -1,0 +1,13 @@
+export const EXPIRED_NBF = 1658829758; // 26/07/2022 in epoch seconds
+
+export function getFutureDateString(): string {
+  const currentDateTime = new Date();
+  currentDateTime.setDate(currentDateTime.getDate() + 180);
+  return currentDateTime.toISOString().split("T")[0];
+}
+
+export function getDateStringPriorToExpiredNbf(): string {
+  return new Date((EXPIRED_NBF - 180 * 24 * 3600) * 1000)
+    .toISOString()
+    .split("T")[0];
+}

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -492,12 +492,8 @@ public class CheckExistingIdentityHandler
             String userId)
             throws EvcsServiceException {
         LocalDateTime vcIssueDate =
-                dcmawDlVc
-                        .getClaimsSet()
-                        .getNotBeforeTime()
-                        .toInstant()
-                        .atZone(ZoneOffset.UTC)
-                        .toLocalDateTime();
+                LocalDateTime.ofInstant(
+                        dcmawDlVc.getClaimsSet().getNotBeforeTime().toInstant(), ZoneOffset.UTC);
 
         var dlExpiryDateString =
                 ((IdentityCheckCredential) dcmawDlVc.getCredential())
@@ -518,7 +514,7 @@ public class CheckExistingIdentityHandler
                 LocalDateTime cutoffDate = vcIssueDate.plusDays(graceDays);
 
                 if (today.isAfter(cutoffDate)) {
-                    var vcsForUpdate = List.of(dcmawDlVc);
+                    var vcsForUpdate = new ArrayList<>(List.of(dcmawDlVc));
                     credentialBundle.stream()
                             .filter(vc -> DRIVING_LICENCE.equals(vc.getCri()))
                             .findFirst()

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -499,6 +499,7 @@ public class CheckExistingIdentityHandler
     }
 
     private boolean checkForExpiredDcmawDrivingPermit(VerifiableCredential dcmawDlVc) {
+        LOGGER.info("Checking for expired DCMAW Driving Permit outside of grace period");
         LocalDateTime vcIssueDate =
                 LocalDateTime.ofInstant(
                         dcmawDlVc.getClaimsSet().getNotBeforeTime().toInstant(), ZoneOffset.UTC);
@@ -522,6 +523,8 @@ public class CheckExistingIdentityHandler
                 LocalDateTime cutoffDate = vcIssueDate.plusDays(graceDays);
 
                 if (today.isAfter(cutoffDate)) {
+                    LOGGER.info(
+                            "User's driving licence is expired and outside of the grace period.");
                     return true;
                 }
             }

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -89,7 +89,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -1140,12 +1139,14 @@ class CheckExistingIdentityHandlerTest {
                                     Optional.empty(),
                                     Gpg45Scores.builder().build()));
             when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
-            when(configService.getDcmawExpiredDlValidityPeriodDays()).thenReturn(180);
 
             try (MockedStatic<VcHelper> mockVcHelper =
                     mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
                 mockVcHelper
-                        .when(() -> VcHelper.hasExpiredDrivingPermitVc(any(), anyInt(), any()))
+                        .when(
+                                () ->
+                                        VcHelper.isExpiredDrivingPermitVc(
+                                                any(), eq(configService), any()))
                         .thenReturn(true);
 
                 var journeyResponse =
@@ -1176,11 +1177,13 @@ class CheckExistingIdentityHandlerTest {
                             List.of(P2), testCredentialBundle, List.of(), true))
                     .thenReturn(buildMatchResultFor(P2, M1A));
             when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
-            when(configService.getDcmawExpiredDlValidityPeriodDays()).thenReturn(180);
             try (MockedStatic<VcHelper> mockVcHelper =
                     mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
                 mockVcHelper
-                        .when(() -> VcHelper.hasExpiredDrivingPermitVc(any(), anyInt(), any()))
+                        .when(
+                                () ->
+                                        VcHelper.isExpiredDrivingPermitVc(
+                                                any(), eq(configService), any()))
                         .thenReturn(false);
 
                 var journeyResponse =
@@ -1192,36 +1195,6 @@ class CheckExistingIdentityHandlerTest {
                 verify(mockEvcsService, times(0))
                         .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
             }
-        }
-
-        @Test
-        void
-                shouldReturnReuseResponseGivenMissingValidityPeriodConfigurationAndCredentialBundleMeetsVtr()
-                        throws Exception {
-            var testCredentialBundle =
-                    List.of(
-                            vcDcmawDrivingPermitDvaExpired(), // VC issue date is 23/01/2024
-                            vcWebDrivingPermitDvaExpired());
-            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
-                            TEST_USER_ID, EVCS_TEST_TOKEN, false, CURRENT, PENDING_RETURN))
-                    .thenReturn(Map.of(CURRENT, testCredentialBundle));
-            when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
-                    .thenReturn(emptyAsyncCriStatus);
-            when(mockVotMatcher.findStrongestMatches(
-                            List.of(P2), testCredentialBundle, List.of(), true))
-                    .thenReturn(buildMatchResultFor(P2, M1A));
-            when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
-
-            when(configService.getDcmawExpiredDlValidityPeriodDays()).thenReturn(null);
-
-            var journeyResponse =
-                    toResponseClass(
-                            checkExistingIdentityHandler.handleRequest(event, context),
-                            JourneyResponse.class);
-
-            assertEquals(JOURNEY_REUSE, journeyResponse);
-            verify(mockEvcsService, never()).markHistoricInEvcs(any(), any());
         }
     }
 
@@ -1560,7 +1533,10 @@ class CheckExistingIdentityHandlerTest {
             try (MockedStatic<VcHelper> mockVcHelper =
                     mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
                 mockVcHelper
-                        .when(() -> VcHelper.hasExpiredDrivingPermitVc(any(), anyInt(), any()))
+                        .when(
+                                () ->
+                                        VcHelper.isExpiredDrivingPermitVc(
+                                                any(), eq(configService), any()))
                         .thenReturn(false);
 
                 var journeyResponse =
@@ -1594,7 +1570,10 @@ class CheckExistingIdentityHandlerTest {
             try (MockedStatic<VcHelper> mockVcHelper =
                     mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
                 mockVcHelper
-                        .when(() -> VcHelper.hasExpiredDrivingPermitVc(any(), anyInt(), any()))
+                        .when(
+                                () ->
+                                        VcHelper.isExpiredDrivingPermitVc(
+                                                any(), eq(configService), any()))
                         .thenReturn(false);
 
                 var journeyResponse =

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -183,6 +183,8 @@ class CheckExistingIdentityHandlerTest {
             new JourneyResponse(JOURNEY_F2F_FAIL_PATH);
     private static final JourneyResponse JOURNEY_REPEAT_FRAUD_CHECK =
             new JourneyResponse(JOURNEY_REPEAT_FRAUD_CHECK_PATH);
+    private static final JourneyResponse JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM =
+            new JourneyResponse(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM_PATH);
     private static final JourneyResponse JOURNEY_FAIL_WITH_NO_CI =
             new JourneyResponse(JOURNEY_FAIL_WITH_NO_CI_PATH);
     private static final JourneyResponse JOURNEY_FAIL_WITH_NO_CI_MEDIUM_CONFIDENCE =
@@ -1159,7 +1161,7 @@ class CheckExistingIdentityHandlerTest {
                                 checkExistingIdentityHandler.handleRequest(event, context),
                                 JourneyResponse.class);
 
-                assertEquals(JOURNEY_IPV_GPG45_MEDIUM, journeyResponse);
+                assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM, journeyResponse);
             }
         }
 

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -226,6 +226,13 @@ public interface VcFixtures {
         return vcClaim;
     }
 
+    private static IdentityCheckCredential vcClaimWebDrivingLicenceDvaExpired() {
+        var vcClaim = vcClaimWebDrivingLicenceDvla();
+        vcClaim.getCredentialSubject().setDrivingPermit(List.of(DRIVING_PERMIT_DVA_EXPIRED));
+        vcClaim.getCredentialSubject().setName(List.of(kennethDecerqueiraName()));
+        return vcClaim;
+    }
+
     private static IdentityCheckCredential vcClaimNinoIdentityCheck() {
         return IdentityCheckCredential.builder()
                 .withType(
@@ -789,6 +796,9 @@ public interface VcFixtures {
     DrivingPermitDetails DRIVING_PERMIT_DVA =
             createDrivingPermitDetails("MORGA753116SM9IJ", "2042-10-01", "DVA", "2018-04-19");
 
+    DrivingPermitDetails DRIVING_PERMIT_DVA_EXPIRED =
+            createDrivingPermitDetails("MORGA753116SM9IJ", "2020-10-01", "DVA", "2018-04-19");
+
     DrivingPermitDetails DRIVING_PERMIT_DVLA =
             createDrivingPermitDetails(
                     "PARKE710112PBFGA", "2032-02-02", "DVLA", "2005-02-02", "123456");
@@ -1084,6 +1094,15 @@ public interface VcFixtures {
                 Instant.ofEpochSecond(1705986521));
     }
 
+    static VerifiableCredential vcWebDrivingPermitDvaExpired() {
+        return generateVerifiableCredential(
+                "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",
+                DRIVING_LICENCE,
+                vcClaimWebDrivingLicenceDvaExpired(),
+                DRIVING_PERMIT_ISSUER_STAGING,
+                Instant.ofEpochSecond(1705986521));
+    }
+
     static VerifiableCredential vcWebDrivingPermitMissingDrivingPermit() {
         var vcClaim = vcClaimWebDrivingLicenceDvla();
         vcClaim.getCredentialSubject().setDrivingPermit(null);
@@ -1258,6 +1277,24 @@ public interface VcFixtures {
                 vcClaimDcmawDrivingPermitDva(),
                 DCMAW_ISSUER_STAGING,
                 Instant.ofEpochSecond(1705986521));
+    }
+
+    static VerifiableCredential vcDcmawDrivingPermitDvaExpired() {
+        return generateVerifiableCredential(
+                "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
+                DCMAW,
+                vcClaimWebDrivingLicenceDvaExpired(),
+                DCMAW_ISSUER_STAGING,
+                Instant.ofEpochSecond(1705986521));
+    }
+
+    static VerifiableCredential vcDcmawDrivingPermitDvaExpiredSameDayAsNbf() {
+        return generateVerifiableCredential(
+                "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
+                DCMAW,
+                vcClaimWebDrivingLicenceDvaExpired(), // Expiry date is 2020-10-01
+                DCMAW_ISSUER_STAGING,
+                Instant.ofEpochSecond(1601555400)); // NBF is set to 2020-10-01T13:30:00
     }
 
     static VerifiableCredential vcDcmawPassport() {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -1297,6 +1297,15 @@ public interface VcFixtures {
                 Instant.ofEpochSecond(1705986521));
     }
 
+    static VerifiableCredential vcDrivingPermitNullNbf() {
+        return generateVerifiableCredential(
+                "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",
+                DCMAW,
+                vcClaimWebDrivingLicenceDvaExpired(),
+                DCMAW_ISSUER_STAGING,
+                null);
+    }
+
     static VerifiableCredential vcDcmawDrivingPermitDvaExpiredSameDayAsNbf() {
         return generateVerifiableCredential(
                 "urn:uuid:01a44342-e643-4ca9-8306-a8e044092fb0",

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/helpers/VerifiableCredentialGenerator.java
@@ -103,9 +103,13 @@ public class VerifiableCredentialGenerator {
                     new JWTClaimsSet.Builder()
                             .claim(SUBJECT, userId)
                             .claim(ISSUER, issuer)
-                            .claim(NOT_BEFORE, nbf.getEpochSecond())
-                            .claim(ISSUED_AT, nbf.getEpochSecond())
                             .claim(VC_CLAIM, OBJECT_MAPPER.convertValue(vcClaim, Object.class));
+
+            if (nbf != null) {
+                claimSetBuilder
+                        .claim(NOT_BEFORE, nbf.getEpochSecond())
+                        .claim(ISSUED_AT, nbf.getEpochSecond());
+            }
 
             if (vot != null) {
                 claimSetBuilder.claim(VC_VOT, vot);

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -335,7 +335,7 @@ public class EvcsService {
 
     public void markHistoricInEvcs(String userId, List<VerifiableCredential> vcs)
             throws EvcsServiceException {
-        var update =
+        var vcsToUpdate =
                 vcs.stream()
                         .map(
                                 vc ->
@@ -344,8 +344,8 @@ public class EvcsService {
                                                 EvcsVCState.HISTORIC,
                                                 null))
                         .toList();
-        if (!update.isEmpty()) {
-            evcsClient.updateUserVCs(userId, update);
+        if (!vcsToUpdate.isEmpty()) {
+            evcsClient.updateUserVCs(userId, vcsToUpdate);
         }
     }
 

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -333,6 +333,22 @@ public class EvcsService {
         if (!vcsToUpdates.isEmpty()) evcsClient.updateUserVCs(userId, vcsToUpdates);
     }
 
+    public void markHistoricInEvcs(String userId, List<VerifiableCredential> vcs)
+            throws EvcsServiceException {
+        var update =
+                vcs.stream()
+                        .map(
+                                vc ->
+                                        new EvcsUpdateUserVCsDto(
+                                                getVcSignature(vc.getVcString()),
+                                                EvcsVCState.HISTORIC,
+                                                null))
+                        .toList();
+        if (!update.isEmpty()) {
+            evcsClient.updateUserVCs(userId, update);
+        }
+    }
+
     private static String getVcSignature(String vcString) {
         return vcString.split("\\.")[2];
     }

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -614,5 +615,30 @@ class EvcsServiceTest {
 
         // Assert
         verify(mockEvcsClient, times(1)).invalidateStoredIdentityRecord(TEST_USER_ID);
+    }
+
+    @Test
+    void markVcsAsHistoricInEvcsShouldUpdateEvcsWithHistoricVcs() throws Exception {
+        // Act
+        evcsService.markHistoricInEvcs(TEST_USER_ID, List.of(VC_DRIVING_PERMIT_TEST));
+
+        // Assert
+        verify(mockEvcsClient, times(1))
+                .updateUserVCs(eq(TEST_USER_ID), evcsUpdateUserVCsDtosCaptor.capture());
+        var evcsUserVCsToUpdate = evcsUpdateUserVCsDtosCaptor.getValue();
+        assertEquals(
+                1,
+                (evcsUserVCsToUpdate.stream()
+                        .filter(dto -> dto.state().equals(EvcsVCState.HISTORIC))
+                        .count()));
+    }
+
+    @Test
+    void markVcsAsHistoricInEvcsShouldNotCallEvcsIfGivenEmptyList() throws Exception {
+        // Act
+        evcsService.markHistoricInEvcs(TEST_USER_ID, List.of());
+
+        // Assert
+        verify(mockEvcsClient, times(0)).updateUserVCs(eq(TEST_USER_ID), any());
     }
 }

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -188,19 +188,14 @@ public class VcHelper {
         return hasExpired(nbf, expiryPeriodInDays, clock);
     }
 
-    private static boolean hasExpired(
-            Instant vcIssueTime, int validityDurationInDays, Clock clock) {
-        var startOfIssueDay =
-                vcIssueTime.atZone(LONDON_TIMEZONE).toLocalDate().atStartOfDay(LONDON_TIMEZONE);
+    public static boolean isExpiredDrivingPermitVc(
+            VerifiableCredential drivingPermitVc, ConfigService configService, Clock clock) {
+        var validityDurationInDays = configService.getDcmawExpiredDlValidityPeriodDays();
 
-        var endOfValidity = startOfIssueDay.plusDays(validityDurationInDays);
-        var now = ZonedDateTime.now(clock);
+        if (validityDurationInDays == null) {
+            return false;
+        }
 
-        return endOfValidity.isBefore(now) || endOfValidity.isEqual(now);
-    }
-
-    public static boolean hasExpiredDrivingPermitVc(
-            VerifiableCredential drivingPermitVc, int validityDurationInDays, Clock clock) {
         var vcIssueTime = drivingPermitVc.getClaimsSet().getNotBeforeTime().toInstant();
 
         var dlExpiryDateString =
@@ -215,6 +210,17 @@ public class VcHelper {
 
         return dlExpiryDate.isBefore(vcIssueTime)
                 && hasExpired(vcIssueTime, validityDurationInDays, clock);
+    }
+
+    private static boolean hasExpired(
+            Instant vcIssueTime, int validityDurationInDays, Clock clock) {
+        var startOfIssueDay =
+                vcIssueTime.atZone(LONDON_TIMEZONE).toLocalDate().atStartOfDay(LONDON_TIMEZONE);
+
+        var endOfValidity = startOfIssueDay.plusDays(validityDurationInDays);
+        var now = ZonedDateTime.now(clock);
+
+        return endOfValidity.isBefore(now) || endOfValidity.isEqual(now);
     }
 
     public static boolean hasUnavailableOrNotApplicableFraudCheck(List<VerifiableCredential> vcs) {

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -36,6 +36,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawDrivingPermi
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawDrivingPermitDvaExpiredSameDayAsNbf;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawDrivingPermitDvaM1b;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawPassport;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitNullNbf;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraud;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudApplicableAuthoritativeSourceFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudAvailableAuthoritativeFailed;
@@ -510,6 +511,28 @@ class VcHelperTest {
         var result =
                 VcHelper.isExpiredDrivingPermitVc(
                         vcDcmawDrivingPermitDvaExpired(), configService, currentTime);
+
+        // Assert
+        assertFalse(result);
+    }
+
+    @Test
+    void isExpiredDrivingPermitVcShouldReturnFalseWhenVcIsMissingNbf() {
+        // Arrange
+        when(configService.getDcmawExpiredDlValidityPeriodDays()).thenReturn(180);
+
+        Clock currentTime =
+                Clock.fixed(
+                        ZonedDateTime.parse(
+                                        "2024-01-24 01:00:00+0100",
+                                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssZ"))
+                                .toInstant(),
+                        ZoneOffset.UTC);
+        // Act
+        // The below DCMAW VC has expiry: "2020-10-01", nbf: null
+        var result =
+                VcHelper.isExpiredDrivingPermitVc(
+                        vcDrivingPermitNullNbf(), configService, currentTime);
 
         // Assert
         assertFalse(result);


### PR DESCRIPTION
## Proposed changes
### What changed

- Add logic for expired DCMAW Driving Licence VCs
- If the DCMAW DL is expired and it's past the grace period, then we route them to [reprove-identity-start](https://identity.build.account.gov.uk/dev/template/reprove-identity-start/en) to reprove their identity

Note: this does not require a feature flag as Mobile isn't yet allowing people to prove their identity with an expired DL so this code shouldn't be touched

### Why did it change

We are introducing a validity period for driving licence VCs from the app. This is because a significant portion of DL scans fail because the DL has recently expired. This is a big issue for users who are attempting to renew their licence and blocks DVLA onboarding. Allowing time-limited expired-licence usage will help with improving these failure rates. 

Mobile are doing work to allow identity verification with DLs 90 days past their expiry (grace period) so we need to be able to support reuse scenarios where the user comes back with the expired driving licence; allowing them to reuse their identity if the current date is within a configured validity period from the VC's issue date.

A user's expired DCMAW DL VC is still valid if:
- the user's DL expired before the VC issue date
- there is a configurable validity period (in days)
- the time of reuse is within the VC's nbf + configurable validity period (days)
In which case, they can reuse their identity.

If not, they have to reprove their identity again.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8830](https://govukverify.atlassian.net/browse/PYIC-8830)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8830]: https://govukverify.atlassian.net/browse/PYIC-8830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ