### PR TITLE
PYIC-8829: Make fraud expiry check start from beginning of issue date

### DIFF
--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -1021,6 +1021,15 @@ public interface VcFixtures {
                 INSTANT_01_01_2099);
     }
 
+    static VerifiableCredential vcExperianFraud(Instant nbf) {
+        return generateVerifiableCredential(
+                TEST_SUBJECT,
+                EXPERIAN_FRAUD,
+                vcClaimExperianFraudScore1(),
+                FRAUD_ISSUER_INTEGRATION,
+                nbf);
+    }
+
     static VerifiableCredential vcExperianFraudMissingName() {
         var vcClaim = vcClaimExperianFraudScore1();
         vcClaim.getCredentialSubject().setName(Collections.emptyList());


### PR DESCRIPTION
## Proposed changes
### What changed

Updated fraud VC expiry period to start from the beginning of the day the VC was issued on

### Why did it change

To be consistent with the new driving licence VC expiry logic.

NOTE: this may need to be changed to fit with the DL changes

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8829](https://govukverify.atlassian.net/browse/PYIC-8829)



[PYIC-8829]: https://govukverify.atlassian.net/browse/PYIC-8829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ