### PR TITLE
PYIC-8829: Switch over to fraud expiry period in days

### DIFF
--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -1444,7 +1444,7 @@ class CheckExistingIdentityHandlerTest {
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
             when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
             when(configService.enabled(REPEAT_FRAUD_CHECK)).thenReturn(true);
-            when(configService.getFraudCheckExpiryPeriodHours()).thenReturn(1);
+            when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(1);
 
             var journeyResponse =
                     toResponseClass(
@@ -1471,7 +1471,7 @@ class CheckExistingIdentityHandlerTest {
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
             when(configService.enabled(RESET_IDENTITY)).thenReturn(false);
             when(configService.enabled(REPEAT_FRAUD_CHECK)).thenReturn(true);
-            when(configService.getFraudCheckExpiryPeriodHours()).thenReturn(100000000);
+            when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(100000000);
 
             var journeyResponse =
                     toResponseClass(

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/InternalOperationsConfig.java
@@ -22,8 +22,8 @@ public class InternalOperationsConfig {
     @NonNull URI audienceForClients;
     @NonNull Long jwtTtlSeconds;
     @NonNull Long maxAllowedAuthClientTtl;
-    @NonNull Integer fraudCheckExpiryPeriodHours;
-    Integer fraudCheckExpiryPeriodDays;
+    Integer fraudCheckExpiryPeriodHours;
+    @NonNull Integer fraudCheckExpiryPeriodDays;
     @NonNull Long dcmawAsyncVcPendingReturnTtl;
     @NonNull Integer dcmawExpiredDlValidityPeriodDays;
     @NonNull String clientJarKmsEncryptionKeyAliasPrimary;

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/ConfigService.java
@@ -171,8 +171,8 @@ public abstract class ConfigService {
         return getConfiguration().getClientConfig(clientId).getIssuer();
     }
 
-    public Integer getFraudCheckExpiryPeriodHours() {
-        return getConfiguration().getSelf().getFraudCheckExpiryPeriodHours();
+    public Integer getFraudCheckExpiryPeriodDays() {
+        return getConfiguration().getSelf().getFraudCheckExpiryPeriodDays();
     }
 
     public URI getSisApplicationUrl() {

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -149,8 +149,8 @@ class AppConfigServiceTest {
     }
 
     @Test
-    void getFraudCheckExpiryPeriodHours_returnsYamlValue() {
-        assertEquals(720, configService.getFraudCheckExpiryPeriodHours());
+    void getFraudCheckExpiryPeriodDays_returnsYamlValue() {
+        assertEquals(180, configService.getFraudCheckExpiryPeriodDays());
     }
 
     @Test

--- a/libs/sis-service/src/test/java/uk/gov/di/ipv/core/library/sis/service/SisServiceTest.java
+++ b/libs/sis-service/src/test/java/uk/gov/di/ipv/core/library/sis/service/SisServiceTest.java
@@ -410,7 +410,7 @@ class SisServiceTest {
         when(evcsService.fetchEvcsVerifiableCredentialsByState(
                         TEST_USER_ID, TEST_TOKEN, true, CURRENT, PENDING_RETURN))
                 .thenReturn(Map.of(CURRENT, EVCS_SUCCESSFUL_VCS, PENDING_RETURN, List.of()));
-        when(configService.getFraudCheckExpiryPeriodHours()).thenReturn(-1 * 100 * 365 * 24);
+        when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(-1 * 100 * 365);
 
         // Act
         sisService.compareStoredIdentityWithStoredVcs(clientOAuthSessionItem, auditEventUser);

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -8,7 +8,7 @@ core:
     audienceForClients: "https://identity.local.account.gov.uk"
     jwtTtlSeconds: 3600
     maxAllowedAuthClientTtl: 3600
-    fraudCheckExpiryPeriodHours: 720
+    fraudCheckExpiryPeriodDays: 180
     dcmawAsyncVcPendingReturnTtl: 1800
     dcmawExpiredDlValidityPeriodDays: 180
     clientJarKmsEncryptionKeyAliasPrimary: "CoreEncryptionKey1"
@@ -390,7 +390,7 @@ core:
         strategicAppEnabled: false
     zeroHourFraudVcExpiry:
       self:
-        fraudCheckExpiryPeriodHours: 0
+        fraudCheckExpiryPeriodDays: 0
     # Disabling CRIs
     f2fDisabled:
       credentialIssuers:

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -184,8 +184,7 @@ public class VcHelper {
             return true;
         }
 
-        var expiryPeriodInHours = configService.getFraudCheckExpiryPeriodHours();
-        int expiryPeriodInDays = expiryPeriodInHours / 24;
+        var expiryPeriodInDays = configService.getFraudCheckExpiryPeriodDays();
         return hasExpired(nbf, expiryPeriodInDays, clock);
     }
 

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -187,7 +187,7 @@ class VcHelperTest {
 
     @Test
     void shouldReturnTrueWhenAllVcsAreExpired() {
-        when(configService.getFraudCheckExpiryPeriodHours()).thenReturn(1);
+        when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(1);
 
         var vc = vcExperianFraudExpired();
 
@@ -198,7 +198,7 @@ class VcHelperTest {
 
     @Test
     void shouldReturnFalseWhenSomeVcsAreNotExpired() {
-        when(configService.getFraudCheckExpiryPeriodHours()).thenReturn(1);
+        when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(1);
 
         var vcExpired = vcExperianFraudExpired();
         var vcNotExpired = vcExperianFraudNotExpired();
@@ -210,7 +210,7 @@ class VcHelperTest {
 
     @Test
     void shouldReturnTrueWhenAllVcsAreExpiredOrNotAvailable() {
-        when(configService.getFraudCheckExpiryPeriodHours()).thenReturn(1);
+        when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(1);
 
         var vcExpired = vcExperianFraudExpired();
         var vcNotAvailable = vcExperianFraudAvailableAuthoritativeFailed();
@@ -281,7 +281,7 @@ class VcHelperTest {
             String vcCreationDateTime,
             String timeOfExpiryTest,
             boolean expectedIsExpired) {
-        when(configService.getFraudCheckExpiryPeriodHours()).thenReturn(expiryPeriodInDays * 24);
+        when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(expiryPeriodInDays);
 
         var vcCreationInstant =
                 ZonedDateTime.parse(

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -11,7 +11,7 @@ core:
     audienceForClients: "https://identity.local.account.gov.uk"
     jwtTtlSeconds: 3600
     maxAllowedAuthClientTtl: 3600
-    fraudCheckExpiryPeriodHours: 720
+    fraudCheckExpiryPeriodDays: 180
     dcmawAsyncVcPendingReturnTtl: 1800
     dcmawExpiredDlValidityPeriodDays: 180
     coreVtmClaim: "https://oidc.local.account.gov.uk/trustmark"
@@ -384,7 +384,7 @@ core:
         strategicAppEnabled: false
     zeroHourFraudVcExpiry:
       self:
-        fraudCheckExpiryPeriodHours: 0
+        fraudCheckExpiryPeriodDays: 0
     # Disabling CRIs
     f2fDisabled:
       credentialIssuers:


### PR DESCRIPTION
Also make hours value nullable so we can remove the config and then finally remove the hours value

## Proposed changes
### What changed

Switch over to using fraud expiry period in days

### Why did it change

To be consistent with the DL check

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8829](https://govukverify.atlassian.net/browse/PYIC-8829)

## Checklists

- [x] Production changes appropriately staged out


[PYIC-8829]: https://govukverify.atlassian.net/browse/PYIC-8829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ