### PR TITLE
PYIC-8873: Remove EnforceStayinSpecificVpc policy from all lambda functions.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -829,17 +829,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
             - Sid: AllowGetDeleteCriResponseDynamoDbTable
               Effect: Allow
               Action:
@@ -1153,17 +1142,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
@@ -1258,17 +1236,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBWritePolicy:
@@ -1369,17 +1336,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
@@ -1504,17 +1460,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
@@ -1658,17 +1603,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
             - Sid: kmsSigningKeyPermission
               Effect: Allow
               Action:
@@ -1796,17 +1730,6 @@ Resources:
                 - 'kms:GenerateDataKey'
               Resource:
                 - !ImportValue AuditEventQueueEncryptionKeyArn
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
       Events:
         IPVCoreMobileAppCallback:
           Type: Api
@@ -1921,17 +1844,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
       Events:
         IPVCoreCheckMobileAppVcReceipt:
           Type: Api
@@ -2030,17 +1942,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBCrudPolicy:
@@ -2150,17 +2051,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:
@@ -2402,17 +2292,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:
@@ -2518,17 +2397,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:
@@ -2641,17 +2509,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:
@@ -2765,17 +2622,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - DynamoDBReadPolicy:
@@ -2988,17 +2834,6 @@ Resources:
             Resource:
               - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
               - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-          - Sid: EnforceStayinSpecificVpc
-            Effect: Allow
-            Action:
-              - 'lambda:CreateFunction'
-              - 'lambda:UpdateFunctionConfiguration'
-            Resource:
-              - "*"
-            Condition:
-              StringEquals:
-                "lambda:VpcIds":
-                  - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
       AutoPublishAlias: live
 
   CheckGpg45ScoreFunctionLogGroup:
@@ -3041,18 +2876,6 @@ Resources:
           - !GetAtt LambdaSecurityGroup.GroupId
       Policies:
         - VPCAccessPolicy: { }
-        - Statement:
-          - Sid: EnforceStayinSpecificVpc
-            Effect: Allow
-            Action:
-              - 'lambda:CreateFunction'
-              - 'lambda:UpdateFunctionConfiguration'
-            Resource:
-              - "*"
-            Condition:
-              StringEquals:
-                "lambda:VpcIds":
-                  - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
       AutoPublishAlias: live
 
   ValidateAppConfigFunctionLogGroup:
@@ -3255,17 +3078,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:
@@ -3363,17 +3175,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
         - KMSDecryptPolicy:
             KeyId: !Ref DynamoDBKmsKey
         - SSMParameterReadPolicy:
@@ -3461,17 +3262,6 @@ Resources:
               Resource:
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
                 - !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/*"
-            - Sid: EnforceStayinSpecificVpc
-              Effect: Allow
-              Action:
-                - 'lambda:CreateFunction'
-                - 'lambda:UpdateFunctionConfiguration'
-              Resource:
-                - "*"
-              Condition:
-                StringEquals:
-                  "lambda:VpcIds":
-                    - Fn::ImportValue: !Sub ${VpcStackName}-VpcId
             - Sid: kmsAuditEventQueueEncryptionKeyPermission
               Effect: Allow
               Action:


### PR DESCRIPTION
## Proposed changes
### What changed

- Removed EnforceStayinSpecificVpc policy from each lambda declaration in CloudFromation template.

### Why did it change

In line with the principle of least privilege, each Lambda should only be granted the permissions required to complete its business function.

The ITHC discovered some potentially overly-permissioned Lambdas, including (most seriously) all of our application Lambdas being granted CreateFunction and UpdateFunctionConfiguration permissions against all resources. This can be found within a historical EnforceStayinSpecificVpc policy defined on each function. It’s not clear why this was added in the first place and what purpose it was intended to serve, but application functions shouldn't need to be able to create and update any further functions themselves.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8873](https://govukverify.atlassian.net/browse/PYIC-8873)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8873]: https://govukverify.atlassian.net/browse/PYIC-8873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ