### PR TITLE
PYIC-8899: deploy api tests to dev01 when pushing to main and from workflow dispatch

### DIFF
--- a/.github/workflows/secure-pipeline-api-tests-image.yml
+++ b/.github/workflows/secure-pipeline-api-tests-image.yml
@@ -6,6 +6,25 @@ on:
       environment:
         required: true
         type: string
+    secrets:
+      BUILD_API_TESTS_IMAGE_ECR_REPO_GHA_ROLE_ARN:
+        description: 'The GHA role for pushing to the ECR repo in build'
+        required: false
+      BUILD_API_TESTS_IMAGE_ECR_REPO_NAME:
+        description: 'The ECR repo name in build to push the api test image to'
+        required: false
+      CONTAINER_SIGN_KMS_KEY:
+        description: 'The KMS key used to sign the container with in build'
+        required: false
+      BUILD_API_TESTS_IMAGE_ECR_REPO_GHA_ROLE_ARN_DEV:
+        description: 'The GHA role for pushing to the ECR repo in dev01'
+        required: false
+      BUILD_API_TESTS_IMAGE_ECR_REPO_NAME_DEV:
+        description: 'The ECR repo name in dev01 to push the api test image to'
+        required: false
+      CONTAINER_SIGN_KMS_KEY_DEV:
+        description: 'The KMS key used to sign the container with in dev01'
+        required: false
 
 jobs:
   build-image-and-push:

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -26,6 +26,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@5250492686b253f06fa55861556d1027b067aeb5 # v9.0.2
+
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4.4.0
+        id: last_successful_commit_push_on_main
+        with:
+          main-branch-name: ${{ steps.branch-name.outputs.default_branch }}
+
       - name: Get changed api-tests files
         id: get-changed-files
         uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v47.0.1
@@ -33,6 +42,7 @@ jobs:
           files: |
             api-tests/**
             .github/workflows/secure-pipeline-api-tests-image.yml
+          base_sha: ${{ steps.last_successful_commit_push_on_main.outputs.base }}
 
       - name: List changed files
         env:
@@ -45,7 +55,7 @@ jobs:
   build-test-images-if-needed-build:
     needs: check-if-api-tests-changed
     if: ${{ needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' && github.event_name == 'push' }}
-    uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@dee13b402a32bb7ba9e4d3610288cc11f9658389
+    uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
     with:
       environment: 'build'
     secrets:
@@ -60,7 +70,7 @@ jobs:
   build-test-images-if-needed-shared-dev:
     needs: check-if-api-tests-changed
     if: ${{ needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' }}
-    uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@dee13b402a32bb7ba9e4d3610288cc11f9658389
+    uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
     with:
       environment: 'dev01'
     secrets:

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -42,12 +42,24 @@ jobs:
             echo "$file was changed"
           done
 
-  build-test-images-if-needed:
+  build-test-images-if-needed-build:
+    needs: check-if-api-tests-changed
+    if: ${{ needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' && github.event_name == 'push' }}
+    uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
+    with:
+      environment: 'build'
+    secrets: inherit # pragma: allowlist secret
+    permissions:
+      id-token: write
+      packages: read
+      contents: read
+
+  build-test-images-if-needed-dev01:
     needs: check-if-api-tests-changed
     if: ${{ needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' }}
     uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
     with:
-      environment: ${{ github.event_name == 'workflow_dispatch' && 'dev01' || 'build' }}
+      environment: 'dev01'
     secrets: inherit # pragma: allowlist secret
     permissions:
       id-token: write
@@ -91,7 +103,8 @@ jobs:
 
   deploy:
     needs:
-      - build-test-images-if-needed
+      - build-test-images-if-needed-build
+      - build-test-images-if-needed-dev01
       - check-if-deploy-needed
     if: |
       !failure() &&

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -45,22 +45,28 @@ jobs:
   build-test-images-if-needed-build:
     needs: check-if-api-tests-changed
     if: ${{ needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' && github.event_name == 'push' }}
-    uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
+    uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@dee13b402a32bb7ba9e4d3610288cc11f9658389
     with:
       environment: 'build'
-    secrets: inherit # pragma: allowlist secret
+    secrets:
+      BUILD_API_TESTS_IMAGE_ECR_REPO_GHA_ROLE_ARN: ${{ secrets.BUILD_API_TESTS_IMAGE_ECR_REPO_GHA_ROLE_ARN }}
+      BUILD_API_TESTS_IMAGE_ECR_REPO_NAME: ${{ secrets.BUILD_API_TESTS_IMAGE_ECR_REPO_NAME }}
+      CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
     permissions:
       id-token: write
       packages: read
       contents: read
 
-  build-test-images-if-needed-dev01:
+  build-test-images-if-needed-shared-dev:
     needs: check-if-api-tests-changed
     if: ${{ needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' }}
-    uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
+    uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@dee13b402a32bb7ba9e4d3610288cc11f9658389
     with:
       environment: 'dev01'
-    secrets: inherit # pragma: allowlist secret
+    secrets:
+      BUILD_API_TESTS_IMAGE_ECR_REPO_GHA_ROLE_ARN_DEV: ${{ secrets.BUILD_API_TESTS_IMAGE_ECR_REPO_GHA_ROLE_ARN_DEV }}
+      BUILD_API_TESTS_IMAGE_ECR_REPO_NAME_DEV: ${{ secrets.BUILD_API_TESTS_IMAGE_ECR_REPO_NAME_DEV }}
+      CONTAINER_SIGN_KMS_KEY_DEV: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
     permissions:
       id-token: write
       packages: read
@@ -104,7 +110,7 @@ jobs:
   deploy:
     needs:
       - build-test-images-if-needed-build
-      - build-test-images-if-needed-dev01
+      - build-test-images-if-needed-shared-dev
       - check-if-deploy-needed
     if: |
       !failure() &&

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -3,7 +3,7 @@ Feature: Audit Events
   Background: Disable the strategic app
     Given I activate the 'disableStrategicApp' feature set
 
-  # TEST: comment to test workflow  - if you see this please delete!
+  # TEST: comment to test workflow  - if you see this please delete!!
   @QualityGateRegressionTest
   Scenario: New identity - p2 app journey
     Given I activate the 'storedIdentityService' feature set

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -3,6 +3,7 @@ Feature: Audit Events
   Background: Disable the strategic app
     Given I activate the 'disableStrategicApp' feature set
 
+  # TEST: comment to test workflow  - if you see this please delete!
   @QualityGateRegressionTest
   Scenario: New identity - p2 app journey
     Given I activate the 'storedIdentityService' feature set


### PR DESCRIPTION
## Proposed changes
### What changed

- update secure-post-merge workflow so that the api-tests are deployed whenever we push into main and whenever the workflow is triggered via workflow_dispatch

### Why did it change

- The api tests are only being deployed to dev01 whenever we trigger a workflow dispatch. This means that the tests in this env can go out of sync with build and the pipelines in dev01 fail. This forces the api tests to be deployed to dev01 for every push to main and every workflow dispatch

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8899](https://govukverify.atlassian.net/browse/PYIC-8899)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8899]: https://govukverify.atlassian.net/browse/PYIC-8899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ