### PR TITLE
PYIC-8899: removing api test comment

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -3,7 +3,6 @@ Feature: Audit Events
   Background: Disable the strategic app
     Given I activate the 'disableStrategicApp' feature set
 
-  # TEST: comment to test workflow  - if you see this please delete!!
   @QualityGateRegressionTest
   Scenario: New identity - p2 app journey
     Given I activate the 'storedIdentityService' feature set


### PR DESCRIPTION
## Proposed changes
### What changed

- remove api test comment used for testing workflow changes

### Why did it change

- This was used to test a GH workflow update when pushing onto main. The workflow behaved like expected so we can get rid of this comment

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8899](https://govukverify.atlassian.net/browse/PYIC-8899)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8899]: https://govukverify.atlassian.net/browse/PYIC-8899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ