### PR TITLE
Pyic 8880 read ais flags

### DIFF
--- a/api-tests/features/account-intervention/fail-open.feature
+++ b/api-tests/features/account-intervention/fail-open.feature
@@ -1,85 +1,170 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Fail open scenarios
-
-  Scenario Outline: Journey with AIS failures but no interventions succeeds
+  Background: Disable strategic app
     Given I activate the 'disableStrategicApp' feature set
-    And The AIS stub will return an '<first_ais_response>' result
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When The AIS stub will return an '<second_ais_response>' result
-    And I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":1} |
-    Then I get a 'page-ipv-success' page response
 
-    Examples:
-      | first_ais_response  | second_ais_response |
-      | ERROR               | AIS_NO_INTERVENTION |
-      | AIS_NO_INTERVENTION | ERROR               |
-      | ERROR               | ERROR               |
+  Rule: Compare AIS descriptions
+    Background: Enable AIS description checking
+      Given I activate the 'disableAisStateCheck' feature set
 
-  Scenario Outline: Journey with AIS failure and <intervention> intervention fails
-    Given I activate the 'disableStrategicApp' feature set
-    And The AIS stub will return an '<first_ais_response>' result
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When The AIS stub will return an '<second_ais_response>' result
-    And I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":1} |
-    Then I get an OAuth response with error code 'session_invalidated'
-    And I don't have a stored identity in EVCS
+    Scenario Outline: Journey with AIS failures but no interventions succeeds
+      Given The AIS stub will return an '<first_ais_response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an '<second_ais_response>' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
 
-    Examples:
-      | intervention           | first_ais_response  | second_ais_response             |
-      | final blocked          | ERROR               | AIS_ACCOUNT_BLOCKED             |
-      | final reprove identity | ERROR               | AIS_FORCED_USER_IDENTITY_VERIFY |
+      Examples:
+        | first_ais_response  | second_ais_response |
+        | ERROR               | AIS_NO_INTERVENTION |
+        | AIS_NO_INTERVENTION | ERROR               |
+        | ERROR               | ERROR               |
 
+    Scenario Outline: Journey with AIS failure and <intervention> intervention fails
+      Given The AIS stub will return an '<first_ais_response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an '<second_ais_response>' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS
 
-  Scenario: Reprove identity journey with AIS failure succeeds
-    Given I activate the 'disableStrategicApp' feature set
-    And the subject already has the following credentials
-      | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
-      | address | kenneth-current              |
-      | fraud   | kenneth-score-2              |
-    And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
-    When I start a new 'medium-confidence' journey
-    Then I get a 'reprove-identity-start' page response
-    When I submit a 'next' event
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When The AIS stub will return an 'ERROR' result
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":1} |
-    Then I get a 'page-ipv-success' page response
+      Examples:
+        | intervention           | first_ais_response  | second_ais_response             |
+        | final blocked          | ERROR               | AIS_ACCOUNT_BLOCKED             |
+        | final reprove identity | ERROR               | AIS_FORCED_USER_IDENTITY_VERIFY |
+
+    Scenario: Reprove identity journey with AIS failure succeeds
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an 'ERROR' result
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+
+  Rule: Compare AIS states
+    Background: Enable AIS state checking
+      Given I activate the 'aisStateCheck' feature set
+
+    Scenario Outline: Journey with AIS failures but no interventions succeeds
+      Given The AIS stub will return an '<first_ais_response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an '<second_ais_response>' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+
+      Examples:
+        | first_ais_response  | second_ais_response |
+        | ERROR               | AIS_NO_INTERVENTION |
+        | AIS_NO_INTERVENTION | ERROR               |
+        | ERROR               | ERROR               |
+
+    Scenario Outline: Journey with AIS failure and <intervention> intervention fails
+      Given The AIS stub will return an '<first_ais_response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an '<second_ais_response>' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS
+
+      Examples:
+        | intervention           | first_ais_response  | second_ais_response             |
+        | final blocked          | ERROR               | AIS_ACCOUNT_BLOCKED             |
+        | final reprove identity | ERROR               | AIS_FORCED_USER_IDENTITY_VERIFY |
+
+    Scenario: Reprove identity journey with AIS failure succeeds
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an 'ERROR' result
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response

--- a/api-tests/features/account-intervention/journey-ending-interventions.feature
+++ b/api-tests/features/account-intervention/journey-ending-interventions.feature
@@ -1,152 +1,338 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Journey ending interventions
 
-  Scenario Outline: <intervention> intervention at of identity proving journey
-    Given I activate the 'disableStrategicApp' feature set
-    And The AIS stub will return an '<first_ais_response>' result
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When The AIS stub will return an '<second_ais_response>' result
-    And I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":1} |
-    Then I get an OAuth response with error code 'session_invalidated'
-    And I don't have a stored identity in EVCS
+  Rule: Compare AIS descriptions
+    Background: Enable AIS description checking
+      Given I activate the 'disableAisStateCheck' feature set
 
-    Examples:
-      | intervention                        | first_ais_response             | second_ais_response                                |
-      | Blocked                             | AIS_NO_INTERVENTION            | AIS_ACCOUNT_BLOCKED                                |
-      | Suspended                           | AIS_NO_INTERVENTION            | AIS_ACCOUNT_SUSPENDED                              |
-      | Password reset                      | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET                     |
-      | Reprove identity                    | AIS_NO_INTERVENTION            | AIS_FORCED_USER_IDENTITY_VERIFY                    |
-      | Password reset and reprove identity | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY |
+    Scenario Outline: <intervention> intervention at of identity proving journey
+      Given I activate the 'disableStrategicApp' feature set
+      And The AIS stub will return an '<first_ais_response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an '<second_ais_response>' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS
 
-  Scenario Outline: TICF <intervention> result during identity proving journey
-    Given I activate the 'disableStrategicApp' feature set
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When TICF CRI will respond with default parameters and
-      | interventionCode | <ticf_intervention_code> |
-    And I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":1} |
-    Then I get an OAuth response with error code 'session_invalidated'
-    And I don't have a stored identity in EVCS
+      Examples:
+        | intervention                        | first_ais_response             | second_ais_response                                |
+        | Blocked                             | AIS_NO_INTERVENTION            | AIS_ACCOUNT_BLOCKED                                |
+        | Suspended                           | AIS_NO_INTERVENTION            | AIS_ACCOUNT_SUSPENDED                              |
+        | Password reset                      | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET                     |
+        | Reprove identity                    | AIS_NO_INTERVENTION            | AIS_FORCED_USER_IDENTITY_VERIFY                    |
+        | Password reset and reprove identity | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY |
 
-    Examples:
-      | intervention                        | ticf_intervention_code |
-      | Blocked                             | 03                     |
-      | Suspended                           | 01                     |
-      | Password reset                      | 04                     |
-      | Reprove identity                    | 05                     |
-      | Password reset and reprove identity | 06                     |
+    Scenario Outline: TICF <intervention> result during identity proving journey
+      Given I activate the 'disableStrategicApp' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When TICF CRI will respond with default parameters and
+        | interventionCode | <ticf_intervention_code> |
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS
 
-  Scenario Outline: <intervention> intervention at of reprove identity journey
-    Given I activate the 'disableStrategicApp' feature set
-    And the subject already has the following credentials
-      | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
-      | address | kenneth-current              |
-      | fraud   | kenneth-score-2              |
-    And The AIS stub will return an '<first_ais_response>' result
-    When I start a new 'medium-confidence' journey
-    Then I get a 'reprove-identity-start' page response
-    When I submit a 'next' event
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get a 'dcmaw' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get a 'page-dcmaw-success' page response
-    When I submit a 'next' event
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When The AIS stub will return an '<second_ais_response>' result
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":1} |
-    Then I get an OAuth response with error code 'session_invalidated'
-    And I don't have a stored identity in EVCS
+      Examples:
+        | intervention                        | ticf_intervention_code |
+        | Blocked                             | 03                     |
+        | Suspended                           | 01                     |
+        | Password reset                      | 04                     |
+        | Reprove identity                    | 05                     |
+        | Password reset and reprove identity | 06                     |
 
-    Examples:
-      | intervention                        | first_ais_response                                 | second_ais_response                                |
-      | Blocked                             | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_ACCOUNT_BLOCKED                                |
-      | Suspended                           | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_ACCOUNT_SUSPENDED                              |
-      | Password reset                      | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_FORCED_USER_PASSWORD_RESET                     |
-      | Password reset and reprove identity | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY |
+    Scenario Outline: <intervention> intervention at of reprove identity journey
+      Given I activate the 'disableStrategicApp' feature set
+      And the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      And The AIS stub will return an '<first_ais_response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an '<second_ais_response>' result
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS
 
-  Scenario: Blocked intervention of update identity journey
-    Given the subject already has the following credentials
-      | CRI     | scenario                     |
-      | dcmaw   | kenneth-driving-permit-valid |
-      | address | kenneth-current              |
-      | fraud   | kenneth-score-2              |
-    And The AIS stub will return an 'AIS_NO_INTERVENTION' result
-    When I start a new 'medium-confidence' journey with AIS stub response of 'AIS_ACCOUNT_BLOCKED'
-    Then I get an OAuth response with error code 'session_invalidated'
+      Examples:
+        | intervention                        | first_ais_response                                 | second_ais_response                                |
+        | Blocked                             | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_ACCOUNT_BLOCKED                                |
+        | Suspended                           | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_ACCOUNT_SUSPENDED                              |
+        | Password reset                      | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_FORCED_USER_PASSWORD_RESET                     |
+        | Password reset and reprove identity | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY |
 
-  Scenario: Blocked intervention at end of update identity journey
-    Given the subject already has the following credentials
-      | CRI     | scenario               |
-      | dcmaw   | kenneth-passport-valid |
-      | address | kenneth-current        |
-      | fraud   | kenneth-score-2        |
-    And The AIS stub will return an 'AIS_NO_INTERVENTION' result
-    When I start a new 'medium-confidence' journey
-    Then I get a 'page-ipv-reuse' page response
-    When I submit a 'update-details' event
-    Then I get a 'update-details' page response
-    When I submit a 'address-only' event
-    Then I get a 'address' CRI response
-    When I submit 'kenneth-changed' details with attributes to the CRI stub
-      | Attribute | Values               |
-      | context   | "international_user" |
-    Then I get a 'fraud' CRI response
-    When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":1} |
-    Then I get an OAuth response with error code 'session_invalidated'
+    Scenario: Blocked intervention of update identity journey
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      And The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      When I start a new 'medium-confidence' journey with AIS stub response of 'AIS_ACCOUNT_BLOCKED'
+      Then I get an OAuth response with error code 'session_invalidated'
 
-  Scenario: Blocked intervention at end of initial F2F journey
-    Given The AIS stub will return an 'AIS_NO_INTERVENTION' result
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'end' event
-    Then I get a 'page-ipv-identity-postoffice-start' page response
-    When I submit a 'next' event
-    Then I get a 'claimedIdentity' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
-    And I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get an OAuth response with error code 'session_invalidated'
-    And I don't have a stored identity in EVCS
+    Scenario: Blocked intervention at end of update identity journey
+      Given the subject already has the following credentials
+        | CRI     | scenario               |
+        | dcmaw   | kenneth-passport-valid |
+        | address | kenneth-current        |
+        | fraud   | kenneth-score-2        |
+      And The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-reuse' page response
+      When I submit a 'update-details' event
+      Then I get a 'update-details' page response
+      When I submit a 'address-only' event
+      Then I get a 'address' CRI response
+      When I submit 'kenneth-changed' details with attributes to the CRI stub
+        | Attribute | Values               |
+        | context   | "international_user" |
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+
+    Scenario: Blocked intervention at end of initial F2F journey
+      Given The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS
+
+  Rule: Compare AIS states
+    Background: Enable AIS state checking
+      Given I activate the 'aisStateCheck' feature set
+
+    Scenario Outline: <intervention> intervention during identity proving journey invalidates session
+      Given I activate the 'disableStrategicApp' feature set
+      And The AIS stub will return an '<first_ais_response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an '<second_ais_response>' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS
+
+      Examples:
+        | intervention                        | first_ais_response             | second_ais_response                                |
+        | Blocked                             | AIS_NO_INTERVENTION            | AIS_ACCOUNT_BLOCKED                                |
+        | Suspended                           | AIS_NO_INTERVENTION            | AIS_ACCOUNT_SUSPENDED                              |
+        | Password reset                      | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET                     |
+        | Reprove identity                    | AIS_NO_INTERVENTION            | AIS_FORCED_USER_IDENTITY_VERIFY                    |
+        | Password reset and reprove identity | AIS_NO_INTERVENTION            | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY |
+
+    Scenario Outline: <intervention> intervention during identity proving journey doesn't invalidate session
+      Given I activate the 'disableStrategicApp' feature set
+      And The AIS stub will return an '<first_ais_response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an '<second_ais_response>' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+
+      Examples:
+        | intervention                        | first_ais_response             | second_ais_response        |
+        | No intervention                     | AIS_NO_INTERVENTION            | AIS_NO_INTERVENTION        |
+        | Unsuspended                         | AIS_NO_INTERVENTION            | AIS_ACCOUNT_UNSUSPENDED    |
+        | Unblocked                           | AIS_NO_INTERVENTION            | AIS_ACCOUNT_UNBLOCKED      |
+        | Password reset cleared              | AIS_NO_INTERVENTION            | AIS_PASSWORD_RESET_CLEARED |
+
+    Scenario Outline: TICF <intervention> result during identity proving journey
+      Given I activate the 'disableStrategicApp' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When TICF CRI will respond with default parameters and
+        | interventionCode | <ticf_intervention_code> |
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS
+
+      Examples:
+        | intervention                        | ticf_intervention_code |
+        | Blocked                             | 03                     |
+        | Suspended                           | 01                     |
+        | Password reset                      | 04                     |
+        | Reprove identity                    | 05                     |
+        | Password reset and reprove identity | 06                     |
+
+    Scenario Outline: <intervention> intervention during reprove identity journey
+      Given I activate the 'disableStrategicApp' feature set
+      And the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      And The AIS stub will return an '<first_ais_response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an '<second_ais_response>' result
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS
+
+      Examples:
+        | intervention                        | first_ais_response                                 | second_ais_response                                |
+        | Blocked                             | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_ACCOUNT_BLOCKED                                |
+        | Suspended                           | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_ACCOUNT_SUSPENDED                              |
+        | Password reset                      | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_FORCED_USER_PASSWORD_RESET                     |
+        | Password reset and reprove identity | AIS_FORCED_USER_IDENTITY_VERIFY                    | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY |
+
+    Scenario: Blocked intervention of update identity journey
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      And The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      When I start a new 'medium-confidence' journey with AIS stub response of 'AIS_ACCOUNT_BLOCKED'
+      Then I get an OAuth response with error code 'session_invalidated'
+
+    Scenario: Blocked intervention at end of update identity journey
+      Given the subject already has the following credentials
+        | CRI     | scenario               |
+        | dcmaw   | kenneth-passport-valid |
+        | address | kenneth-current        |
+        | fraud   | kenneth-score-2        |
+      And The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-reuse' page response
+      When I submit a 'update-details' event
+      Then I get a 'update-details' page response
+      When I submit a 'address-only' event
+      Then I get a 'address' CRI response
+      When I submit 'kenneth-changed' details with attributes to the CRI stub
+        | Attribute | Values               |
+        | context   | "international_user" |
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an OAuth response with error code 'session_invalidated'
+
+    Scenario: Blocked intervention at end of initial F2F journey
+      Given The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an OAuth response with error code 'session_invalidated'
+      And I don't have a stored identity in EVCS

--- a/api-tests/features/account-intervention/journey-ending-interventions.feature
+++ b/api-tests/features/account-intervention/journey-ending-interventions.feature
@@ -215,7 +215,7 @@ Feature: Journey ending interventions
         | No intervention                     | AIS_NO_INTERVENTION            | AIS_NO_INTERVENTION        |
         | Unsuspended                         | AIS_NO_INTERVENTION            | AIS_ACCOUNT_UNSUSPENDED    |
         | Unblocked                           | AIS_NO_INTERVENTION            | AIS_ACCOUNT_UNBLOCKED      |
-        | Password reset cleared              | AIS_NO_INTERVENTION            | AIS_PASSWORD_RESET_CLEARED |
+        | Password reset cleared              | AIS_NO_INTERVENTION            | PASSWORD_RESET_CLEARED     |
 
     Scenario Outline: TICF <intervention> result during identity proving journey
       Given I activate the 'disableStrategicApp' feature set

--- a/api-tests/features/account-intervention/journey-starting-intervention.feature
+++ b/api-tests/features/account-intervention/journey-starting-intervention.feature
@@ -1,26 +1,59 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: First Account Intervention call
 
-  Scenario Outline: Not allowed <intervention> intervention on start of identity proving journey
-    Given The AIS stub will return an '<response>' result
-    When I start a new 'medium-confidence' journey
-    Then I get an OAuth response with error code 'session_invalidated'
+  Rule: Compare AIS descriptions
+    Background: Enable AIS description checking
+      Given I activate the 'disableAisStateCheck' feature set
 
-    Examples:
-      | intervention                        | response                                            |
-      | Blocked                             | AIS_ACCOUNT_BLOCKED                                 |
-      | Suspended                           | AIS_ACCOUNT_SUSPENDED                               |
-      | Password reset                      | AIS_FORCED_USER_PASSWORD_RESET                      |
-      | Password reset and reprove identity | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY  |
+    Scenario Outline: Not allowed <intervention> intervention on start of identity proving journey
+      Given The AIS stub will return an '<response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get an OAuth response with error code 'session_invalidated'
 
-  Scenario Outline: Allowed <intervention> intervention on start of identity proving journey
-    Given The AIS stub will return an '<response>' result
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
+      Examples:
+        | intervention                        | response                                            |
+        | Blocked                             | AIS_ACCOUNT_BLOCKED                                 |
+        | Suspended                           | AIS_ACCOUNT_SUSPENDED                               |
+        | Password reset                      | AIS_FORCED_USER_PASSWORD_RESET                      |
+        | Password reset and reprove identity | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY  |
 
-#    Reprove identity is handled in separate file
-    Examples:
-      | intervention                        | response                                            |
-      | No intervention                     | AIS_NO_INTERVENTION                                 |
-      | Unsuspended                         | AIS_ACCOUNT_UNSUSPENDED                             |
-      | Unblocked                           | AIS_ACCOUNT_UNBLOCKED                               |
+    Scenario Outline: Allowed <intervention> intervention on start of identity proving journey
+      Given The AIS stub will return an '<response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+
+  #    Reprove identity is handled in separate file
+      Examples:
+        | intervention                        | response                                            |
+        | No intervention                     | AIS_NO_INTERVENTION                                 |
+        | Unsuspended                         | AIS_ACCOUNT_UNSUSPENDED                             |
+        | Unblocked                           | AIS_ACCOUNT_UNBLOCKED                               |
+
+  Rule: Compare AIS states
+    Background: Enable AIS state checking
+      Given I activate the 'aisStateCheck' feature set
+
+    Scenario Outline: Not allowed <intervention> intervention on start of identity proving journey
+      Given The AIS stub will return an '<response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get an OAuth response with error code 'session_invalidated'
+
+      Examples:
+        | intervention                        | response                                            |
+        | Blocked                             | AIS_ACCOUNT_BLOCKED                                 |
+        | Suspended                           | AIS_ACCOUNT_SUSPENDED                               |
+        | Password reset                      | AIS_FORCED_USER_PASSWORD_RESET                      |
+        | Password reset and reprove identity | AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY  |
+
+    Scenario Outline: Allowed <intervention> intervention on start of identity proving journey
+      Given The AIS stub will return an '<response>' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+
+  #    Reprove identity is handled in separate file
+      Examples:
+        | intervention                        | response                                            |
+        | No intervention                     | AIS_NO_INTERVENTION                                 |
+        | Unsuspended                         | AIS_ACCOUNT_UNSUSPENDED                             |
+        | Unblocked                           | AIS_ACCOUNT_UNBLOCKED                               |
+        | Password reset cleared              | AIS_PASSWORD_RESET_CLEARED                          |

--- a/api-tests/features/account-intervention/journey-starting-intervention.feature
+++ b/api-tests/features/account-intervention/journey-starting-intervention.feature
@@ -56,6 +56,6 @@ Feature: First Account Intervention call
         | No intervention                     | AIS_NO_INTERVENTION                     |
         | Unsuspended                         | AIS_ACCOUNT_UNSUSPENDED                 |
         | Unblocked                           | AIS_ACCOUNT_UNBLOCKED                   |
-        | Password reset cleared              | AIS_PASSWORD_RESET_CLEARED              |
-        | Password reset and reverify cleared | AIS_PASSWORD_RESET_AND_REVERIFY_CLEARED |
-        | Ewvweification cleared              | AIS_REVERIFY_CLEARED                    |
+        | Password reset cleared              | PASSWORD_RESET_CLEARED                  |
+        | Password reset and reverify cleared | PASSWORD_RESET_AND_REVERIFY_CLEARED     |
+        | Ewvweification cleared              | REVERIFY_CLEARED                        |

--- a/api-tests/features/account-intervention/journey-starting-intervention.feature
+++ b/api-tests/features/account-intervention/journey-starting-intervention.feature
@@ -52,8 +52,10 @@ Feature: First Account Intervention call
 
   #    Reprove identity is handled in separate file
       Examples:
-        | intervention                        | response                                            |
-        | No intervention                     | AIS_NO_INTERVENTION                                 |
-        | Unsuspended                         | AIS_ACCOUNT_UNSUSPENDED                             |
-        | Unblocked                           | AIS_ACCOUNT_UNBLOCKED                               |
-        | Password reset cleared              | AIS_PASSWORD_RESET_CLEARED                          |
+        | intervention                        | response                                |
+        | No intervention                     | AIS_NO_INTERVENTION                     |
+        | Unsuspended                         | AIS_ACCOUNT_UNSUSPENDED                 |
+        | Unblocked                           | AIS_ACCOUNT_UNBLOCKED                   |
+        | Password reset cleared              | AIS_PASSWORD_RESET_CLEARED              |
+        | Password reset and reverify cleared | AIS_PASSWORD_RESET_AND_REVERIFY_CLEARED |
+        | Ewvweification cleared              | AIS_REVERIFY_CLEARED                    |

--- a/api-tests/features/account-intervention/p2-reprove-identity.feature
+++ b/api-tests/features/account-intervention/p2-reprove-identity.feature
@@ -64,7 +64,7 @@ Feature: Reprove Identity Journey
           | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-          | Attribute          | Values                                          |
+          | Attribute          | Values                                      |
           | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
       Then I get a 'page-face-to-face-handoff' page response
 
@@ -93,7 +93,7 @@ Feature: Reprove Identity Journey
           | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-          | Attribute          | Values                                          |
+          | Attribute          | Values                                      |
           | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
       Then I get a 'page-face-to-face-handoff' page response
 
@@ -133,7 +133,7 @@ Feature: Reprove Identity Journey
           | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-          | Attribute          | Values                                          |
+          | Attribute          | Values                                      |
           | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
       Then I get a 'page-face-to-face-handoff' page response
 
@@ -194,9 +194,9 @@ Feature: Reprove Identity Journey
       Then I get a 'P2' identity
 
       Examples:
-        | intervention                        | ais_response                            |
-        | Reverify                            | AIS_FORCED_USER_IDENTITY_VERIFY         |
-        | Password reset cleared and reverify | AIS_PASSWORD_RESET_CLEARED_AND_REVERIFY |
+        | intervention                        | ais_response                        |
+        | Reverify                            | AIS_FORCED_USER_IDENTITY_VERIFY     |
+        | Password reset cleared and reverify | PASSWORD_RESET_CLEARED_AND_REVERIFY |
 
     Scenario: User reproves with F2F with AIS
       Given the subject already has the following credentials
@@ -224,7 +224,7 @@ Feature: Reprove Identity Journey
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-        | Attribute          | Values                                          |
+        | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
       Then I get a 'page-face-to-face-handoff' page response
 
@@ -253,7 +253,7 @@ Feature: Reprove Identity Journey
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-        | Attribute          | Values                                          |
+        | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
       Then I get a 'page-face-to-face-handoff' page response
 
@@ -294,7 +294,7 @@ Feature: Reprove Identity Journey
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
       When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-        | Attribute          | Values                                          |
+        | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
       Then I get a 'page-face-to-face-handoff' page response
 

--- a/api-tests/features/account-intervention/p2-reprove-identity.feature
+++ b/api-tests/features/account-intervention/p2-reprove-identity.feature
@@ -1,157 +1,315 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Reprove Identity Journey
-    Background: Disable strategic app
-        Given I activate the 'disableStrategicApp' feature set
+  Background: Disable strategic app
+    Given I activate the 'disableStrategicApp' feature set
 
-    Rule: Flag from AIS
-        # These are duplicates of the tests above but using the AIS API instead of the orchestrator flag
-        Scenario: User reproves identity with AIS
-            Given the subject already has the following credentials
-                | CRI     | scenario                     |
-                | dcmaw   | kenneth-driving-permit-valid |
-                | address | kenneth-current              |
-                | fraud   | kenneth-score-2              |
-            And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
-            When I start a new 'medium-confidence' journey
-            Then I get a 'reprove-identity-start' page response
-            When I submit a 'next' event
-            Then I get a 'live-in-uk' page response
-            When I submit a 'uk' event
-            Then I get a 'page-ipv-identity-document-start' page response
-            When I submit an 'appTriage' event
-            Then I get a 'dcmaw' CRI response
-            When I submit 'kenneth-passport-valid' details to the CRI stub
-            Then I get a 'page-dcmaw-success' page response
-            When I submit a 'next' event
-            Then I get an 'address' CRI response
-            When I submit 'kenneth-current' details to the CRI stub
-            Then I get a 'fraud' CRI response
-            When The AIS stub will return an 'AIS_NO_INTERVENTION' result
-            And I submit 'kenneth-score-2' details with attributes to the CRI stub
-                | Attribute          | Values                   |
-                | evidence_requested | {"identityFraudScore":1} |
-            Then I get a 'page-ipv-success' page response
-            When I submit a 'next' event
-            Then I get an OAuth response
-            When I use the OAuth response to get my identity
-            Then I get a 'P2' identity
+  Rule: Flag from AIS
+    Background: Enable AIS description checking
+      Given I activate the 'disableAisStateCheck' feature set
 
-        Scenario: User reproves with F2F with AIS
-            Given the subject already has the following credentials
-                | CRI     | scenario                     |
-                | dcmaw   | kenneth-driving-permit-valid |
-                | address | kenneth-current              |
-                | fraud   | kenneth-score-2              |
-            And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
-            When I start a new 'medium-confidence' journey
-            Then I get a 'reprove-identity-start' page response
-            When I submit a 'next' event
-            Then I get a 'live-in-uk' page response
-            When I submit a 'uk' event
-            Then I get a 'page-ipv-identity-document-start' page response
-            When I submit an 'end' event
-            Then I get a 'page-ipv-identity-postoffice-start' page response
-            When I submit a 'next' event
-            Then I get a 'claimedIdentity' CRI response
-            When I submit 'kenneth-current' details to the CRI stub
-            Then I get an 'address' CRI response
-            When I submit 'kenneth-current' details to the CRI stub
-            Then I get a 'fraud' CRI response
-            When I submit 'kenneth-score-2' details with attributes to the CRI stub
-                | Attribute          | Values                   |
-                | evidence_requested | {"identityFraudScore":2} |
-            Then I get a 'f2f' CRI response
-            When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-                | Attribute          | Values                                          |
-                | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
-            Then I get a 'page-face-to-face-handoff' page response
+    Scenario: User reproves identity with AIS
+      Given the subject already has the following credentials
+          | CRI     | scenario                     |
+          | dcmaw   | kenneth-driving-permit-valid |
+          | address | kenneth-current              |
+          | fraud   | kenneth-score-2              |
+      And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+          | Attribute          | Values                   |
+          | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: User reproves with F2F with AIS
+      Given the subject already has the following credentials
+          | CRI     | scenario                     |
+          | dcmaw   | kenneth-driving-permit-valid |
+          | address | kenneth-current              |
+          | fraud   | kenneth-score-2              |
+      And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+          | Attribute          | Values                   |
+          | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+          | Attribute          | Values                                          |
+          | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey after popping out to the Post Office
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: User needs to reprove their identity with F2F pending with AIS
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+          | Attribute          | Values                   |
+          | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+          | Attribute          | Values                                          |
+          | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+  # Users been to the Post Office but sadly now has an account intervention
+      Given The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      And I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+
+  Rule: F2F journeys are subject to COI checks
+    Background:
+      Given the subject already has the following credentials
+          | CRI     | scenario                     |
+          | dcmaw   | kenneth-driving-permit-valid |
+          | address | kenneth-current              |
+          | fraud   | kenneth-score-2              |
+      And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      When I start a new 'medium-confidence' journey with reprove identity
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+
+    Scenario: Reproving with F2F journey with same identity passes COI check
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+          | Attribute          | Values                   |
+          | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+          | Attribute          | Values                                          |
+          | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey after popping out to the Post Office
+      When I start new 'medium-confidence' journeys with reprove identity until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: Reproving with F2F journey with different identity fails COI check
+      When I submit 'lora' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'lora-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'lora-score-2' details with attributes to the CRI stub
+          | Attribute          | Values                   |
+          | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+
+  Rule: Flag from AIS use state comparison
+    Background: Enable AIS description checking
+      Given I activate the 'aisStateCheck' feature set
+
+    Scenario: User reproves identity with AIS
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'dcmaw' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When The AIS stub will return an 'AIS_NO_INTERVENTION' result
+      And I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
+
+    Scenario: User reproves with F2F with AIS
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      When I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
 
         # Return journey after popping out to the Post Office
-            When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
-            When I submit a 'next' event
-            Then I get an OAuth response
-            When I use the OAuth response to get my identity
-            Then I get a 'P2' identity
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
 
-        Scenario: User needs to reprove their identity with F2F pending with AIS
-            When I start a new 'medium-confidence' journey
-            Then I get a 'live-in-uk' page response
-            When I submit a 'uk' event
-            Then I get a 'page-ipv-identity-document-start' page response
-            When I submit an 'end' event
-            Then I get a 'page-ipv-identity-postoffice-start' page response
-            When I submit a 'next' event
-            Then I get a 'claimedIdentity' CRI response
-            When I submit 'kenneth-current' details to the CRI stub
-            Then I get an 'address' CRI response
-            When I submit 'kenneth-current' details to the CRI stub
-            Then I get a 'fraud' CRI response
-            When I submit 'kenneth-score-2' details with attributes to the CRI stub
-                | Attribute          | Values                   |
-                | evidence_requested | {"identityFraudScore":2} |
-            Then I get a 'f2f' CRI response
-            When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-                | Attribute          | Values                                          |
-                | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
-            Then I get a 'page-face-to-face-handoff' page response
+    Scenario: User needs to reprove their identity with F2F pending with AIS
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
 
         # Users been to the Post Office but sadly now has an account intervention
-            Given The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
-            And I start a new 'medium-confidence' journey
-            Then I get a 'reprove-identity-start' page response
-            When I submit a 'next' event
-            Then I get a 'live-in-uk' page response
+      Given The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      And I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
 
-    Rule: F2F journeys are subject to COI checks
-        Background:
-            Given the subject already has the following credentials
-                | CRI     | scenario                     |
-                | dcmaw   | kenneth-driving-permit-valid |
-                | address | kenneth-current              |
-                | fraud   | kenneth-score-2              |
-            And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
-            When I start a new 'medium-confidence' journey with reprove identity
-            Then I get a 'reprove-identity-start' page response
-            When I submit a 'next' event
-            Then I get a 'live-in-uk' page response
-            When I submit a 'uk' event
-            Then I get a 'page-ipv-identity-document-start' page response
-            When I submit an 'end' event
-            Then I get a 'page-ipv-identity-postoffice-start' page response
-            When I submit a 'next' event
-            Then I get a 'claimedIdentity' CRI response
+  Rule: F2F journeys are subject to COI checks
+    Background:
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+        | fraud   | kenneth-score-2              |
+      And I activate the 'aisStateCheck' feature set
+      And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      When I start a new 'medium-confidence' journey with reprove identity
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
 
-        Scenario: Reproving with F2F journey with same identity passes COI check
-            When I submit 'kenneth-current' details to the CRI stub
-            Then I get an 'address' CRI response
-            When I submit 'kenneth-current' details to the CRI stub
-            Then I get a 'fraud' CRI response
-            When I submit 'kenneth-score-2' details with attributes to the CRI stub
-                | Attribute          | Values                   |
-                | evidence_requested | {"identityFraudScore":2} |
-            Then I get a 'f2f' CRI response
-            When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
-                | Attribute          | Values                                          |
-                | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
-            Then I get a 'page-face-to-face-handoff' page response
+    Scenario: Reproving with F2F journey with same identity passes COI check
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
 
             # Return journey after popping out to the Post Office
-            When I start new 'medium-confidence' journeys with reprove identity until I get a 'page-ipv-reuse' page response
-            When I submit a 'next' event
-            Then I get an OAuth response
-            When I use the OAuth response to get my identity
-            Then I get a 'P2' identity
+      When I start new 'medium-confidence' journeys with reprove identity until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P2' identity
 
-        Scenario: Reproving with F2F journey with different identity fails COI check
-            When I submit 'lora' details to the CRI stub
-            Then I get an 'address' CRI response
-            When I submit 'lora-current' details to the CRI stub
-            Then I get a 'fraud' CRI response
-            When I submit 'lora-score-2' details with attributes to the CRI stub
-                | Attribute          | Values                   |
-                | evidence_requested | {"identityFraudScore":2} |
-            Then I get a 'pyi-no-match' page response
-            When I submit a 'next' event
-            Then I get an OAuth response
-            When I use the OAuth response to get my identity
-            Then I get a 'P0' identity
+    Scenario: Reproving with F2F journey with different identity fails COI check
+      When I submit 'lora' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'lora-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'lora-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity

--- a/api-tests/features/account-intervention/p2-reprove-identity.feature
+++ b/api-tests/features/account-intervention/p2-reprove-identity.feature
@@ -162,13 +162,13 @@ Feature: Reprove Identity Journey
     Background: Enable AIS description checking
       Given I activate the 'aisStateCheck' feature set
 
-    Scenario: User reproves identity with AIS
+    Scenario Outline: User reproves identity with AIS (<intervention>)
       Given the subject already has the following credentials
         | CRI     | scenario                     |
         | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
-      And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
+      And The AIS stub will return an '<ais_response>' result
       When I start a new 'medium-confidence' journey
       Then I get a 'reprove-identity-start' page response
       When I submit a 'next' event
@@ -192,6 +192,11 @@ Feature: Reprove Identity Journey
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I get a 'P2' identity
+
+      Examples:
+        | intervention                        | ais_response                            |
+        | Reverify                            | AIS_FORCED_USER_IDENTITY_VERIFY         |
+        | Password reset cleared and reverify | AIS_PASSWORD_RESET_CLEARED_AND_REVERIFY |
 
     Scenario: User reproves with F2F with AIS
       Given the subject already has the following credentials

--- a/api-tests/src/clients/ais-management-api.ts
+++ b/api-tests/src/clients/ais-management-api.ts
@@ -1,7 +1,15 @@
 import config from "../config/config.js";
 
+interface AisState {
+  blocked: boolean;
+  suspended: boolean;
+  reproveIdentity: boolean;
+  resetPassword: boolean;
+}
+
 interface AisManagementRequestBody {
   intervention: string;
+  state?: AisState;
   statusCode?: number;
 }
 
@@ -11,6 +19,19 @@ export const primeResponseForUser = async (
 ) => {
   const requestBody: AisManagementRequestBody = {
     intervention: AisValidResponseTypes[desiredResponse],
+  };
+
+  await sendManagementRequest(userId, requestBody);
+};
+
+export const primeCustomResponseForUser = async (
+  userId: string,
+  baseResponse: AisValidResponseTypes,
+  customState: AisState,
+) => {
+  const requestBody: AisManagementRequestBody = {
+    intervention: AisValidResponseTypes[baseResponse],
+    state: customState,
   };
 
   await sendManagementRequest(userId, requestBody);
@@ -44,8 +65,9 @@ async function sendManagementRequest(
   });
 
   if (!response.ok) {
+    const errorBody = await response.text();
     throw new Error(
-      `AIS Management API request failed: ${response.statusText}`,
+      `AIS Management API request failed: ${response.statusText}: ${errorBody}`,
     );
   }
 }

--- a/api-tests/src/steps/ais-steps.ts
+++ b/api-tests/src/steps/ais-steps.ts
@@ -19,10 +19,55 @@ When(
     }
 
     if (desiredApiResult === "AIS_PASSWORD_RESET_CLEARED") {
-      // Mimic the case where an intervention has been cleared, but the description has not been updated.
+      // Mimic the case where a password reset has happened, but the description has not been updated.
       await primeCustomResponseForUser(
         this.userId,
         AisValidResponseTypes.AIS_FORCED_USER_PASSWORD_RESET,
+        {
+          blocked: false,
+          resetPassword: false,
+          reproveIdentity: false,
+          suspended: false,
+        },
+      );
+      return;
+    }
+
+    if (desiredApiResult === "AIS_REVERIFY_CLEARED") {
+      // Mimic the case where a reverification has happened, but the description has not been updated.
+      await primeCustomResponseForUser(
+        this.userId,
+        AisValidResponseTypes.AIS_FORCED_USER_IDENTITY_VERIFY,
+        {
+          blocked: false,
+          resetPassword: false,
+          reproveIdentity: false,
+          suspended: false,
+        },
+      );
+      return;
+    }
+
+    if (desiredApiResult === "AIS_PASSWORD_RESET_CLEARED_AND_REVERIFY") {
+      // Mimic the case where a password reset has happened, but the description has not been updated and the user still needs to reverify.
+      await primeCustomResponseForUser(
+        this.userId,
+        AisValidResponseTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
+        {
+          blocked: false,
+          resetPassword: false,
+          reproveIdentity: true,
+          suspended: true,
+        },
+      );
+      return;
+    }
+
+    if (desiredApiResult === "AIS_PASSWORD_RESET_AND_REVERIFY_CLEARED") {
+      // Mimic the case where a password reset and reverification has happened, but the description has not been updated.
+      await primeCustomResponseForUser(
+        this.userId,
+        AisValidResponseTypes.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY,
         {
           blocked: false,
           resetPassword: false,

--- a/api-tests/src/steps/ais-steps.ts
+++ b/api-tests/src/steps/ais-steps.ts
@@ -18,7 +18,7 @@ When(
       return;
     }
 
-    if (desiredApiResult === "AIS_PASSWORD_RESET_CLEARED") {
+    if (desiredApiResult === "PASSWORD_RESET_CLEARED") {
       // Mimic the case where a password reset has happened, but the description has not been updated.
       await primeCustomResponseForUser(
         this.userId,
@@ -33,7 +33,7 @@ When(
       return;
     }
 
-    if (desiredApiResult === "AIS_REVERIFY_CLEARED") {
+    if (desiredApiResult === "REVERIFY_CLEARED") {
       // Mimic the case where a reverification has happened, but the description has not been updated.
       await primeCustomResponseForUser(
         this.userId,
@@ -48,7 +48,7 @@ When(
       return;
     }
 
-    if (desiredApiResult === "AIS_PASSWORD_RESET_CLEARED_AND_REVERIFY") {
+    if (desiredApiResult === "PASSWORD_RESET_CLEARED_AND_REVERIFY") {
       // Mimic the case where a password reset has happened, but the description has not been updated and the user still needs to reverify.
       await primeCustomResponseForUser(
         this.userId,
@@ -63,7 +63,7 @@ When(
       return;
     }
 
-    if (desiredApiResult === "AIS_PASSWORD_RESET_AND_REVERIFY_CLEARED") {
+    if (desiredApiResult === "PASSWORD_RESET_AND_REVERIFY_CLEARED") {
       // Mimic the case where a password reset and reverification has happened, but the description has not been updated.
       await primeCustomResponseForUser(
         this.userId,

--- a/api-tests/src/steps/ais-steps.ts
+++ b/api-tests/src/steps/ais-steps.ts
@@ -2,6 +2,7 @@ import { World } from "../types/world.js";
 import { getRandomString } from "../utils/random-string-generator.js";
 import {
   AisValidResponseTypes,
+  primeCustomResponseForUser,
   primeErrorResponseForUser,
   primeResponseForUser,
 } from "../clients/ais-management-api.js";
@@ -14,6 +15,21 @@ When(
 
     if (desiredApiResult === "ERROR") {
       await primeErrorResponseForUser(this.userId, 500);
+      return;
+    }
+
+    if (desiredApiResult === "AIS_PASSWORD_RESET_CLEARED") {
+      // Mimic the case where an intervention has been cleared, but the description has not been updated.
+      await primeCustomResponseForUser(
+        this.userId,
+        AisValidResponseTypes.AIS_FORCED_USER_PASSWORD_RESET,
+        {
+          blocked: false,
+          resetPassword: false,
+          reproveIdentity: false,
+          suspended: false,
+        },
+      );
       return;
     }
 

--- a/lambdas/check-existing-identity/build.gradle
+++ b/lambdas/check-existing-identity/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 			libs.junitJupiter,
 			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests'),
+			project(path: ':libs:ais-service', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
 	mockitoAgent(libs.mockitoCore) {

--- a/lambdas/process-candidate-identity/build.gradle
+++ b/lambdas/process-candidate-identity/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 			libs.junitJupiter,
 			libs.mockitoJunit,
 			project(path: ':libs:common-services', configuration: 'tests'),
+			project(path: ':libs:ais-service', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
 	mockitoAgent(libs.mockitoCore) {

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -124,7 +124,7 @@ public class ProcessCandidateIdentityHandler
             new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
     private static final JourneyResponse JOURNEY_ACCOUNT_INTERVENTION =
             new JourneyResponse(JOURNEY_ACCOUNT_INTERVENTION_PATH);
-    private static final Map<String, AisInterventionType> interventionCodeTypes =
+    private static final Map<String, AisInterventionType> aisDescriptionByTicfCode =
             Map.of(
                     "00", AIS_NO_INTERVENTION,
                     "01", AIS_ACCOUNT_SUSPENDED,
@@ -699,7 +699,7 @@ public class ProcessCandidateIdentityHandler
                 .filter(Objects::nonNull)
                 .map(Intervention::getInterventionCode)
                 .filter(Objects::nonNull)
-                .map(interventionCodeTypes::get)
+                .map(aisDescriptionByTicfCode::get)
                 .anyMatch(
                         aisInterventionType ->
                                 AccountInterventionEvaluator.hasTicfIntervention(

--- a/libs/ais-service/build.gradle
+++ b/libs/ais-service/build.gradle
@@ -68,3 +68,15 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
+
+configurations {
+	tests.extendsFrom(testImplementation)
+}
+
+tasks.register('jarTest', Jar) {
+	from sourceSets.test.output
+	archiveClassifier.set('tests')
+}
+artifacts {
+	tests jarTest
+}

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluator.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluator.java
@@ -6,12 +6,17 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.domain.AisInterventionType;
 import uk.gov.di.ipv.core.library.dto.AccountInterventionState;
+import uk.gov.di.ipv.core.library.enums.TicfCode;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_ACCOUNT_UNBLOCKED;
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_ACCOUNT_UNSUSPENDED;
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_FORCED_USER_IDENTITY_VERIFY;
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_NO_INTERVENTION;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.ACCOUNT_UNBLOCKED;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.ACCOUNT_UNSUSPENDED;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.FORCED_USER_IDENTITY_VERIFY;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.NO_INTERVENTION;
 
 public final class AccountInterventionEvaluator {
 
@@ -95,6 +100,12 @@ public final class AccountInterventionEvaluator {
                 || AIS_ACCOUNT_UNSUSPENDED.equals(aisInterventionType);
     }
 
+    private static boolean isNotACurrentIntervention(TicfCode ticfInterventionType) {
+        return NO_INTERVENTION.equals(ticfInterventionType)
+                || ACCOUNT_UNBLOCKED.equals(ticfInterventionType)
+                || ACCOUNT_UNSUSPENDED.equals(ticfInterventionType);
+    }
+
     public static boolean hasStartOfJourneyIntervention(AccountInterventionState aisState) {
         var noIntervention = hasNoInterventionFlag(aisState);
         var isReprove = isReprove(aisState);
@@ -143,13 +154,12 @@ public final class AccountInterventionEvaluator {
     }
 
     public static boolean hasTicfIntervention(
-            AccountInterventionState currentAisState, AisInterventionType ticfIntervention) {
+            AccountInterventionState currentAisState, TicfCode ticfIntervention) {
         var bothValid =
                 hasNoInterventionFlag(currentAisState)
                         && isNotACurrentIntervention(ticfIntervention);
         var bothReprove =
-                isReprove(currentAisState)
-                        && AIS_FORCED_USER_IDENTITY_VERIFY.equals(ticfIntervention);
+                isReprove(currentAisState) && FORCED_USER_IDENTITY_VERIFY.equals(ticfIntervention);
         var reproveToValid =
                 isReprove(currentAisState) && isNotACurrentIntervention(ticfIntervention);
 

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluator.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluator.java
@@ -93,6 +93,28 @@ public final class AccountInterventionEvaluator {
                 || AIS_ACCOUNT_UNSUSPENDED.equals(aisInterventionType);
     }
 
+    public static boolean hasStartOfJourneyIntervention(AccountInterventionState aisState) {
+        var noIntervention = hasNoInterventionFlag(aisState);
+        var isReprove = isReprove(aisState);
+
+        if (noIntervention || isReprove) {
+            return false;
+        }
+
+        try {
+            LOGGER.info(
+                    LogHelper.buildLogMessage(
+                            "Start of journey intervention detected. Intervention state: %s"
+                                    .formatted(OBJECT_MAPPER.writeValueAsString(aisState))));
+        } catch (JsonProcessingException e) {
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Error converting account intervention state to string", e));
+            LOGGER.info(LogHelper.buildLogMessage("Start of journey intervention detected."));
+        }
+        return true;
+    }
+
     public static boolean hasMidJourneyIntervention(
             boolean isReproveIdentity, AccountInterventionState currentAccountInterventionState) {
         var noAisIntervention = hasNoInterventionFlag(currentAccountInterventionState);
@@ -162,7 +184,7 @@ public final class AccountInterventionEvaluator {
                 && !accountInterventionState.isSuspended();
     }
 
-    private static boolean isReprove(AccountInterventionState accountInterventionState) {
+    public static boolean isReprove(AccountInterventionState accountInterventionState) {
         // The suspended flag should be set whenever the reproveIdentity flag is set, but if it
         // isn't for any reason we should still treat the state as reprove, so we don't check the
         // suspended flag here.

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluator.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluator.java
@@ -19,7 +19,7 @@ public final class AccountInterventionEvaluator {
     }
 
     public static boolean hasStartOfJourneyIntervention(AisInterventionType interventionType) {
-        if (isValidIntervention(interventionType)
+        if (isNotACurrentIntervention(interventionType)
                 || AIS_FORCED_USER_IDENTITY_VERIFY.equals(interventionType)) {
             return false;
         }
@@ -37,8 +37,8 @@ public final class AccountInterventionEvaluator {
 
         var bothReprove =
                 isReproveIdentity && AIS_FORCED_USER_IDENTITY_VERIFY.equals(aisInterventionType);
-        var reproveToValid = isReproveIdentity && isValidIntervention(aisInterventionType);
-        var isValid = isValidIntervention(aisInterventionType);
+        var reproveToValid = isReproveIdentity && isNotACurrentIntervention(aisInterventionType);
+        var isValid = isNotACurrentIntervention(aisInterventionType);
 
         if (bothReprove || reproveToValid || isValid) {
             return false;
@@ -55,7 +55,8 @@ public final class AccountInterventionEvaluator {
             AisInterventionType currentIntervention, AisInterventionType ticfIntervention) {
 
         var bothValid =
-                isValidIntervention(currentIntervention) && isValidIntervention(ticfIntervention);
+                isNotACurrentIntervention(currentIntervention)
+                        && isNotACurrentIntervention(ticfIntervention);
         var bothReprove = isBothIdentityVerify(currentIntervention, ticfIntervention);
         var reproveToValid = isIdentityVerifyToValid(currentIntervention, ticfIntervention);
 
@@ -78,10 +79,11 @@ public final class AccountInterventionEvaluator {
 
     private static boolean isIdentityVerifyToValid(
             AisInterventionType initial, AisInterventionType current) {
-        return AIS_FORCED_USER_IDENTITY_VERIFY.equals(initial) && isValidIntervention(current);
+        return AIS_FORCED_USER_IDENTITY_VERIFY.equals(initial)
+                && isNotACurrentIntervention(current);
     }
 
-    private static boolean isValidIntervention(AisInterventionType aisInterventionType) {
+    private static boolean isNotACurrentIntervention(AisInterventionType aisInterventionType) {
         return AIS_NO_INTERVENTION.equals(aisInterventionType)
                 || AIS_ACCOUNT_UNBLOCKED.equals(aisInterventionType)
                 || AIS_ACCOUNT_UNSUSPENDED.equals(aisInterventionType);

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluator.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluator.java
@@ -17,6 +17,8 @@ public final class AccountInterventionEvaluator {
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String OBJECT_MAPPING_ERROR_MESSAGE =
+            "Error converting account intervention state to string";
 
     private AccountInterventionEvaluator() {
         // prevent initialisation
@@ -107,9 +109,7 @@ public final class AccountInterventionEvaluator {
                             "Start of journey intervention detected. Intervention state: %s"
                                     .formatted(OBJECT_MAPPER.writeValueAsString(aisState))));
         } catch (JsonProcessingException e) {
-            LOGGER.error(
-                    LogHelper.buildErrorMessage(
-                            "Error converting account intervention state to string", e));
+            LOGGER.error(LogHelper.buildErrorMessage(OBJECT_MAPPING_ERROR_MESSAGE, e));
             LOGGER.info(LogHelper.buildLogMessage("Start of journey intervention detected."));
         }
         return true;
@@ -136,9 +136,7 @@ public final class AccountInterventionEvaluator {
                                             OBJECT_MAPPER.writeValueAsString(
                                                     currentAccountInterventionState))));
         } catch (JsonProcessingException e) {
-            LOGGER.error(
-                    LogHelper.buildErrorMessage(
-                            "Error converting account intervention state to string", e));
+            LOGGER.error(LogHelper.buildErrorMessage(OBJECT_MAPPING_ERROR_MESSAGE, e));
             LOGGER.info(LogHelper.buildLogMessage("Mid journey intervention detected."));
         }
         return true;
@@ -167,9 +165,7 @@ public final class AccountInterventionEvaluator {
                                             OBJECT_MAPPER.writeValueAsString(currentAisState),
                                             ticfIntervention)));
         } catch (JsonProcessingException e) {
-            LOGGER.error(
-                    LogHelper.buildErrorMessage(
-                            "Error converting account intervention state to string", e));
+            LOGGER.error(LogHelper.buildErrorMessage(OBJECT_MAPPING_ERROR_MESSAGE, e));
             LOGGER.info(LogHelper.buildLogMessage("TICF intervention detected."));
         }
 

--- a/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/service/AisService.java
+++ b/libs/ais-service/src/main/java/uk/gov/di/ipv/core/library/ais/service/AisService.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.ais.client.AisClient;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.domain.AisInterventionType;
+import uk.gov.di.ipv.core.library.dto.AccountInterventionState;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_NO_INTERVENTION;
@@ -33,5 +34,23 @@ public class AisService {
             LOGGER.error(AIS_FAIL_OPEN_ERROR_DESCRIPTION, e);
             return AIS_NO_INTERVENTION;
         }
+    }
+
+    public AccountInterventionState fetchAisState(String userId) {
+        try {
+            return aisClient.getAccountInterventionStatus(userId).getState();
+        } catch (Exception e) {
+            LOGGER.error(AIS_FAIL_OPEN_ERROR_DESCRIPTION, e);
+            return createNoInterventionState();
+        }
+    }
+
+    public static AccountInterventionState createNoInterventionState() {
+        return AccountInterventionState.builder()
+                .isBlocked(false)
+                .isReproveIdentity(false)
+                .isResetPassword(false)
+                .isSuspended(false)
+                .build();
     }
 }

--- a/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/TestData.java
+++ b/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/TestData.java
@@ -81,4 +81,34 @@ public class TestData {
                     .auditLevel(AisAuditLevel.STANDARD)
                     .history(new AccountInterventionStatusDto.InterventionHistory[0])
                     .build();
+
+    public static AccountInterventionState createNoInterventionAisState() {
+        return createAisState(false, false, false, false);
+    }
+
+    public static AccountInterventionState createReproveIdentityAisState() {
+        return createAisState(true, true, false, false);
+    }
+
+    public static AccountInterventionState createBlockedIdentityAisState() {
+        return createAisState(false, false, false, true);
+    }
+
+    public static AccountInterventionState createSuspendedIdentityAisState() {
+        return createAisState(false, true, false, false);
+    }
+
+    public static AccountInterventionState createResetPasswordAisState() {
+        return createAisState(false, false, true, false);
+    }
+
+    private static AccountInterventionState createAisState(
+            boolean reprove, boolean suspended, boolean resetPassword, boolean blocked) {
+        return AccountInterventionState.builder()
+                .isReproveIdentity(reprove)
+                .isSuspended(suspended)
+                .isResetPassword(resetPassword)
+                .isBlocked(blocked)
+                .build();
+    }
 }

--- a/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluatorTest.java
+++ b/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluatorTest.java
@@ -166,6 +166,31 @@ class AccountInterventionEvaluatorTest {
 
     // Equivalent tests to the above but using AIS state
     @ParameterizedTest
+    @MethodSource("aisStatesToTriggerStartOfJourneyIntervention")
+    void shouldReturnTrueWhenProvideInvalidAccountState(AccountInterventionState aisState) {
+        assertTrue(AccountInterventionEvaluator.hasStartOfJourneyIntervention(aisState));
+    }
+
+    private static Stream<Arguments> aisStatesToTriggerStartOfJourneyIntervention() {
+        return Stream.of(
+                Arguments.of(createSuspendedIdentityAisState()),
+                Arguments.of(createBlockedIdentityAisState()),
+                Arguments.of(createResetPasswordAisState()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("aisStatesToNotTriggerStartOfJourneyIntervention")
+    void shouldReturnFalseWhenProvideValidAccountState(AccountInterventionState aisState) {
+        assertFalse(AccountInterventionEvaluator.hasStartOfJourneyIntervention(aisState));
+    }
+
+    private static Stream<Arguments> aisStatesToNotTriggerStartOfJourneyIntervention() {
+        return Stream.of(
+                Arguments.of(createNoInterventionAisState()),
+                Arguments.of(createReproveIdentityAisState()));
+    }
+
+    @ParameterizedTest
     @MethodSource("aisStatesToTriggerMidJourneyIntervention")
     void shouldReturnTrueWhenProvideInvalidMidJourneyAccountInterventionTypes(
             boolean isReproveJourney, AccountInterventionState finalAisInterventionType) {

--- a/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluatorTest.java
+++ b/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.ipv.core.library.domain.AisInterventionType;
 import uk.gov.di.ipv.core.library.dto.AccountInterventionState;
+import uk.gov.di.ipv.core.library.enums.TicfCode;
 
 import java.util.stream.Stream;
 
@@ -23,6 +24,14 @@ import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_FORCED_U
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_FORCED_USER_PASSWORD_RESET;
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY;
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_NO_INTERVENTION;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.ACCOUNT_BLOCKED;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.ACCOUNT_SUSPENDED;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.ACCOUNT_UNBLOCKED;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.ACCOUNT_UNSUSPENDED;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.FORCED_USER_IDENTITY_VERIFY;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.FORCED_USER_PASSWORD_RESET;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY;
+import static uk.gov.di.ipv.core.library.enums.TicfCode.NO_INTERVENTION;
 
 class AccountInterventionEvaluatorTest {
 
@@ -230,7 +239,7 @@ class AccountInterventionEvaluatorTest {
     @MethodSource("ticfCodesToTriggerMidJourneyIntervention")
     void shouldReturnTrueWhenProvideInvalidMidJourneyTicfCode(
             AccountInterventionState currentAccountInterventionType,
-            AisInterventionType ticfAccountInterventionType) {
+            TicfCode ticfAccountInterventionType) {
         assertTrue(
                 AccountInterventionEvaluator.hasTicfIntervention(
                         currentAccountInterventionType, ticfAccountInterventionType));
@@ -238,26 +247,26 @@ class AccountInterventionEvaluatorTest {
 
     private static Stream<Arguments> ticfCodesToTriggerMidJourneyIntervention() {
         return Stream.of(
-                Arguments.of(createNoInterventionAisState(), AIS_ACCOUNT_BLOCKED),
-                Arguments.of(createNoInterventionAisState(), AIS_ACCOUNT_SUSPENDED),
-                Arguments.of(createNoInterventionAisState(), AIS_FORCED_USER_PASSWORD_RESET),
-                Arguments.of(createNoInterventionAisState(), AIS_FORCED_USER_IDENTITY_VERIFY),
+                Arguments.of(createNoInterventionAisState(), ACCOUNT_BLOCKED),
+                Arguments.of(createNoInterventionAisState(), ACCOUNT_SUSPENDED),
+                Arguments.of(createNoInterventionAisState(), FORCED_USER_PASSWORD_RESET),
+                Arguments.of(createNoInterventionAisState(), FORCED_USER_IDENTITY_VERIFY),
                 Arguments.of(
                         createNoInterventionAisState(),
-                        AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY),
-                Arguments.of(createReproveIdentityAisState(), AIS_ACCOUNT_BLOCKED),
-                Arguments.of(createReproveIdentityAisState(), AIS_ACCOUNT_SUSPENDED),
-                Arguments.of(createReproveIdentityAisState(), AIS_FORCED_USER_PASSWORD_RESET),
+                        FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY),
+                Arguments.of(createReproveIdentityAisState(), ACCOUNT_BLOCKED),
+                Arguments.of(createReproveIdentityAisState(), ACCOUNT_SUSPENDED),
+                Arguments.of(createReproveIdentityAisState(), FORCED_USER_PASSWORD_RESET),
                 Arguments.of(
                         createReproveIdentityAisState(),
-                        AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY));
+                        FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY));
     }
 
     @ParameterizedTest
     @MethodSource("ticfCodesToNotTriggerMidJourneyIntervention")
     void shouldReturnFalseWhenProvideValidMidJourneyTicfCode(
             AccountInterventionState currentAccountInterventionType,
-            AisInterventionType ticfAccountInterventionType) {
+            TicfCode ticfAccountInterventionType) {
         assertFalse(
                 AccountInterventionEvaluator.hasTicfIntervention(
                         currentAccountInterventionType, ticfAccountInterventionType));
@@ -265,12 +274,12 @@ class AccountInterventionEvaluatorTest {
 
     private static Stream<Arguments> ticfCodesToNotTriggerMidJourneyIntervention() {
         return Stream.of(
-                Arguments.of(createNoInterventionAisState(), AIS_NO_INTERVENTION),
-                Arguments.of(createNoInterventionAisState(), AIS_ACCOUNT_UNSUSPENDED),
-                Arguments.of(createNoInterventionAisState(), AIS_ACCOUNT_UNBLOCKED),
-                Arguments.of(createReproveIdentityAisState(), AIS_FORCED_USER_IDENTITY_VERIFY),
-                Arguments.of(createReproveIdentityAisState(), AIS_ACCOUNT_UNBLOCKED),
-                Arguments.of(createReproveIdentityAisState(), AIS_ACCOUNT_UNSUSPENDED),
-                Arguments.of(createReproveIdentityAisState(), AIS_NO_INTERVENTION));
+                Arguments.of(createNoInterventionAisState(), NO_INTERVENTION),
+                Arguments.of(createNoInterventionAisState(), ACCOUNT_UNSUSPENDED),
+                Arguments.of(createNoInterventionAisState(), ACCOUNT_UNBLOCKED),
+                Arguments.of(createReproveIdentityAisState(), FORCED_USER_IDENTITY_VERIFY),
+                Arguments.of(createReproveIdentityAisState(), ACCOUNT_UNBLOCKED),
+                Arguments.of(createReproveIdentityAisState(), ACCOUNT_UNSUSPENDED),
+                Arguments.of(createReproveIdentityAisState(), NO_INTERVENTION));
     }
 }

--- a/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluatorTest.java
+++ b/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluatorTest.java
@@ -4,11 +4,17 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.ipv.core.library.domain.AisInterventionType;
+import uk.gov.di.ipv.core.library.dto.AccountInterventionState;
 
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.ipv.core.library.ais.TestData.createBlockedIdentityAisState;
+import static uk.gov.di.ipv.core.library.ais.TestData.createNoInterventionAisState;
+import static uk.gov.di.ipv.core.library.ais.TestData.createReproveIdentityAisState;
+import static uk.gov.di.ipv.core.library.ais.TestData.createResetPasswordAisState;
+import static uk.gov.di.ipv.core.library.ais.TestData.createSuspendedIdentityAisState;
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_ACCOUNT_BLOCKED;
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_ACCOUNT_SUSPENDED;
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_ACCOUNT_UNBLOCKED;
@@ -156,5 +162,90 @@ class AccountInterventionEvaluatorTest {
                 Arguments.of(AIS_FORCED_USER_IDENTITY_VERIFY, AIS_ACCOUNT_UNBLOCKED),
                 Arguments.of(AIS_FORCED_USER_IDENTITY_VERIFY, AIS_ACCOUNT_UNSUSPENDED),
                 Arguments.of(AIS_FORCED_USER_IDENTITY_VERIFY, AIS_NO_INTERVENTION));
+    }
+
+    // Equivalent tests to the above but using AIS state
+    @ParameterizedTest
+    @MethodSource("aisStatesToTriggerMidJourneyIntervention")
+    void shouldReturnTrueWhenProvideInvalidMidJourneyAccountInterventionTypes(
+            boolean isReproveJourney, AccountInterventionState finalAisInterventionType) {
+        assertTrue(
+                AccountInterventionEvaluator.hasMidJourneyIntervention(
+                        isReproveJourney, finalAisInterventionType));
+    }
+
+    private static Stream<Arguments> aisStatesToTriggerMidJourneyIntervention() {
+        return Stream.of(
+                Arguments.of(false, createBlockedIdentityAisState()),
+                Arguments.of(false, createSuspendedIdentityAisState()),
+                Arguments.of(false, createReproveIdentityAisState()),
+                Arguments.of(false, createResetPasswordAisState()),
+                Arguments.of(true, createBlockedIdentityAisState()),
+                Arguments.of(true, createSuspendedIdentityAisState()),
+                Arguments.of(true, createResetPasswordAisState()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("aisStatesToNotTriggerMidJourneyIntervention")
+    void shouldReturnFalseWhenProvideValidMidJourneyAccountInterventionTypes(
+            boolean isReproveIdentity, AccountInterventionState finalAisInterventionType) {
+        assertFalse(
+                AccountInterventionEvaluator.hasMidJourneyIntervention(
+                        isReproveIdentity, finalAisInterventionType));
+    }
+
+    private static Stream<Arguments> aisStatesToNotTriggerMidJourneyIntervention() {
+        return Stream.of(
+                Arguments.of(false, createNoInterventionAisState()),
+                Arguments.of(true, createReproveIdentityAisState()),
+                Arguments.of(true, createNoInterventionAisState()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("ticfCodesToTriggerMidJourneyIntervention")
+    void shouldReturnTrueWhenProvideInvalidTicfAccountInterventionTypes(
+            AccountInterventionState currentAccountInterventionType,
+            AisInterventionType ticfAccountInterventionType) {
+        assertTrue(
+                AccountInterventionEvaluator.hasTicfIntervention(
+                        currentAccountInterventionType, ticfAccountInterventionType));
+    }
+
+    private static Stream<Arguments> ticfCodesToTriggerMidJourneyIntervention() {
+        return Stream.of(
+                Arguments.of(createNoInterventionAisState(), AIS_ACCOUNT_BLOCKED),
+                Arguments.of(createNoInterventionAisState(), AIS_ACCOUNT_SUSPENDED),
+                Arguments.of(createNoInterventionAisState(), AIS_FORCED_USER_PASSWORD_RESET),
+                Arguments.of(createNoInterventionAisState(), AIS_FORCED_USER_IDENTITY_VERIFY),
+                Arguments.of(
+                        createNoInterventionAisState(),
+                        AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY),
+                Arguments.of(createReproveIdentityAisState(), AIS_ACCOUNT_BLOCKED),
+                Arguments.of(createReproveIdentityAisState(), AIS_ACCOUNT_SUSPENDED),
+                Arguments.of(createReproveIdentityAisState(), AIS_FORCED_USER_PASSWORD_RESET),
+                Arguments.of(
+                        createReproveIdentityAisState(),
+                        AIS_FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY));
+    }
+
+    @ParameterizedTest
+    @MethodSource("ticfCodesToNotTriggerMidJourneyIntervention")
+    void shouldReturnFalseWhenProvideValidMidJourneyAccountInterventionTypes(
+            AccountInterventionState currentAccountInterventionType,
+            AisInterventionType ticfAccountInterventionType) {
+        assertFalse(
+                AccountInterventionEvaluator.hasTicfIntervention(
+                        currentAccountInterventionType, ticfAccountInterventionType));
+    }
+
+    private static Stream<Arguments> ticfCodesToNotTriggerMidJourneyIntervention() {
+        return Stream.of(
+                Arguments.of(createNoInterventionAisState(), AIS_NO_INTERVENTION),
+                Arguments.of(createNoInterventionAisState(), AIS_ACCOUNT_UNSUSPENDED),
+                Arguments.of(createNoInterventionAisState(), AIS_ACCOUNT_UNBLOCKED),
+                Arguments.of(createReproveIdentityAisState(), AIS_FORCED_USER_IDENTITY_VERIFY),
+                Arguments.of(createReproveIdentityAisState(), AIS_ACCOUNT_UNBLOCKED),
+                Arguments.of(createReproveIdentityAisState(), AIS_ACCOUNT_UNSUSPENDED),
+                Arguments.of(createReproveIdentityAisState(), AIS_NO_INTERVENTION));
     }
 }

--- a/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluatorTest.java
+++ b/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/helper/AccountInterventionEvaluatorTest.java
@@ -139,7 +139,7 @@ class AccountInterventionEvaluatorTest {
 
     @ParameterizedTest
     @MethodSource("getValidTicfAccountInterventionTypes")
-    void shouldReturnFalseWhenProvideValidMidJourneyAccountInterventionTypes(
+    void shouldReturnFalseWhenProvideValidMidJourneyAccountInterventionTypesFromTicf(
             AisInterventionType currentAccountInterventionType,
             AisInterventionType ticfAccountInterventionType) {
         assertFalse(
@@ -192,7 +192,7 @@ class AccountInterventionEvaluatorTest {
 
     @ParameterizedTest
     @MethodSource("aisStatesToTriggerMidJourneyIntervention")
-    void shouldReturnTrueWhenProvideInvalidMidJourneyAccountInterventionTypes(
+    void shouldReturnTrueWhenProvideInvalidMidJourneyAccountInterventionState(
             boolean isReproveJourney, AccountInterventionState finalAisInterventionType) {
         assertTrue(
                 AccountInterventionEvaluator.hasMidJourneyIntervention(
@@ -212,7 +212,7 @@ class AccountInterventionEvaluatorTest {
 
     @ParameterizedTest
     @MethodSource("aisStatesToNotTriggerMidJourneyIntervention")
-    void shouldReturnFalseWhenProvideValidMidJourneyAccountInterventionTypes(
+    void shouldReturnFalseWhenProvideValidMidJourneyAccountInterventionState(
             boolean isReproveIdentity, AccountInterventionState finalAisInterventionType) {
         assertFalse(
                 AccountInterventionEvaluator.hasMidJourneyIntervention(
@@ -228,7 +228,7 @@ class AccountInterventionEvaluatorTest {
 
     @ParameterizedTest
     @MethodSource("ticfCodesToTriggerMidJourneyIntervention")
-    void shouldReturnTrueWhenProvideInvalidTicfAccountInterventionTypes(
+    void shouldReturnTrueWhenProvideInvalidMidJourneyTicfCode(
             AccountInterventionState currentAccountInterventionType,
             AisInterventionType ticfAccountInterventionType) {
         assertTrue(
@@ -255,7 +255,7 @@ class AccountInterventionEvaluatorTest {
 
     @ParameterizedTest
     @MethodSource("ticfCodesToNotTriggerMidJourneyIntervention")
-    void shouldReturnFalseWhenProvideValidMidJourneyAccountInterventionTypes(
+    void shouldReturnFalseWhenProvideValidMidJourneyTicfCode(
             AccountInterventionState currentAccountInterventionType,
             AisInterventionType ticfAccountInterventionType) {
         assertFalse(

--- a/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/service/AisServiceTest.java
+++ b/libs/ais-service/src/test/java/uk/gov/di/ipv/core/library/ais/service/AisServiceTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.ipv.core.library.ais.exception.AisClientException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.ais.TestData.createNoInterventionAisState;
 import static uk.gov.di.ipv.core.library.domain.AisInterventionType.AIS_NO_INTERVENTION;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,5 +53,31 @@ class AisServiceTest {
 
         // Assert
         assertThat(result).isEqualTo(AIS_NO_INTERVENTION);
+    }
+
+    @Test
+    void fetchAisState_whenCalled_returnsAisState() throws AisClientException {
+        // Arrange
+        when(aisClient.getAccountInterventionStatus(TEST_USER_ID))
+                .thenReturn(TestData.AIS_NO_INTERVENTION_DTO);
+
+        // Act
+        var result = underTest.fetchAisState(TEST_USER_ID);
+
+        // Assert
+        assertThat(result).isEqualTo(createNoInterventionAisState());
+    }
+
+    @Test
+    void fetchAisState_whenClientErrors_returnsNoInterventionState() throws AisClientException {
+        // Arrange
+        when(aisClient.getAccountInterventionStatus(TEST_USER_ID))
+                .thenThrow(new AisClientException("test", new Exception()));
+
+        // Act
+        var result = underTest.fetchAisState(TEST_USER_ID);
+
+        // Assert
+        assertThat(result).isEqualTo(createNoInterventionAisState());
     }
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -7,7 +7,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     SQS_ASYNC("sqsAsync"),
     DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
     STORED_IDENTITY_SERVICE("storedIdentityServiceEnabled"),
-    SIS_VERIFICATION("sisVerificationEnabled");
+    SIS_VERIFICATION("sisVerificationEnabled"),
+    AIS_STATE_CHECK("aisStateCheckEnabled");
 
     private final String name;
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/TicfCode.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/TicfCode.java
@@ -1,0 +1,27 @@
+package uk.gov.di.ipv.core.library.enums;
+
+import java.util.Arrays;
+
+public enum TicfCode {
+    NO_INTERVENTION("00"),
+    ACCOUNT_SUSPENDED("01"),
+    ACCOUNT_UNSUSPENDED("02"),
+    ACCOUNT_BLOCKED("03"),
+    FORCED_USER_PASSWORD_RESET("04"),
+    FORCED_USER_IDENTITY_VERIFY("05"),
+    FORCED_USER_PASSWORD_RESET_AND_IDENTITY_VERIFY("06"),
+    ACCOUNT_UNBLOCKED("07");
+
+    private final String code;
+
+    TicfCode(String code) {
+        this.code = code;
+    }
+
+    public static TicfCode fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(ticfCode -> ticfCode.code.equals(code))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -359,6 +359,7 @@ core:
     sorryTechnicalErrorEnabled: false
     storedIdentityServiceEnabled: true
     sisVerificationEnabled: true
+    aisStateCheckEnabled: false
     testFeatureFlag: false
   features:
     testFeature:
@@ -391,6 +392,12 @@ core:
     zeroHourFraudVcExpiry:
       self:
         fraudCheckExpiryPeriodDays: 0
+    aisStateCheck:
+      featureFlags:
+        aisStateCheckEnabled: true
+    disableAisStateCheck:
+      featureFlags:
+        aisStateCheckEnabled: false
     # Disabling CRIs
     f2fDisabled:
       credentialIssuers:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -362,8 +362,15 @@ core:
     sorryTechnicalErrorEnabled: false
     storedIdentityServiceEnabled: true
     sisVerificationEnabled: true
+    aisStateCheckEnabled: false
 
   features:
+    aisStateCheck:
+      featureFlags:
+        aisStateCheckEnabled: true
+    disableAisStateCheck:
+      featureFlags:
+        aisStateCheckEnabled: false
     storedIdentityService:
       featureFlags:
         storedIdentityServiceEnabled: true


### PR DESCRIPTION
## Proposed changes
### What changed

Added the ability to do AIS interventions based on AIS state rather than description

### Why did it change

The descriptions are not fully reliable

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8880](https://govukverify.atlassian.net/browse/PYIC-8880)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated


[PYIC-8880]: https://govukverify.atlassian.net/browse/PYIC-8880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ