### PR TITLE
PYIC-8792: Release 'Sorry Technical Error' page to users

### DIFF
--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -124,13 +124,13 @@ Feature: P2 F2F journey
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'f2f' CRI response
 
-    Scenario: Oauth server_error error F2F
+    #Scenario: Oauth server_error error F2F
     # This scenario can be removed when the sorryTechnicalError flag is turned on or
     # cleaned up as the flag-on behaviour is tested in unexpected-cri-error.feature
-      When I call the CRI stub with attributes and get a 'server_error' OAuth error
-        | Attribute          | Values                                      |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
-      Then I get a 'pyi-technical' page response
+    #  When I call the CRI stub with attributes and get a 'server_error' OAuth error
+    #    | Attribute          | Values                                      |
+    #    | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+    #  Then I get a 'pyi-technical' page response
 
     Scenario: Oauth access_denied error F2F
       # Initial journey

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -1,4 +1,4 @@
-@Build @QualityGateIntegrationTest @QualityGateRegresstionTest
+@Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Handling unexpected CRI errors
   Rule: Driving Licence and Passport CRIs
     Background: Go through web route

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -1,4 +1,4 @@
-@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
+@Build @QualityGateIntegrationTest @QualityGateRegresstionTest
 Feature: Handling unexpected CRI errors
   Rule: Driving Licence and Passport CRIs
     Background: Go through web route

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -356,7 +356,7 @@ core:
     sqsAsync: true
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: true
-    sorryTechnicalErrorEnabled: false
+    sorryTechnicalErrorEnabled: true
     storedIdentityServiceEnabled: true
     sisVerificationEnabled: true
     aisStateCheckEnabled: false

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -359,7 +359,7 @@ core:
     sqsAsync: true
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: true
-    sorryTechnicalErrorEnabled: false
+    sorryTechnicalErrorEnabled: true
     storedIdentityServiceEnabled: true
     sisVerificationEnabled: true
     aisStateCheckEnabled: false


### PR DESCRIPTION


## Proposed changes
### What changed

**### _NOT TO BE MERGED UNTIL [8792](https://govukverify.atlassian.net/browse/PYIC-8863) IS MERGED_**

- Feature flag sorryTechnicalErrorEnabled and feature set sorryTechnicalError are set to true 
- Quality gate tag for these tests has been updated to @QualityGateRegressionTest

### Why did it change

- While a new error screen was built to allow users to recover from some technical errors to still complete a successful journey, this page is not yet exposed to users.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8792](https://govukverify.atlassian.net/browse/PYIC-8792)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8792]: https://govukverify.atlassian.net/browse/PYIC-8792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ