### PR TITLE
PYIC-8757: Make steps depend on previous steps completing successfully

### DIFF
--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -66,7 +66,7 @@ jobs:
     needs:
       - automatedTests
       - check-if-api-tests-changed
-    if: ${{ needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' && github.event_name == 'push' }}
+    if: success() && needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' && github.event_name == 'push'
     uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
     with:
       environment: 'build'
@@ -83,7 +83,7 @@ jobs:
     needs:
       - automatedTests
       - check-if-api-tests-changed
-    if: ${{ needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' }}
+    if: success() && needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true'
     uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
     with:
       environment: 'dev01'
@@ -137,7 +137,7 @@ jobs:
       - build-api-test-images-if-changed-shared-dev
       - check-if-deploy-needed
     if: |
-      !failure() &&
+      success() &&
       (needs.check-if-deploy-needed.outputs.deploy-needed == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -66,7 +66,9 @@ jobs:
     needs:
       - automatedTests
       - check-if-api-tests-changed
-    if: success() && needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' && github.event_name == 'push'
+    if: |
+      needs.automatedTests.result == 'success' &&
+      needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true' && github.event_name == 'push'
     uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
     with:
       environment: 'build'
@@ -83,7 +85,9 @@ jobs:
     needs:
       - automatedTests
       - check-if-api-tests-changed
-    if: success() && needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true'
+    if: |
+      needs.automatedTests.result == 'success' &&
+      needs.check-if-api-tests-changed.outputs.api-tests-changed == 'true'
     uses: govuk-one-login/ipv-core-back/.github/workflows/secure-pipeline-api-tests-image.yml@main
     with:
       environment: 'dev01'
@@ -136,8 +140,10 @@ jobs:
       - build-api-test-images-if-changed
       - build-api-test-images-if-changed-shared-dev
       - check-if-deploy-needed
+#    !failure() will return true if steps are cancelled or skipped. We need the tests to explicitly succeed
     if: |
-      success() &&
+      !failure() &&
+      needs.automatedTests.result == 'success' &&
       (needs.check-if-deploy-needed.outputs.deploy-needed == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION


## Proposed changes
### What changed

Make steps depend on previous steps completing successfully

### Why did it change

Adding an "if" statement to a job overrides the requirement for the "needs" jobs to complete successfully. !failure() will continue if a step is cancelled or skipped. success() will only be true if all steps have completed successfully.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8757](https://govukverify.atlassian.net/browse/PYIC-8757)



[PYIC-8757]: https://govukverify.atlassian.net/browse/PYIC-8757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ