### PR TITLE
PYIC-8846: add name attribute to LoadBalancerListenerTargetGroupECS

### DIFF
--- a/journey-map/deploy/template.yaml
+++ b/journey-map/deploy/template.yaml
@@ -206,6 +206,7 @@ Resources:
   LoadBalancerListenerTargetGroupECS:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      Name: !Sub "${AWS::StackName}-ecs-tg"
       HealthCheckEnabled: TRUE
       HealthCheckProtocol: HTTP
       HealthCheckPort: 8080


### PR DESCRIPTION
## Proposed changes
### What changed

- add name attribute to LoadBalancerListenerTargetGroupECS in journey map

### Why did it change

- Deployment is failing because the new update requires creating a new load balance. When cloudformation tries to replace the old ALB with the new one before deleting the old one, the target group is still attached to the old one so we get a "target groups cannot be associated with more than one load balancer" error. Adding a name to the target group forces CF to create a new target group instead of reusing the existing one

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8846](https://govukverify.atlassian.net/browse/PYIC-8846)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8846]: https://govukverify.atlassian.net/browse/PYIC-8846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ