### PR TITLE
PYIC-8920: resolve netty-codec-http vulnerabilities

### DIFF
--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.provider:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -28,6 +28,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/lambdas/call-dcmaw-async-cri/build.gradle
+++ b/lambdas/call-dcmaw-async-cri/build.gradle
@@ -30,6 +30,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/lambdas/call-dcmaw-async-cri/build.gradle
+++ b/lambdas/call-dcmaw-async-cri/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.provider:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/lambdas/user-reverification/build.gradle
+++ b/lambdas/user-reverification/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/lambdas/user-reverification/build.gradle
+++ b/lambdas/user-reverification/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.provider:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/libs/ais-service/build.gradle
+++ b/libs/ais-service/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/libs/ais-service/build.gradle
+++ b/libs/ais-service/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/libs/evcs-service/build.gradle
+++ b/libs/evcs-service/build.gradle
@@ -30,6 +30,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/libs/evcs-service/build.gradle
+++ b/libs/evcs-service/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/libs/sis-service/build.gradle
+++ b/libs/sis-service/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/libs/sis-service/build.gradle
+++ b/libs/sis-service/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/libs/test-helpers/build.gradle
+++ b/libs/test-helpers/build.gradle
@@ -28,6 +28,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/libs/test-helpers/build.gradle
+++ b/libs/test-helpers/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}

--- a/libs/ticf-cri-service/build.gradle
+++ b/libs/ticf-cri-service/build.gradle
@@ -28,6 +28,10 @@ dependencies {
 		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
+
+		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
+			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
+		}
 	}
 
 	mockitoAgent(libs.mockitoCore) {

--- a/libs/ticf-cri-service/build.gradle
+++ b/libs/ticf-cri-service/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 			because "this version patches the vulnerability CVE-2025-55163"
 		}
 
+		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
+		// is able to resolve this vulnerability
 		testImplementation('io.netty:netty-codec-http:4.1.129.Final') {
 			because "this version patches the vulnerabilities CVE-2025-67735 and CVE-2025-58056"
 		}


### PR DESCRIPTION
## Proposed changes
### What changed

- force netty-codec-http:4.1.129.Final transitive dependency to be used

### Why did it change

to resolve: 
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/89
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/71

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8920](https://govukverify.atlassian.net/browse/PYIC-8920)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8920]: https://govukverify.atlassian.net/browse/PYIC-8920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ