### PR TITLE
Revert "PYIC-8920: resolve netty-codec-http2 vulnerability CVE-2025-55163"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,6 @@ awsSdk = "2.41.0"
 jackson = "2.21.0"
 log4j = "2.25.3"
 mockito = "5.21.0"
-# Before updating the pact version, check whether the new version
-# resolves old vulnerabilities and if we can remove some of our
-# overrides. See comment above the pact libraries below.
-# Once the overrides are removed, remove comments where necessary.
 pact = "4.6.19"
 powertools = "2.9.0"
 
@@ -42,15 +38,8 @@ mockitoJunit = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mo
 nimbusdsOauth2OidcSdk = "com.nimbusds:oauth2-oidc-sdk:11.32"
 openTelemetryBom = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.24.0-alpha"
 openTelemetryJavaHttpClient = { module = "io.opentelemetry.instrumentation:opentelemetry-java-http-client" }
-
-# The pact libraries below transitively depend on vulnerable packages.
-# To resolve them, we override those packages in each build.gradle file which
-# use the below libraries. When updating to a new version these pact libraries,
-# check if the new version resolves the vulnerabilities and remove package overrides.
-# Once the overrides are removed, remove comments where necessary.
 pactConsumerJunit = { module = "au.com.dius.pact.consumer:junit5", version.ref = "pact" }
 pactProviderJunit = { module = "au.com.dius.pact.provider:junit5", version.ref = "pact" }
-
 powertoolsLogging = { module = "software.amazon.lambda:powertools-logging-log4j", version.ref = "powertools" }
 powertoolsMetrics = { module = "software.amazon.lambda:powertools-metrics", version.ref = "powertools" }
 powertoolsParameters = { module = "software.amazon.lambda:powertools-parameters", version.ref = "powertools" }

--- a/lambdas/build-user-identity/build.gradle
+++ b/lambdas/build-user-identity/build.gradle
@@ -24,14 +24,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.provider:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/lambdas/call-dcmaw-async-cri/build.gradle
+++ b/lambdas/call-dcmaw-async-cri/build.gradle
@@ -26,14 +26,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/lambdas/issue-client-access-token/build.gradle
+++ b/lambdas/issue-client-access-token/build.gradle
@@ -28,14 +28,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.provider:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/lambdas/process-async-cri-credential/build.gradle
+++ b/lambdas/process-async-cri-credential/build.gradle
@@ -28,14 +28,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/lambdas/process-cri-callback/build.gradle
+++ b/lambdas/process-cri-callback/build.gradle
@@ -33,14 +33,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(':libs:test-helpers',)
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/lambdas/user-reverification/build.gradle
+++ b/lambdas/user-reverification/build.gradle
@@ -25,14 +25,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.provider:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/libs/ais-service/build.gradle
+++ b/libs/ais-service/build.gradle
@@ -25,14 +25,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/libs/cimit-service/build.gradle
+++ b/libs/cimit-service/build.gradle
@@ -27,14 +27,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/libs/evcs-service/build.gradle
+++ b/libs/evcs-service/build.gradle
@@ -26,14 +26,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/libs/sis-service/build.gradle
+++ b/libs/sis-service/build.gradle
@@ -30,14 +30,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/libs/test-helpers/build.gradle
+++ b/libs/test-helpers/build.gradle
@@ -24,14 +24,6 @@ dependencies {
 			libs.hamcrest,
 			libs.mockitoJunit
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}

--- a/libs/ticf-cri-service/build.gradle
+++ b/libs/ticf-cri-service/build.gradle
@@ -24,14 +24,6 @@ dependencies {
 			project(path: ':libs:common-services', configuration: 'tests'),
 			project(path: ':libs:test-helpers')
 
-	constraints {
-		// TODO: remove when new version of au.com.dius.pact.consumer:junit5
-		// is able to resolve this vulnerability
-		testImplementation('io.netty:netty-codec-http2:4.1.124.Final') {
-			because "this version patches the vulnerability CVE-2025-55163"
-		}
-	}
-
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false
 	}


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-back#3710

The decision has been made to not override the dependencies since they're low risk and just keep the alerts up.