### PR TITLE
PYIC-8846: add session timeout  to journey map

### DIFF
--- a/journey-map/deploy/template.yaml
+++ b/journey-map/deploy/template.yaml
@@ -244,6 +244,7 @@ Resources:
             UserInfoEndpoint: https://openidconnect.googleapis.com/v1/userinfo
             Scope: "openid email"
             OnUnauthenticatedRequest: authenticate
+            SessionTimeout: "43200"
         - Order: 2
           TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
           Type: forward


### PR DESCRIPTION
## Proposed changes
### What changed

- add session timeout  to journey map

### Why did it change

- We now authenticate via Google SSO. The session is persisted via an ALB-managed cookie and as long as it remains valid, will no longer consult Google. This means that even after logging out of Google, a user will still have access to the journey map. Adding a session timeout will help reduce the window for bad actors by invalidating the session after a given period of time and requiring the user to log back in

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8846](https://govukverify.atlassian.net/browse/PYIC-8846)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8846]: https://govukverify.atlassian.net/browse/PYIC-8846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ