### PR TITLE
BAU: Change API test timeout from 15 to 20 minutes

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -86,7 +86,7 @@ jobs:
 
   api-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       id-token: write
       packages: read


### PR DESCRIPTION
## Proposed changes
### What changed

API test timeout

### Why did it change

Tests have started to timeout frequently causing delays in deployments
