### PR TITLE
[DCMAW-18492] Update DcmawCri consumer Pact tests

### DIFF
--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -2767,7 +2767,7 @@ class ContractTest {
                       "documentNumber": "ZR8016200",
                       "expiryDate": "2024-02-25",
                       "icaoIssuerCode": "GBR",
-                      "documentType": "IR"
+                      "documentType": "CR"
                     }
                   ]
                 },
@@ -2798,7 +2798,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_BRP_VC_SIGNATURE =
-            "dIXAu4yrIN0YGFisw8nhrJdS4mHrWR_BFAmveloHEwloM5nXQLk9cPfPPbWDtvd_ZwLIexnSrTdXNm1FgB_N5g"; // pragma: allowlist secret
+            "yGgpft2Kl3Xt9O8lC-bHrAgxQCX3ks8bTEQvD2IJWrrbBcrCnSZ4adRq4h1G9EYhaU5LD6VAR4El2b1Fbf3Qww"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-5175-AC1
@@ -2815,6 +2815,10 @@ class ContractTest {
                 "@context": [
                   "https://www.w3.org/2018/credentials/v1",
                   "https://vocab.account.gov.uk/contexts/identity-v1.jsonld"
+                ],
+                "type": [
+                  "VerifiableCredential",
+                  "IdentityCheckCredential"
                 ],
                 "credentialSubject": {
                   "name": [
@@ -2836,24 +2840,20 @@ class ContractTest {
                       "value": "1980-01-01"
                     }
                   ],
-                  "residencePermit": [
-                    {
-                      "icaoIssuerCode": "GBR",
-                      "documentNumber": "ZR8016200",
-                      "expiryDate": "2024-02-25",
-                      "documentType": "IR"
-                    }
-                  ],
                   "deviceId": [
                     {
                       "value": "7d8f0d3c-6a0a-4298-afe5-0cf23633618c"
                     }
+                  ],
+                  "residencePermit": [
+                    {
+                      "documentNumber": "ZR8016200",
+                      "expiryDate": "2024-02-25",
+                      "icaoIssuerCode": "GBR",
+                      "documentType": "IR"
+                    }
                   ]
                 },
-                "type": [
-                  "VerifiableCredential",
-                  "IdentityCheckCredential"
-                ],
                 "evidence": [
                   {
                     "type": "IdentityCheck",
@@ -2884,7 +2884,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_BRP_VC_SIGNATURE =
-            "LWfukxi6ZCVz52LIVnNdUFg8Wcv1A5DqcRAQ4R5w3p3U3GNox-Kn6IcGgygt_nJFg4X4lgCqV2q-wSBdWDOGTg"; // pragma: allowlist secret
+            "2rdyetzKV4FPL9p6OZzjewd8nwqfF1MKfBBGmTN1xEcKTPgAR-hWgcwiHDN_KA3ZdMGrZxnYQBck0DImsixSIA"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From BRC DCMAW-5176-AC1-valid-doc-chip-clone-detection-successful (there is also a BRP
@@ -2902,6 +2902,10 @@ class ContractTest {
                 "@context": [
                   "https://www.w3.org/2018/credentials/v1",
                   "https://vocab.account.gov.uk/contexts/identity-v1.jsonld"
+                ],
+                "type": [
+                  "VerifiableCredential",
+                  "IdentityCheckCredential"
                 ],
                 "credentialSubject": {
                   "name": [
@@ -2923,24 +2927,20 @@ class ContractTest {
                       "value": "1980-01-01"
                     }
                   ],
-                  "residencePermit": [
-                    {
-                      "icaoIssuerCode": "GBR",
-                      "documentNumber": "ZR8016200",
-                      "expiryDate": "2024-02-25",
-                      "documentType": "CR"
-                    }
-                  ],
                   "deviceId": [
                     {
                       "value": "7d8f0d3c-6a0a-4298-afe5-0cf23633618c"
                     }
+                  ],
+                  "residencePermit": [
+                    {
+                      "documentNumber": "ZR8016200",
+                      "expiryDate": "2024-02-25",
+                      "icaoIssuerCode": "GBR",
+                      "documentType": "CR"
+                    }
                   ]
                 },
-                "type": [
-                  "VerifiableCredential",
-                  "IdentityCheckCredential"
-                ],
                 "evidence": [
                   {
                     "type": "IdentityCheck",
@@ -2968,7 +2968,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_BRC_VC_SIGNATURE =
-            "254TQIjoodWhV_ij2QvLleVFzRpMDnLLPw8-Lr_WAxdxfLPTs-5mnXPa0n-GsNvYPl7FZx7rJInnficNaWlygQ"; // pragma: allowlist secret
+            "HtbCDCsMJFtTI1XZf-lEydXCr_GZf98sY8h8tX9-41rpk7KjXAK-ciP7uknct5g7eKX2keKCMExz59-eMD6lrg"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-5175-AC2
@@ -2985,6 +2985,10 @@ class ContractTest {
                 "@context": [
                   "https://www.w3.org/2018/credentials/v1",
                   "https://vocab.account.gov.uk/contexts/identity-v1.jsonld"
+                ],
+                "type": [
+                  "VerifiableCredential",
+                  "IdentityCheckCredential"
                 ],
                 "credentialSubject": {
                   "name": [
@@ -3006,24 +3010,20 @@ class ContractTest {
                       "value": "1980-01-01"
                     }
                   ],
-                  "residencePermit": [
-                    {
-                      "icaoIssuerCode": "GBR",
-                      "documentNumber": "ZR8016200",
-                      "expiryDate": "2024-02-25",
-                      "documentType": "CR"
-                    }
-                  ],
                   "deviceId": [
                     {
                       "value": "7d8f0d3c-6a0a-4298-afe5-0cf23633618c"
                     }
+                  ],
+                  "residencePermit": [
+                    {
+                      "documentNumber": "ZR8016200",
+                      "expiryDate": "2024-02-25",
+                      "icaoIssuerCode": "GBR",
+                      "documentType": "CR"
+                    }
                   ]
                 },
-                "type": [
-                  "VerifiableCredential",
-                  "IdentityCheckCredential"
-                ],
                 "evidence": [
                   {
                     "type": "IdentityCheck",
@@ -3052,5 +3052,5 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_BRC_VC_SIGNATURE =
-            "2Ubk2LfcqMTOCgKJg7bJSwr8CqZHCptZpzxLX6qyYOgQpYxVHhwxs16lCugG811Ho7QRD5Oy28Qubh7hJwQxAA"; // pragma: allowlist secret
+            "KsFSlV6PysyG5LJYGFQ9e1uVTdnSfdNjOsJCOsd8zxYrR0lK5f-Zu4UH3dxhwqvFzG2nn0zixkpo6CvMhapbcA"; // pragma: allowlist secret
 }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -1342,7 +1342,7 @@ class ContractTest {
                                 assertEquals("2024-02-25", brp.get("expiryDate").asText());
                                 assertEquals("ZR8016200", brp.get("documentNumber").asText());
                                 assertEquals("GBR", brp.get("icaoIssuerCode").asText());
-                                assertEquals("CR", brp.get("documentType").asText());
+                                assertEquals("IR", brp.get("documentType").asText());
 
                                 assertEquals("1980-01-01", birthDateNode.get("value").asText());
 
@@ -2773,7 +2773,7 @@ class ContractTest {
                       "documentNumber": "ZR8016200",
                       "expiryDate": "2024-02-25",
                       "icaoIssuerCode": "GBR",
-                      "documentType": "CR"
+                      "documentType": "IR"
                     }
                   ]
                 },
@@ -2804,7 +2804,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_BRP_VC_SIGNATURE =
-            "yGgpft2Kl3Xt9O8lC-bHrAgxQCX3ks8bTEQvD2IJWrrbBcrCnSZ4adRq4h1G9EYhaU5LD6VAR4El2b1Fbf3Qww"; // pragma: allowlist secret
+            "uOWSIKd-MufE0KCYoSxKy8nXApOmje5Gk6SqurLmZWdylX9otKt1PYJ3ePjsQsp4edeWBWqoXrdAAwOpfBqk-w"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-5175-AC1

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -1879,7 +1879,7 @@ class ContractTest {
                   "drivingPermit": [
                     {
                       "personalNumber": "DOE99802085J99FG",
-                      "expiryDate": "2023-01-18",
+                      "expiryDate": "2046-11-07",
                       "issueDate": "2022-05-29",
                       "issueNumber": null,
                       "issuedBy": "DVLA",
@@ -1905,6 +1905,10 @@ class ContractTest {
                 },
                 "evidence": [
                   {
+                    "type": "IdentityCheck",
+                    "txn": "ea2feefe-45a3-4a29-923f-604cd4017ec0",
+                    "strengthScore": 3,
+                    "validityScore": 2,
                     "activityHistoryScore": 1,
                     "checkDetails": [
                       {
@@ -1916,11 +1920,7 @@ class ContractTest {
                         "biometricVerificationProcessLevel": 3,
                         "checkMethod": "bvr"
                       }
-                    ],
-                    "strengthScore": 3,
-                    "validityScore": 2,
-                    "txn": "ea2feefe-45a3-4a29-923f-604cd4017ec0",
-                    "type": "IdentityCheck"
+                    ]
                   }
                 ]
               },
@@ -1931,7 +1931,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_DVLA_VC_SIGNATURE =
-            "mlvF1U-39OcV1Dic-OYVgIxuCW6Q59Qyytrj1hfTuXcjstY0K7NWX0RM3ni_2PV9Dw-JlLspo9qpzyrPYhqxzw"; // pragma: allowlist secret
+            "XNCcDilpQRNjZuCKrt-Vw11UiVlf8l-Vif_UjFZGqrWhk1G8XtxI058z5nFRZllticAwW6esu51m7ER-gEx4jQ"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // Based on DCMAW-410-AC1 with given names removed
@@ -1958,8 +1958,12 @@ class ContractTest {
                     {
                       "nameParts": [
                         {
-                          "value": "Doe The Ball",
-                          "type": "FamilyName"
+                          "type": "GivenName",
+                          "value": ""
+                        },
+                        {
+                          "type": "FamilyName",
+                          "value": "Doe The Ball"
                         }
                       ]
                     }
@@ -1972,6 +1976,16 @@ class ContractTest {
                   "deviceId": [
                     {
                       "value": "fb03ce33-6cb4-4b27-b428-f614eba26dd0"
+                    }
+                  ],
+                  "drivingPermit": [
+                    {
+                      "personalNumber": "DOE99802085J99FG",
+                      "expiryDate": "2046-11-07",
+                      "issueDate": "2022-05-29",
+                      "issueNumber": null,
+                      "issuedBy": "DVLA",
+                      "fullAddress": "WHATEVER STREET, WIRRAL, CH1 1AQ"
                     }
                   ],
                   "address": [
@@ -1989,16 +2003,6 @@ class ContractTest {
                       "postalCode": "CH1 1AQ",
                       "addressCountry": null
                     }
-                  ],
-                  "drivingPermit": [
-                    {
-                      "personalNumber": "DOE99802085J99FG",
-                      "expiryDate": "2023-01-18",
-                      "issueNumber": null,
-                      "issuedBy": "DVLA",
-                      "issueDate": "2022-05-29",
-                      "fullAddress": "WHATEVER STREET, WIRRAL, CH1 1AQ"
-                    }
                   ]
                 },
                 "evidence": [
@@ -2015,8 +2019,8 @@ class ContractTest {
                         "activityFrom": "2022-05-29"
                       },
                       {
-                        "checkMethod": "bvr",
-                        "biometricVerificationProcessLevel": 3
+                        "biometricVerificationProcessLevel": 3,
+                        "checkMethod": "bvr"
                       }
                     ]
                   }
@@ -2029,7 +2033,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_DVLA_VC_NO_GIVEN_NAME_SIGNATURE =
-            "lRGorJP0byCFDhXiHjPYSvaEZ5dDX2QwYeKogOvfBECwuGJ-4jfxfsPQ7TxODB_B32uZ0IAIMliyutZ1rqsD9Q"; // pragma: allowlist secret
+            "nw_Am3oXGUFrPYNCTxwZBib-FCKaNSE2UVUyiA1_FBn2DXfAVjZvaw_IMDfRgiFhXL87-fK-ue7sop82DhPuLw"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-5477-AC1
@@ -2056,12 +2060,12 @@ class ContractTest {
                     {
                       "nameParts": [
                         {
-                          "value": "Jane",
-                          "type": "GivenName"
+                          "type": "GivenName",
+                          "value": "Jane"
                         },
                         {
-                          "value": "Doe",
-                          "type": "FamilyName"
+                          "type": "FamilyName",
+                          "value": "Doe"
                         }
                       ]
                     }
@@ -2074,6 +2078,16 @@ class ContractTest {
                   "deviceId": [
                     {
                       "value": "fb03ce33-6cb4-4b27-b428-f614eba26dd0"
+                    }
+                  ],
+                  "drivingPermit": [
+                    {
+                      "personalNumber": "DOEDO861281JF9DH",
+                      "expiryDate": "2046-11-07",
+                      "issueDate": null,
+                      "issueNumber": null,
+                      "issuedBy": "DVLA",
+                      "fullAddress": "102 TEST ROAD,WIRRAL,CH62 6AQ"
                     }
                   ],
                   "address": [
@@ -2091,16 +2105,6 @@ class ContractTest {
                       "postalCode": "CH62 6AQ",
                       "addressCountry": null
                     }
-                  ],
-                  "drivingPermit": [
-                    {
-                      "personalNumber": "DOEDO861281JF9DH",
-                      "issueNumber": null,
-                      "issuedBy": "DVLA",
-                      "issueDate": null,
-                      "expiryDate": "2028-08-07",
-                      "fullAddress": "102 TEST ROAD,WIRRAL,CH62 6AQ"
-                    }
                   ]
                 },
                 "evidence": [
@@ -2109,10 +2113,10 @@ class ContractTest {
                     "txn": "bcd2346",
                     "strengthScore": 3,
                     "validityScore": 0,
+                    "activityHistoryScore": 0,
                     "ci": [
                       "V01"
                     ],
-                    "activityHistoryScore": 0,
                     "failedCheckDetails": [
                       {
                         "checkMethod": "vri",
@@ -2134,7 +2138,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_DVLA_VC_WITH_CI_SIGNATURE =
-            "_hXmVCbpsxoMZFyape27lYfcu0X_QAbkKwhVBRCuPNz9YqqdP97zltkDknArWmW7H9KDt0WwUc04yl_uDxL5Yw"; // pragma: allowlist secret
+            "eipWy-RiHykq209fYHa65bhqBKpng2BmTFYVqQiqPJDQTU8HN6lYdSwOhjn1CyO41VaaPvlnDAy4v0ZGSz1XRQ"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-1045-AC1
@@ -2161,16 +2165,16 @@ class ContractTest {
                     {
                       "nameParts": [
                         {
-                          "value": "SARAH",
-                          "type": "GivenName"
+                          "type": "GivenName",
+                          "value": "SARAH"
                         },
                         {
-                          "value": "MEREDYTH",
-                          "type": "GivenName"
+                          "type": "GivenName",
+                          "value": "MEREDYTH"
                         },
                         {
-                          "value": "MORGAN",
-                          "type": "FamilyName"
+                          "type": "FamilyName",
+                          "value": "MORGAN"
                         }
                       ]
                     }
@@ -2183,6 +2187,16 @@ class ContractTest {
                   "deviceId": [
                     {
                       "value": "a3017511-b639-46ff-ab73-66e5ab0193c9"
+                    }
+                  ],
+                  "drivingPermit": [
+                    {
+                      "personalNumber": "MORGA753116SM9IJ",
+                      "expiryDate": "2046-11-07",
+                      "issueDate": null,
+                      "issueNumber": null,
+                      "issuedBy": "DVA",
+                      "fullAddress": "122 BURNS CRESCENT EDINBURGH EH1 9GP"
                     }
                   ],
                   "address": [
@@ -2200,16 +2214,6 @@ class ContractTest {
                       "postalCode": "EH1 9GP",
                       "addressCountry": null
                     }
-                  ],
-                  "drivingPermit": [
-                    {
-                      "personalNumber": "MORGA753116SM9IJ",
-                      "issueNumber": null,
-                      "issuedBy": "DVA",
-                      "issueDate": null,
-                      "expiryDate": "2023-01-18",
-                      "fullAddress": "122 BURNS CRESCENT EDINBURGH EH1 9GP"
-                    }
                   ]
                 },
                 "evidence": [
@@ -2218,8 +2222,8 @@ class ContractTest {
                     "txn": "bcd2346",
                     "strengthScore": 3,
                     "validityScore": 0,
-                    "ci": [],
                     "activityHistoryScore": 0,
+                    "ci": [],
                     "failedCheckDetails": [
                       {
                         "checkMethod": "vri",
@@ -2241,7 +2245,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_DVA_VC_NO_CI_SIGNATURE =
-            "eOwpmHQD8b-zLrkk35jzay56-3J17VFYR7gE1z9ZWx0XtIDG0VNwByMmzWA4HiCTzei8SHxbTClrdMpG7zBnEg"; // pragma: allowlist secret
+            "vvS_jP4Jap_FF3GhA3A8QPnib6PH032IxyQErWNDu5h6xK7ddSa5NGNOzPz4E61SNuuL-aKhVjMIqfA2hdKCPQ"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-1559-AC2
@@ -2268,16 +2272,16 @@ class ContractTest {
                     {
                       "nameParts": [
                         {
-                          "value": "OLGA",
-                          "type": "GivenName"
+                          "type": "GivenName",
+                          "value": "OLGA"
                         },
                         {
-                          "value": "A",
-                          "type": "GivenName"
+                          "type": "GivenName",
+                          "value": "A"
                         },
                         {
-                          "value": "KULYK",
-                          "type": "FamilyName"
+                          "type": "FamilyName",
+                          "value": "KULYK"
                         }
                       ]
                     }
@@ -2290,6 +2294,16 @@ class ContractTest {
                   "deviceId": [
                     {
                       "value": "a3017511-b639-46ff-ab73-66e5ab0193c9"
+                    }
+                  ],
+                  "drivingPermit": [
+                    {
+                      "personalNumber": "5823131861",
+                      "expiryDate": "2046-11-07",
+                      "issueDate": "2022-05-29",
+                      "issueNumber": null,
+                      "issuedBy": "DVA",
+                      "fullAddress": null
                     }
                   ],
                   "address": [
@@ -2307,16 +2321,6 @@ class ContractTest {
                       "postalCode": null,
                       "addressCountry": null
                     }
-                  ],
-                  "drivingPermit": [
-                    {
-                      "expiryDate": "2028-02-20",
-                      "issueDate": "2022-05-29",
-                      "issueNumber": null,
-                      "issuedBy": "DVA",
-                      "personalNumber": "5823131861",
-                      "fullAddress": null
-                    }
                   ]
                 },
                 "evidence": [
@@ -2333,8 +2337,8 @@ class ContractTest {
                         "activityFrom": "2022-05-29"
                       },
                       {
-                        "checkMethod": "bvr",
-                        "biometricVerificationProcessLevel": 3
+                        "biometricVerificationProcessLevel": 3,
+                        "checkMethod": "bvr"
                       }
                     ]
                   }
@@ -2347,7 +2351,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_DVA_VC_SIGNATURE =
-            "nXWlQ20h1h8KMaX5C09P0krYwYS5R7m9dEVHJf7TP3Tw4cZZEj8Ss1vvqnsF0gv3c7wWaiAp8OcbWNDgdM8jPA"; // pragma: allowlist secret
+            "band-kIzrrEO8DEnDhxdFGcF9BaiifWEt1qW4_Cc657YtvfIlVFFV_mg3NyOmCm4ZLIcTrHe5xy9a_0ZUkHD4g"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-4733-AC1
@@ -2374,16 +2378,16 @@ class ContractTest {
                     {
                       "nameParts": [
                         {
-                          "value": "Jane",
-                          "type": "GivenName"
+                          "type": "GivenName",
+                          "value": "Jane"
                         },
                         {
-                          "value": "Julian",
-                          "type": "GivenName"
+                          "type": "GivenName",
+                          "value": "Julian"
                         },
                         {
-                          "value": "Boe",
-                          "type": "FamilyName"
+                          "type": "FamilyName",
+                          "value": "Boe"
                         }
                       ]
                     }
@@ -2396,6 +2400,16 @@ class ContractTest {
                   "deviceId": [
                     {
                       "value": "fb03ce33-6cb4-4b27-b428-f614eba26dd0"
+                    }
+                  ],
+                  "drivingPermit": [
+                    {
+                      "personalNumber": "BOEJJ861281TP9DH",
+                      "expiryDate": "2046-11-07",
+                      "issueDate": "2022-05-29",
+                      "issueNumber": null,
+                      "issuedBy": "DVLA",
+                      "fullAddress": "102 ROVER ROAD, WIRRAL, CH62 2AQ"
                     }
                   ],
                   "address": [
@@ -2413,16 +2427,6 @@ class ContractTest {
                       "postalCode": "CH62 2AQ",
                       "addressCountry": null
                     }
-                  ],
-                  "drivingPermit": [
-                    {
-                      "personalNumber": "BOEJJ861281TP9DH",
-                      "expiryDate": "2028-08-07",
-                      "issueNumber": null,
-                      "issuedBy": null,
-                      "issueDate": "2022-05-29",
-                      "fullAddress": "102 ROVER ROAD, WIRRAL, CH62 2AQ"
-                    }
                   ]
                 },
                 "evidence": [
@@ -2439,8 +2443,8 @@ class ContractTest {
                         "activityFrom": "2022-05-29"
                       },
                       {
-                        "checkMethod": "bvr",
-                        "biometricVerificationProcessLevel": 3
+                        "biometricVerificationProcessLevel": 3,
+                        "checkMethod": "bvr"
                       }
                     ]
                   }
@@ -2453,7 +2457,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_DRIVING_LICENCE_NO_ISSUER_VC_SIGNATURE =
-            "NUDPh22c35rtjMukSbD027MZFO5zYP67ldqseOjPzMqZE19fzGeQEoG9PqReLAzCWsbMh10kPAhWtmeasHnrbw"; // pragma: allowlist secret
+            "KCr0lmThH8quu1rYTodSrt012HuBJ9s0pTRFsKLDbmNxL8emvYQE23zuNRyGYvW-yInQcz01nCtO4Y6K-PQBtA"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-3079-AC1

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -2557,6 +2557,10 @@ class ContractTest {
                   "https://www.w3.org/2018/credentials/v1",
                   "https://vocab.account.gov.uk/contexts/identity-v1.jsonld"
                 ],
+                "type": [
+                  "VerifiableCredential",
+                  "IdentityCheckCredential"
+                ],
                 "credentialSubject": {
                   "name": [
                     {
@@ -2588,16 +2592,12 @@ class ContractTest {
                   ],
                   "passport": [
                     {
-                      "icaoIssuerCode": "NLD",
                       "documentNumber": "NXC65LP76",
-                      "expiryDate": "2026-04-01"
+                      "expiryDate": "2026-04-01",
+                      "icaoIssuerCode": "NLD"
                     }
                   ]
                 },
-                "type": [
-                  "VerifiableCredential",
-                  "IdentityCheckCredential"
-                ],
                 "evidence": [
                   {
                     "type": "IdentityCheck",
@@ -2625,7 +2625,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_NLD_PASSPORT_VC_SIGNATURE =
-            "1xYHkbBWWdoNJIYW9tZ9yQ2Z4pacWFj8BvEmFHN9kY4tdETqDu9rz2lf7f1WjLJK6Wf99lPuSTX49exQTCHQYQ"; // pragma: allowlist secret
+            "gmw-0o2_MlM5SqG71TE3EjUHlhPogqJ5uojMMT9-DsZFJMID09h9XItLKdGITABT49rQzoDOyedTSG7ZRAGl2w"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From DCMAW-3171-AC2
@@ -2642,6 +2642,10 @@ class ContractTest {
                 "@context": [
                   "https://www.w3.org/2018/credentials/v1",
                   "https://vocab.account.gov.uk/contexts/identity-v1.jsonld"
+                ],
+                "type": [
+                  "VerifiableCredential",
+                  "IdentityCheckCredential"
                 ],
                 "credentialSubject": {
                   "name": [
@@ -2674,16 +2678,12 @@ class ContractTest {
                   ],
                   "passport": [
                     {
-                      "icaoIssuerCode": "GBR",
                       "documentNumber": "549364783",
-                      "expiryDate": "2027-08-01"
+                      "expiryDate": "2027-08-01",
+                      "icaoIssuerCode": "GBR"
                     }
                   ]
                 },
-                "type": [
-                  "VerifiableCredential",
-                  "IdentityCheckCredential"
-                ],
                 "evidence": [
                   {
                     "type": "IdentityCheck",
@@ -2714,7 +2714,7 @@ class ContractTest {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_PASSPORT_VC_WITH_CI_SIGNATURE =
-            "DA8wlJZtGn80_9QAllvQ6qPU2xftkWtx-BhmFFjc0-VLCsmaTB3ZF4RV3J6Mw4i9RxARTtePtv2kGhrryH850A"; // pragma: allowlist secret
+            "aRNWqaeF5-_T7D5RZuX0r1Z-jV3a0ql0OY0C-61JeFa_BO-ITho1N5Cz9p-0oyLsU_GzNEH3thQPqTEzpjj2DA"; // pragma: allowlist secret
 
     // 2099-01-01 00:00:00 is 4070908800 in epoch seconds
     // From BRP DCMAW-5176-AC1-valid-doc-chip-clone-detection-successful (there is also a BRC

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -309,7 +309,7 @@ class ContractTest {
                                         "Doe The Ball", nameParts.get(2).get("value").asText());
 
                                 assertEquals(
-                                        "2023-01-18", drivingPermitNode.get("expiryDate").asText());
+                                        "2046-11-07", drivingPermitNode.get("expiryDate").asText());
                                 assertEquals(
                                         "DOE99802085J99FG",
                                         drivingPermitNode.get("personalNumber").asText());
@@ -417,13 +417,15 @@ class ContractTest {
 
                                 assertEquals("CH1 1AQ", addressNode.get("postalCode").asText());
 
-                                assertEquals(1, nameParts.size());
-                                assertEquals("FamilyName", nameParts.get(0).get("type").asText());
+                                assertEquals(2, nameParts.size());
+                                assertEquals("GivenName", nameParts.get(0).get("type").asText());
+                                assertEquals("", nameParts.get(0).get("value").asText());
+                                assertEquals("FamilyName", nameParts.get(1).get("type").asText());
                                 assertEquals(
-                                        "Doe The Ball", nameParts.get(0).get("value").asText());
+                                        "Doe The Ball", nameParts.get(1).get("value").asText());
 
                                 assertEquals(
-                                        "2023-01-18", drivingPermitNode.get("expiryDate").asText());
+                                        "2046-11-07", drivingPermitNode.get("expiryDate").asText());
                                 assertEquals(
                                         "DOE99802085J99FG",
                                         drivingPermitNode.get("personalNumber").asText());
@@ -540,7 +542,7 @@ class ContractTest {
                                 assertEquals("Doe", nameParts.get(1).get("value").asText());
 
                                 assertEquals(
-                                        "2028-08-07", drivingPermitNode.get("expiryDate").asText());
+                                        "2046-11-07", drivingPermitNode.get("expiryDate").asText());
                                 assertEquals(
                                         "DOEDO861281JF9DH",
                                         drivingPermitNode.get("personalNumber").asText());
@@ -659,7 +661,7 @@ class ContractTest {
                                 assertEquals("MORGAN", nameParts.get(2).get("value").asText());
 
                                 assertEquals(
-                                        "2023-01-18", drivingPermitNode.get("expiryDate").asText());
+                                        "2046-11-07", drivingPermitNode.get("expiryDate").asText());
                                 assertEquals(
                                         "MORGA753116SM9IJ",
                                         drivingPermitNode.get("personalNumber").asText());
@@ -776,7 +778,7 @@ class ContractTest {
                                 assertEquals("KULYK", nameParts.get(2).get("value").asText());
 
                                 assertEquals(
-                                        "2028-02-20", drivingPermitNode.get("expiryDate").asText());
+                                        "2046-11-07", drivingPermitNode.get("expiryDate").asText());
                                 assertEquals(
                                         "2022-05-29", drivingPermitNode.get("issueDate").asText());
                                 assertEquals(
@@ -894,7 +896,7 @@ class ContractTest {
                                 assertEquals("Boe", nameParts.get(2).get("value").asText());
 
                                 assertEquals(
-                                        "2028-08-07", drivingPermitNode.get("expiryDate").asText());
+                                        "2046-11-07", drivingPermitNode.get("expiryDate").asText());
                                 assertEquals(
                                         "BOEJJ861281TP9DH",
                                         drivingPermitNode.get("personalNumber").asText());
@@ -1340,7 +1342,7 @@ class ContractTest {
                                 assertEquals("2024-02-25", brp.get("expiryDate").asText());
                                 assertEquals("ZR8016200", brp.get("documentNumber").asText());
                                 assertEquals("GBR", brp.get("icaoIssuerCode").asText());
-                                assertEquals("IR", brp.get("documentType").asText());
+                                assertEquals("CR", brp.get("documentType").asText());
 
                                 assertEquals("1980-01-01", birthDateNode.get("value").asText());
 

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -825,7 +825,7 @@ class ContractTest {
     @PactTestFor(pactMethod = "invalidUserInfoRequestReturns404Error")
     void fetchVerifiableCredential_whenCalledAgainstDcmawCri_forDvaVcWithNoIssuer_throwsAnException(
             MockServer mockServer)
-            throws URISyntaxException, CriApiException, JsonProcessingException {
+            throws URISyntaxException {
         // Arrange
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         configureMockConfigService(credentialIssuerConfig);

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -798,8 +798,7 @@ class ContractTest {
     }
 
     @Pact(provider = "DcmawCriProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact invalidUserInfoRequestReturns404Error(
-            PactDslWithProvider builder) {
+    public RequestResponsePact invalidUserInfoRequestReturns404Error(PactDslWithProvider builder) {
         return builder.given("dummyAccessToken is a valid access token")
                 .given("test-subject is a valid subject")
                 .given("dummyDcmawComponentId is a valid issuer")
@@ -812,10 +811,13 @@ class ContractTest {
                 .willRespondWith()
                 .status(404)
                 .body(
-                        newJsonBody(body -> {
-                                body.stringValue("https://vocab.account.gov.uk/v1/credentialStatus", "failed");
-                        })
-                        .build())
+                        newJsonBody(
+                                        body -> {
+                                            body.stringValue(
+                                                    "https://vocab.account.gov.uk/v1/credentialStatus",
+                                                    "failed");
+                                        })
+                                .build())
                 .toPact();
     }
 

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -824,8 +824,7 @@ class ContractTest {
     @Test
     @PactTestFor(pactMethod = "invalidUserInfoRequestReturns404Error")
     void fetchVerifiableCredential_whenCalledAgainstDcmawCri_forDvaVcWithNoIssuer_throwsAnException(
-            MockServer mockServer)
-            throws URISyntaxException {
+            MockServer mockServer) throws URISyntaxException {
         // Arrange
         var credentialIssuerConfig = getMockCredentialIssuerConfig(mockServer);
         configureMockConfigService(credentialIssuerConfig);


### PR DESCRIPTION
## Proposed changes
### What changed

This PR updates the expected VC JSON structures for VCs
asserted in the `pact/dcmawCri/ContractTest.java` Pacts.

- 

### Why did it change

In nearly 100% of test scenarios, the change is purely a JSON
structure update. We need to do this because Pact currently
does not support deep comparison of JWTs.   The DcmawCri
provider Pact tests fail because the VCs returned by DcmawCri
contain payloads serialised in a different order to those
hardcoded in the `ipv-core-back` DcmawCri contract test.

In a few scenarios there are some additional internal attributes
changes.  These arise because the DCMAW test VCs files which
are read by the Provider Pact tests have small differences from
the hard-coded VCs in `pact/dcmawCri/ContractTest.java`.

In one scenario - `DCMAW-410-AC1 with given name removed`
we need to discuss what is currently returned from the DCMAW
CRI, as it differs in one significant way from the asserted VC
in these contract tests.

- 

### Issue tracking

- [DCMAW-18492](https://govukverify.atlassian.net/browse/DCMAW-18492)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[DCMAW-18492]: https://govukverify.atlassian.net/browse/DCMAW-18492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ