### PR TITLE
PYIC-8927: explicitly handle oauth errors from DCMAW async

### DIFF
--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -287,3 +287,31 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'back' event
       Then I get a 'page-ipv-identity-document-start' page response
+
+    Scenario Outline: <error> from DCMAW
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces an '<error>' error response
+      When I wait for 1 seconds for the async credential to be processed
+      # This will probably need to change once the polling is working
+      And I pass on the DCMAW callback
+      Then I get a 'pyi-technical' page response
+
+      Examples:
+        | error                     |
+        | server_error              |
+        | temporarily_unavailable   |
+        | invalid_request           |
+        | unauthorized_client       |
+        | unsupported_response_type |
+        | invalid_scope             |

--- a/api-tests/src/clients/core-back-internal-client.ts
+++ b/api-tests/src/clients/core-back-internal-client.ts
@@ -91,12 +91,6 @@ export const callbackFromStrategicApp = async (
     body: JSON.stringify({ state: world.oauthState }),
   });
 
-  if (!response.ok) {
-    throw new Error(
-      `callbackFromStrategicApp request failed: ${response.statusText}`,
-    );
-  }
-
   const body = await response.json();
 
   world.clientOAuthSessionId = body?.clientOAuthSessionId;

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -326,6 +326,9 @@ nestedJourneyStates:
             targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE:
     response:
@@ -343,6 +346,9 @@ nestedJourneyStates:
             targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   MOBILE_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER:
     response:
@@ -388,6 +394,9 @@ nestedJourneyStates:
             targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE:
     response:
@@ -405,6 +414,9 @@ nestedJourneyStates:
             targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
       anotherWay:
         exitEventToEmit: anotherWay
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
 
   MOBILE_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER:
     response:


### PR DESCRIPTION
## Proposed changes
### What changed

- explicitly handle oauth error responses from the async DCMAW in the journey map

### Why did it change

- When core receives an oauth error from async DCMAW, the user correctly sees the "pyi-technical" screen but this is implicitly handled by core-front. Core-front receives a "/journey/error" which it tries to send to the journey engine. However, because this event isn't explicitly handled by the appropriate states, core-back will respond with a 500. Core-front will handle this unexpected error by displaying the generic technical error page. Instead, we should explicitly support the error event in the journey map states which then allows us to test the scenario in the api tests.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8927](https://govukverify.atlassian.net/browse/PYIC-8927)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8927]: https://govukverify.atlassian.net/browse/PYIC-8927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ