### PR TITLE
[DCMAW-18492] Make dummyInvalidAuthCode pact distinct. Remove over-specified 404 body.

### DIFF
--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/dcmawCri/ContractTest.java
@@ -148,7 +148,8 @@ class ContractTest {
 
     @Pact(provider = "DcmawCriProvider", consumer = "IpvCoreBack")
     public RequestResponsePact invalidAuthCodeRequestReturns401(PactDslWithProvider builder) {
-        return builder.given("dummyDcmawComponentId is the DCMAW CRI component ID")
+        return builder.given("dummyInvalidAuthCode is an invalid authorization code")
+                .given("dummyDcmawComponentId is the DCMAW CRI component ID")
                 .given(
                         "DCMAW CRI uses CORE_BACK_SIGNING_PRIVATE_KEY_JWK to validate core signatures")
                 .uponReceiving("Invalid auth code")
@@ -810,14 +811,6 @@ class ContractTest {
                 .headers("x-api-key", PRIVATE_API_KEY, "Authorization", "Bearer dummyAccessToken")
                 .willRespondWith()
                 .status(404)
-                .body(
-                        newJsonBody(
-                                        body -> {
-                                            body.stringValue(
-                                                    "https://vocab.account.gov.uk/v1/credentialStatus",
-                                                    "failed");
-                                        })
-                                .build())
                 .toPact();
     }
 


### PR DESCRIPTION
## Proposed changes
### What changed

1. The Pact for DcmawCri's /token endpoint that checks behaviour with an
   invalid authCode was impossible for the provider test to match with unique
   state handlers, as it's set of `given()` was a subset of the _valid_ authcode
   test.  This means the provider test can't provide appropriate state.

2. The Pact for DcmawCri's 404 error response, due to a DL vendor response
   that lacks `issuedBy` was over-specified: none of the other 40x checks in
   this Pact bother to specify the exact response body.  Make this one consistent.

- 

### Why did it change

For: 
1.  an extra `given()` is added, which provides a 'hook' for the provider test to
   register a new state handler, making a unique combination of states for this
   interaction, and so making it possible to test
2.  the provider Pact was having trouble matching the exact response body
   served with the 404 response.   I think it's fine to ignore.

- 

### Issue tracking

- [DCMAW-18492](https://govukverify.atlassian.net/browse/DCMAW-18492)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[DCMAW-18492]: https://govukverify.atlassian.net/browse/DCMAW-18492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ