### PR TITLE
BAU: remove "This will probably need to change once the polling is working" comment from the api tests as its no longer needed

### DIFF
--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
@@ -65,7 +65,6 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces an 'access_denied' error response
-      # This will probably need to change once the polling is working
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
       When I poll for async DCMAW credential receipt

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
@@ -175,7 +175,6 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces an 'access_denied' error response
-      # This will probably need to change once the polling is working
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
       When I poll for async DCMAW credential receipt

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -160,7 +160,6 @@ Feature: P2 App journey
       When I submit an 'iphone' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces an 'access_denied' error response
-      # This will probably need to change once the polling is working
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
       When I poll for async DCMAW credential receipt
@@ -303,7 +302,6 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
       When the async DCMAW CRI produces an '<error>' error response
       When I wait for 1 seconds for the async credential to be processed
-      # This will probably need to change once the polling is working
       And I pass on the DCMAW callback
       Then I get a 'pyi-technical' page response
 

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -24,7 +24,6 @@ Feature: Identity reuse update details failures
             When I submit an 'iphone' event
             Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
             When the async DCMAW CRI produces an 'access_denied' error response
-            # This will probably need to change once the polling is working
             And I pass on the DCMAW callback
             Then I get a 'check-mobile-app-result' page response
             When I poll for async DCMAW credential receipt


### PR DESCRIPTION
## Proposed changes
### What changed

- remove "This will probably need to change once the polling is working" comment from the api tests

### Why did it change

- it's no longer needed

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
