### PR TITLE
PYIC-8932 Consolidate app routing: add limited failover routing for DCMAW Async CRI

### DIFF
--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -1,20 +1,19 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Disabled CRI journeys
-  # TODO: Leaving this test suite for PYIC-8932 when adding failover routing for the V2 app
   Background: Disable the strategic app
     Given I activate the 'disableStrategicApp' feature set
 
   Rule: DCMAW is disabled
 
-    Scenario: A P1 journey takes the user on a no photo ID journey
-      Given I activate the 'dcmawOffTest' feature sets
+    Scenario: A P1 journey takes the user down the no photo ID NINO route instead
+      Given I activate the 'dcmawAsyncDisabled' feature set
       When I start a new 'low-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'prove-identity-no-photo-id' page response with context 'nino'
 
-    Scenario: A P2 journey takes the user to the document select page
-      Given I activate the 'dcmawOffTest' feature set
+    Scenario: A P2 journey takes the user down the web route instead
+      Given I activate the 'dcmawAsyncDisabled' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
@@ -23,7 +22,7 @@ Feature: Disabled CRI journeys
       Then I get a 'page-multiple-doc-check' page response
 
     Scenario: Choosing DCMAW after escaping from KBV CRIs leads to technical failure
-      Given I activate the 'dcmawOffTest' feature set
+      Given I activate the 'dcmawAsyncDisabled' feature set
       Given I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
@@ -58,14 +57,14 @@ Feature: Disabled CRI journeys
         | address     | kenneth-current                     |
         | fraud       | kenneth-score-2                     |
         | experianKbv | kenneth-needs-enhanced-verification |
-      And I activate the 'dcmawOffTest' feature set
+      And I activate the 'dcmawAsyncDisabled' feature set
       Given I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-technical' page response
 
     Scenario: Same session enhanced verification mitigation with DCMAW leads to technical failure
-      Given I activate the 'dcmawOffTest' feature set
+      Given I activate the 'dcmawAsyncDisabled' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -1,6 +1,7 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Disabled CRI journeys
   Background: Disable the strategic app
+    # TODO: remove this once strategicApp feature flag is removed in PYIC-8928
     Given I activate the 'disableStrategicApp' feature set
 
   Rule: DCMAW is disabled

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -34,7 +34,7 @@ states:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
             targetEntryEvent: appTriage
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
@@ -142,7 +142,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetState: NINO_START_PAGE
             checkMitigation:
               enhanced-verification:
@@ -371,7 +371,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       f2f:
@@ -558,7 +558,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       end:
@@ -578,7 +578,7 @@ states:
             targetState: STRATEGIC_APP_TRIAGE
             targetEntryEvent: appTriage
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       passport:
@@ -612,7 +612,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       end:
@@ -726,7 +726,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       f2f:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -34,7 +34,7 @@ states:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
             targetEntryEvent: appTriage
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
@@ -142,7 +142,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetState: MULTIPLE_DOC_CHECK_PAGE
       end:
         targetState: F2F_START_PAGE
@@ -378,7 +378,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       f2f:
@@ -579,7 +579,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       end:
@@ -612,7 +612,7 @@ states:
             targetState: STRATEGIC_APP_TRIAGE
             targetEntryEvent: appTriage
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       passport:
@@ -646,7 +646,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       end:
@@ -666,7 +666,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       end:
@@ -781,7 +781,7 @@ states:
           strategicAppEnabled:
             targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
-          dcmaw:
+          dcmawAsync:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       f2f:

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -415,9 +415,9 @@ core:
       credentialIssuers:
         drivingLicence:
           enabled: false
-    dcmawOffTest:
+    dcmawAsyncDisabled:
       credentialIssuers:
-        dcmaw:
+        dcmawAsync:
           enabled: false
     # Enabling CRIs
     ticfCriBeta:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -413,6 +413,10 @@ core:
       credentialIssuers:
         dcmaw:
           enabled: false
+    dcmawAsyncDisabled:
+      credentialIssuers:
+        dcmawAsync:
+          enabled: false
     # Enabling CRIs
     ticfCriBeta:
       credentialIssuers:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -409,10 +409,6 @@ core:
       credentialIssuers:
         drivingLicence:
           enabled: false
-    dcmawOffTest:
-      credentialIssuers:
-        dcmaw:
-          enabled: false
     dcmawAsyncDisabled:
       credentialIssuers:
         dcmawAsync:


### PR DESCRIPTION
## Proposed changes
### What changed

Maintain limited failover routing for v2 app (DCMAW Async CRI), most importantly re-routing app entry points at the start of new proving journeys. This is *not* a complete nor strategic journey resilience solution, there may still be entry points into the app which are not covered.

### Why did it change

As part of retiring the v1 app we are consolidating app routing in the journey map and we want to maintain the existing limited failover routing in case of an app outage, in this case by disabling the DCMAW Async CRI.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8932](https://govukverify.atlassian.net/browse/PYIC-8932)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8932]: https://govukverify.atlassian.net/browse/PYIC-8932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ