### PR TITLE
BAU: Fix expanding doubly-nested journeys with event overrides

### DIFF
--- a/journey-map/src/helpers/expand-nested.ts
+++ b/journey-map/src/helpers/expand-nested.ts
@@ -81,8 +81,8 @@ export const expandNestedJourneys = (
                   (!t.targetEntryEvent && implicitEntryEvent === entryEvent),
               )
               .forEach((t) => {
+                delete t.targetEntryEvent; // Clear any resolved target entry event
                 Object.assign(t, entryEventDef);
-                delete t.targetEntryEvent;
               });
           });
         });

--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -43,7 +43,7 @@ const NESTED_JOURNEY_TYPE_SEARCH_PARAM = "nestedJourneyType";
 const JOURNEY_TYPE_SEARCH_PARAM = "journeyType";
 
 mermaid.initialize({
-  maxTextSize: 100000,
+  maxTextSize: 200000,
   startOnLoad: false,
   // Required to enable links and callbacks
   // This is (relatively) safe, as we only run on our own generated mermaid charts


### PR DESCRIPTION
Currently the 'expand nested journeys' option in the journey map doesn't work when there are doubly-nested journeys with `targetEntryEvent` overrides.