### PR TITLE
Pyic 8913 m1c mitigation

### DIFF
--- a/api-tests/.env.local
+++ b/api-tests/.env.local
@@ -11,6 +11,9 @@ ASYNC_QUEUE_DELAY=2
 AIS_STUB_BASE_URL="https://ais.stubs.account.gov.uk"
 CIMIT_STUB_BASE_URL="https://cimit.stubs.account.gov.uk"
 CIMIT_INTERNAL_API_URL="https://cimit-api.stubs.account.gov.uk"
+# Example values for using dev env CIMIT stub
+#CIMIT_STUB_BASE_URL="https://cimit-dev-danc.02.core.dev.stubs.account.gov.uk"
+#CIMIT_INTERNAL_API_URL="https://cimit-api-dev-danc.02.core.dev.stubs.account.gov.uk"
 EVCS_STUB_BASE_URL="https://evcs.stubs.account.gov.uk"
 TICF_STUB_BASE_URL="https://ticf.stubs.account.gov.uk"
 

--- a/api-tests/README.md
+++ b/api-tests/README.md
@@ -16,7 +16,7 @@
 
 ## Running the tests
 
-There are 3 presets that can be used:
+There are 4 presets that can be used:
 
 - `npm run test:build` - runs against the deployed build environment
 - `npm run test:local` - runs against an already-running local instance of core-back
@@ -41,20 +41,42 @@ To run against dev environments copy `.env.dev.template` to `.env.dev` and provi
 It is also possible to set up other `.env.<name>` files,
 which can be selected by setting `CORE_ENV=<name>` when running the tests.
 
-As an example, to run against a deployment in the dev01 account you could create a `.env.dev01` file something like:
+As an example, to run against a deployment in the dev02 account you could create a `.env.dev02` file something like:
 
 ```
-CORE_BACK_COMPONENT_ID="https://dev-chrisw.01.dev.identity.account.gov.uk"
-CORE_BACK_INTERNAL_API_URL="https://internal-test-api-dev-chrisw.01.dev.identity.account.gov.uk"
-CORE_BACK_INTERNAL_API_KEY=<get from CoreBackInternalTestingApiKey secret in secrets manager>-dev-chrisw
-CORE_BACK_EXTERNAL_API_URL="https://api-dev-chrisw.01.dev.identity.account.gov.uk"
+CORE_BACK_COMPONENT_ID="https://dev-danc.02.dev.identity.account.gov.uk"
+CORE_BACK_INTERNAL_API_URL="https://internal-test-api-dev-danc.02.dev.identity.account.gov.uk"
+CORE_BACK_INTERNAL_API_KEY=<get from CoreBackInternalTestingApiKey secret in secrets manager>-dev-danc
+CORE_BACK_EXTERNAL_API_URL="https://api-dev-danc.02.dev.identity.account.gov.uk"
 CORE_BACK_PUBLIC_ENCRYPTION_KEY='{"kty":"RSA","e":"AQAB","kid":"b454ac07-e188-415d-a3c8-f1d0d38aaecd","n":"loHeaSxvMgiHStKmb-ZK5ZPpwRWrhSSQ-nTyuKQj-mYWYFNGgGGNP-37Zvzo453bUGtEeFu1zdlLAoHyT3kgs1XdqXCvPinNccpJ8lWGXcFKGRhj5jxIiIMvEBHfLs\*-cMIWW0166ndTT93ocoXdXaP64mH2iF7WWDyKqOcrVjuaUnbFbS4X2fhJwwRPj_Kin5jpJCx3MJd9eIuYyJB4CltbLTpX25oCwLw9t-p2lzHfazJSITcfTzEbOZV40fPJIR6HlJi7ApXYfAQ-dlbjMsYinFQnY6ILJXkbsjD4JXWUYaB0RbK8WTTKyehFU7P_Q8vFb7qWU4Xj9MTEHc7W3Q"}'
-ORCHESTRATOR_REDIRECT_URL="https://orch-dev-chrisw.01.core.dev.stubs.account.gov.uk/callback"
+ORCHESTRATOR_REDIRECT_URL="https://orch-dev-danc.02.core.dev.stubs.account.gov.uk/callback"
 JAR_SIGNING_KEY='{"kty":"EC","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}' // pragma: allowlist secret
-ASYNC_QUEUE_NAME="stubQueue_criResponseQueue_dev-chrisw"
+ASYNC_QUEUE_NAME="stubQueue_criResponseQueue_dev-danc"
 ASYNC_QUEUE_DELAY=5
+CIMIT_STUB_BASE_URL="https://cimit-dev-danc.02.core.dev.stubs.account.gov.uk"
+CIMIT_INTERNAL_API_URL="https://cimit-api-dev-danc.02.core.dev.stubs.account.gov.uk"
 MANAGEMENT_CIMIT_STUB_API_KEY="example-value" # pragma: allowlist secret
+CIMIT_INTERNAL_API_KEY="example-value" # pragma: allowlist secret
 ```
+
+#### Substituting individual stubs
+
+It is possible to run the tests mostly against local/build core and stubs and just substitute in a single stub running
+in your developer environment. This can be useful if you want to make sure stub changes don't break the tests. To do this
+you will need to update the config values for the relevant stub in your `.env.build` or `.env.local` file. This typically
+means updating the URLs and possibly api keys and signing and encryption keys.
+
+e.g. to use a CIMIT stub deployed to a dev env you need to update:
+
+- `CIMIT_STUB_BASE_URL` to something like `https://cimit-dev-danc.02.core.dev.stubs.account.gov.uk`
+- `CIMIT_INTERNAL_API_URL` to something like `https://cimit-api-dev-danc.02.core.dev.stubs.account.gov.uk`
+- `CIMIT_INTERNAL_API_KEY` to the internal API key of the dev env CIMIT stub (find this in AWS console - see below)
+- `MANAGEMENT_CIMIT_STUB_API_KEY` to the external API key of the dev env CIMIT stub (find this in AWS console - see below)
+
+At time of writing, the process for finding dev env API keys is so bad it deserves documenting. To find an API key for a
+specific API you need to go to `API Gateway / API Keys` in AWS console and then filter by the key prefix (e.g. cimit).
+If you know when the key was created you can use the date to find the right one. Otherwise you will just need to click on
+each one until you find the one with the right `Associated Stage` value.
 
 ## Working on the tests
 

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-score-0-mortality-breaching/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-score-0-mortality-breaching/credentialSubject.json
@@ -1,0 +1,32 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "buildingName": "",
+      "streetName": "HADLEY ROAD",
+      "postalCode": "BA2 5AA",
+      "buildingNumber": "8",
+      "addressLocality": "BATH",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-score-0-mortality-breaching/evidence.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-score-0-mortality-breaching/evidence.json
@@ -1,0 +1,31 @@
+{
+  "activityHistoryScore": 0,
+  "checkDetails": [
+    {
+      "checkMethod": "data",
+      "fraudCheck": "applicable_authoritative_source"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "available_authoritative_source"
+    }
+  ],
+  "failedCheckDetails": [
+    {
+      "checkMethod": "data",
+      "fraudCheck": "mortality_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "identity_theft_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "synthetic_identity_check"
+    }
+  ],
+  "ci": ["BREACHING"],
+  "txn": "RB000117420948",
+  "identityFraudScore": 0,
+  "type": "IdentityCheck"
+}

--- a/api-tests/features/cimit/p2-mortality-mitigation.feature
+++ b/api-tests/features/cimit/p2-mortality-mitigation.feature
@@ -1,4 +1,4 @@
-@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest @qqqqqq
+@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
 Feature: Mortality check failures
   Background:
     Given I activate the 'strategicApp' feature set

--- a/api-tests/features/cimit/p2-mortality-mitigation.feature
+++ b/api-tests/features/cimit/p2-mortality-mitigation.feature
@@ -1,7 +1,6 @@
 @Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
 Feature: Mortality check failures
   Background:
-    Given I activate the 'strategicApp' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'uk' event

--- a/api-tests/features/cimit/p2-mortality-mitigation.feature
+++ b/api-tests/features/cimit/p2-mortality-mitigation.feature
@@ -1,0 +1,49 @@
+@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest @qqqqqq
+Feature: Mortality check failures
+  Background:
+    Given I activate the 'strategicApp' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+    When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
+          # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get a 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+
+  Scenario: Mitigated mortality check results in M1C
+    When I tell the CIMIT stub that the 'BREACHING' CI is already mitigated
+    And  I submit 'kenneth-score-0-mortality-breaching' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P2' identity
+
+  Scenario: Unmitigated mortality check results in failure
+    When I submit 'kenneth-score-0-mortality-breaching' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
+    Then I get a 'pyi-no-match' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I get a 'P0' identity

--- a/api-tests/src/clients/cimit-stub-client.ts
+++ b/api-tests/src/clients/cimit-stub-client.ts
@@ -41,6 +41,32 @@ export const createUserCi = async (
   );
 
   if (!response.ok) {
-    throw new Error(`createUserCi request failed: ${response.statusText}`);
+    throw new Error(
+      `createUserCi request failed: ${response.statusText} ${await response.text()}`,
+    );
+  }
+};
+
+export const createPreMitigation = async (
+  userId: string,
+  ciToMitigate: string,
+  mitigations: string[],
+): Promise<void> => {
+  const response = await fetch(
+    `${config.cimit.managementCimitUrl}/user/${userId}/premitigations/${ciToMitigate}`,
+    {
+      headers: {
+        "x-api-key": config.cimit.managementCimitApiKey,
+        "content-type": "application/json",
+      },
+      method: "POST",
+      body: JSON.stringify({ mitigations }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `createMitigation request failed: ${response.statusText} ${await response.text()}`,
+    );
   }
 };

--- a/api-tests/src/steps/cimit-steps.ts
+++ b/api-tests/src/steps/cimit-steps.ts
@@ -9,13 +9,27 @@ When(
     this.userId = this.userId ?? getRandomString(16);
     const ciRequests = [];
     for (const row of table.hashes()) {
+      const mitigations: string[] = row.Mitigations
+        ? row.Mitigations.split(",").map((s) => s.trim())
+        : [];
       ciRequests.push({
-        code: row.code,
-        document: row.document,
+        code: row.Code,
+        document: row.Document,
+        mitigations,
         issuer: "issued-by-api-tests",
         txn: getRandomString(16),
       });
     }
     await cimitStubClient.createUserCi(this.userId, ciRequests);
+  },
+);
+
+When(
+  "I tell the CIMIT stub that the {string} CI is already mitigated",
+  async function (this: World, ciCode: string): Promise<void> {
+    this.userId = this.userId ?? getRandomString(16);
+    await cimitStubClient.createPreMitigation(this.userId, ciCode, [
+      "MITIGATION",
+    ]);
   },
 );

--- a/api-tests/src/types/cimit-stub.ts
+++ b/api-tests/src/types/cimit-stub.ts
@@ -10,9 +10,3 @@ export interface CimitStubUserCisRequest {
   issuanceDate?: string;
   mitigations?: string[];
 }
-
-export interface CimitStubMitigationRequest {
-  mitigations: string[];
-  vcJti: string;
-  forFutureCi?: boolean;
-}

--- a/api-tests/src/types/cimit-stub.ts
+++ b/api-tests/src/types/cimit-stub.ts
@@ -10,3 +10,9 @@ export interface CimitStubUserCisRequest {
   issuanceDate?: string;
   mitigations?: string[];
 }
+
+export interface CimitStubMitigationRequest {
+  mitigations: string[];
+  vcJti: string;
+  forFutureCi?: boolean;
+}

--- a/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
+++ b/lambdas/build-cri-oauth-request/src/main/java/uk/gov/di/ipv/core/buildcrioauthrequest/BuildCriOauthRequestHandler.java
@@ -382,7 +382,7 @@ public class BuildCriOauthRequestHandler
     private EvidenceRequest getEvidenceRequestForF2F(
             List<VerifiableCredential> vcs, Vot requestedVot) {
         var gpg45Scores = gpg45ProfileEvaluator.buildScore(vcs);
-        var isFraudScoreRequired = !VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
+        var isFraudScoreRequired = !VcHelper.isFraudScoreOptionalForGpg45Evaluation(vcs);
         var requiredEvidences =
                 gpg45Scores.calculateGpg45ScoresRequiredToMeetAProfile(
                         requestedVot.getSupportedGpg45Profiles(isFraudScoreRequired));

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -1113,6 +1113,26 @@ public interface VcFixtures {
                 INSTANT_01_01_2099);
     }
 
+    // Note that this VC is unrealistic and only for specific testsing
+    static VerifiableCredential vcExperianFraudMortalityNonZeroScore() {
+        var vcClaim = vcClaimExperianFraudScore1();
+        vcClaim.getEvidence()
+                .get(0)
+                .setFailedCheckDetails(
+                        List.of(
+                                CheckDetails.builder()
+                                        .withCheckMethod(CheckDetails.CheckMethodType.DATA)
+                                        .withFraudCheck(CheckDetails.FraudCheckType.MORTALITY_CHECK)
+                                        .build()));
+
+        return generateVerifiableCredential(
+                TEST_SUBJECT,
+                EXPERIAN_FRAUD,
+                vcClaim,
+                FRAUD_ISSUER_INTEGRATION,
+                INSTANT_01_01_2099);
+    }
+
     static VerifiableCredential vcWebDrivingPermitDvaValid() {
         return generateVerifiableCredential(
                 "urn:uuid:e4999e16-b95e-4abe-8615-e0ef763353cc",

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/fixtures/VcFixtures.java
@@ -1073,7 +1073,7 @@ public interface VcFixtures {
                 INSTANT_01_01_2099);
     }
 
-    static VerifiableCredential vcExperianFraudAvailableAuthoritativeFailed() {
+    static VerifiableCredential vcExperianFraudAvailableAuthoritativeSourceFailed() {
         var vcClaim = vcClaimExperianFraudScore0();
         vcClaim.getEvidence()
                 .get(0)
@@ -1084,6 +1084,25 @@ public interface VcFixtures {
                                         .withFraudCheck(
                                                 CheckDetails.FraudCheckType
                                                         .AVAILABLE_AUTHORITATIVE_SOURCE)
+                                        .build()));
+
+        return generateVerifiableCredential(
+                TEST_SUBJECT,
+                EXPERIAN_FRAUD,
+                vcClaim,
+                FRAUD_ISSUER_INTEGRATION,
+                INSTANT_01_01_2099);
+    }
+
+    static VerifiableCredential vcExperianFraudMortalityFailed() {
+        var vcClaim = vcClaimExperianFraudScore0();
+        vcClaim.getEvidence()
+                .get(0)
+                .setFailedCheckDetails(
+                        List.of(
+                                CheckDetails.builder()
+                                        .withCheckMethod(CheckDetails.CheckMethodType.DATA)
+                                        .withFraudCheck(CheckDetails.FraudCheckType.MORTALITY_CHECK)
                                         .build()));
 
         return generateVerifiableCredential(

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -81,7 +81,7 @@ public class UserIdentityService {
                                 vc ->
                                         VcHelper.isSuccessfulVc(vc)
                                                 || VcHelper.hasUnavailableOrNotApplicableFraudCheck(
-                                                        List.of(vc)))
+                                                        vc))
                         .map(VerifiableCredential::getVcString)
                         .toList();
 

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/VotMatcher.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/VotMatcher.java
@@ -88,7 +88,7 @@ public class VotMatcher {
             Gpg45Scores gpg45Scores,
             List<ContraIndicator> contraIndicators) {
 
-        var isFraudScoreRequired = !VcHelper.hasUnavailableOrNotApplicableFraudCheck(gpg45Vcs);
+        var isFraudScoreRequired = !VcHelper.isFraudScoreOptionalForGpg45Evaluation(gpg45Vcs);
         var achievableProfiles = requestedVot.getSupportedGpg45Profiles(isFraudScoreRequired);
 
         Optional<Gpg45Profile> matchedGpg45Profile =

--- a/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
+++ b/libs/user-identity-service/src/test/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityServiceTest.java
@@ -75,7 +75,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawDrivingPermi
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawFailedPassport;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawPassport;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudApplicableAuthoritativeSourceFailed;
-import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudAvailableAuthoritativeFailed;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudAvailableAuthoritativeSourceFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudMissingName;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreOne;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreTwo;
@@ -1478,7 +1478,8 @@ class UserIdentityServiceTest {
         var validAddress = vcAddressOne();
         var validFraudApplicableAuthoritativeSource =
                 vcExperianFraudApplicableAuthoritativeSourceFailed();
-        var validFraudAvailableAuthoritativeSource = vcExperianFraudAvailableAuthoritativeFailed();
+        var validFraudAvailableAuthoritativeSource =
+                vcExperianFraudAvailableAuthoritativeSourceFailed();
         var vcs =
                 List.of(
                         validDrivingPermit,

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -237,9 +237,7 @@ public class VcHelper {
                 .anyMatch(
                         vc ->
                                 hasUnavailableOrNotApplicableFraudCheck(vc)
-                                        || (VcHelper.hasFailedFraudCheck(
-                                                        vc, Set.of(MORTALITY_CHECK))
-                                                && getIdentityCheckFraudScore(vc) == 0));
+                                        || hasFailedMortalityCheck(vc));
     }
 
     public static boolean hasUnavailableOrNotApplicableFraudCheck(VerifiableCredential vc) {
@@ -249,6 +247,11 @@ public class VcHelper {
 
     public static boolean hasUnavailableFraudCheck(VerifiableCredential vc) {
         return hasFailedFraudCheck(vc, Set.of(AVAILABLE_AUTHORITATIVE_SOURCE));
+    }
+
+    private static boolean hasFailedMortalityCheck(VerifiableCredential vc) {
+        return VcHelper.hasFailedFraudCheck(vc, Set.of(MORTALITY_CHECK))
+                && getIdentityCheckFraudScore(vc) == 0;
     }
 
     private static int getIdentityCheckFraudScore(VerifiableCredential vc) {

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -44,10 +44,11 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawPassport;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDrivingPermitNullNbf;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraud;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudApplicableAuthoritativeSourceFailed;
-import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudAvailableAuthoritativeFailed;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudAvailableAuthoritativeSourceFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudEvidenceFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudExpired;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudM1a;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudMortalityFailed;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudNotExpired;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreOne;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianKbvM1a;
@@ -224,7 +225,7 @@ class VcHelperTest {
         when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(1);
 
         var vcExpired = vcExperianFraudExpired();
-        var vcNotAvailable = vcExperianFraudAvailableAuthoritativeFailed();
+        var vcNotAvailable = vcExperianFraudAvailableAuthoritativeSourceFailed();
 
         assertTrue(
                 VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
@@ -264,7 +265,7 @@ class VcHelperTest {
         when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(1);
 
         var vcExpired = vcExperianFraudExpired();
-        var vcNotAvailable = vcExperianFraudAvailableAuthoritativeFailed();
+        var vcNotAvailable = vcExperianFraudAvailableAuthoritativeSourceFailed();
 
         // Act & Assert
         assertTrue(
@@ -362,15 +363,10 @@ class VcHelperTest {
             hasUnavailableOrNotApplicableFraudCheckShouldReturnTrueForApplicableAuthoritativeSourceFailedFraudCheck() {
 
         // Arrange
-        var vcs =
-                List.of(
-                        vcDcmawPassport(),
-                        vcAddressM1a(),
-                        vcExperianFraudApplicableAuthoritativeSourceFailed(),
-                        vcExperianKbvM1a());
+        var vc = vcExperianFraudApplicableAuthoritativeSourceFailed();
 
         // Act
-        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
+        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vc);
 
         // Assert
         assertTrue(result);
@@ -381,22 +377,73 @@ class VcHelperTest {
             hasUnavailableOrNotApplicableFraudCheckShouldReturnTrueForAuthoritativeAvailableSourceFailedFraudCheck() {
 
         // Arrange
-        var vcs =
-                List.of(
-                        vcDcmawPassport(),
-                        vcAddressM1a(),
-                        vcExperianFraudAvailableAuthoritativeFailed(),
-                        vcExperianKbvM1a());
+        var vc = vcExperianFraudAvailableAuthoritativeSourceFailed();
 
         // Act
-        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
+        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vc);
 
         // Assert
         assertTrue(result);
     }
 
     @Test
-    void hasUnavailableOrNotApplicableFraudCheckShouldReturnFalseForOtherFailedFraudCheck() {
+    void
+            isFraudScoreOptionalForGpg45EvaluationShouldReturnTrueForApplicableAuthoritativeSourceFailedFraudCheck() {
+
+        // Arrange
+        var vcs =
+                List.of(
+                        vcDcmawPassport(),
+                        vcAddressM1a(),
+                        vcExperianFraudApplicableAuthoritativeSourceFailed(),
+                        vcExperianKbvM1a());
+
+        // Act
+        var result = VcHelper.isFraudScoreOptionalForGpg45Evaluation(vcs);
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    void
+            isFraudScoreOptionalForGpg45EvaluationShouldReturnTrueForAuthoritativeAvailableSourceFailedFraudCheck() {
+
+        // Arrange
+        var vcs =
+                List.of(
+                        vcDcmawPassport(),
+                        vcAddressM1a(),
+                        vcExperianFraudAvailableAuthoritativeSourceFailed(),
+                        vcExperianKbvM1a());
+
+        // Act
+        var result = VcHelper.isFraudScoreOptionalForGpg45Evaluation(vcs);
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    void isFraudScoreOptionalForGpg45EvaluationShouldReturnTrueForFailedMortalityCheck() {
+
+        // Arrange
+        var vcs =
+                List.of(
+                        vcDcmawPassport(),
+                        vcAddressM1a(),
+                        vcExperianFraudMortalityFailed(),
+                        vcExperianKbvM1a());
+
+        // Act
+        var result = VcHelper.isFraudScoreOptionalForGpg45Evaluation(vcs);
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    void isFraudScoreOptionalForGpg45EvaluationShouldReturnFalseForOtherFailedFraudCheck() {
 
         // Arrange
         var vcs =
@@ -407,14 +454,14 @@ class VcHelperTest {
                         vcExperianKbvM1a());
 
         // Act
-        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
+        var result = VcHelper.isFraudScoreOptionalForGpg45Evaluation(vcs);
 
         // Assert
         assertFalse(result);
     }
 
     @Test
-    void hasUnavailableOrNotApplicableFraudCheckShouldReturnFalseForSuccessfulFraudCheck() {
+    void isFraudScoreOptionalForGpg45EvaluationShouldReturnFalseForSuccessfulFraudCheck() {
 
         // Arrange
         var vcs =
@@ -425,20 +472,20 @@ class VcHelperTest {
                         vcExperianKbvM1a());
 
         // Act
-        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
+        var result = VcHelper.isFraudScoreOptionalForGpg45Evaluation(vcs);
 
         // Assert
         assertFalse(result);
     }
 
     @Test
-    void hasUnavailableOrNotApplicableFraudCheckShouldReturnFalseForMissingFraudCheck() {
+    void isFraudScoreOptionalForGpg45EvaluationShouldReturnFalseForMissingFraudCheck() {
 
         // Arrange
         var vcs = List.of(vcDcmawPassport(), vcAddressM1a(), vcExperianKbvM1a());
 
         // Act
-        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vcs);
+        var result = VcHelper.isFraudScoreOptionalForGpg45Evaluation(vcs);
 
         // Assert
         assertFalse(result);
@@ -448,7 +495,7 @@ class VcHelperTest {
     void hasUnavailableFraudCheckShouldReturnTrueForUnavailableFraudCheck() {
 
         // Arrange
-        var vc = vcExperianFraudAvailableAuthoritativeFailed();
+        var vc = vcExperianFraudAvailableAuthoritativeSourceFailed();
 
         // Act
         var result = VcHelper.hasUnavailableFraudCheck(vc);

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -49,6 +49,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudEvid
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudExpired;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudM1a;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudMortalityFailed;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudMortalityNonZeroScore;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudNotExpired;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianFraudScoreOne;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcExperianKbvM1a;
@@ -451,6 +452,25 @@ class VcHelperTest {
                         vcDcmawPassport(),
                         vcAddressM1a(),
                         vcExperianFraudEvidenceFailed(),
+                        vcExperianKbvM1a());
+
+        // Act
+        var result = VcHelper.isFraudScoreOptionalForGpg45Evaluation(vcs);
+
+        // Assert
+        assertFalse(result);
+    }
+
+    @Test
+    void
+            isFraudScoreOptionalForGpg45EvaluationShouldReturnFalseForailedMortalityCheckWithNonZeroFraudScore() {
+
+        // Arrange
+        var vcs =
+                List.of(
+                        vcDcmawPassport(),
+                        vcAddressM1a(),
+                        vcExperianFraudMortalityNonZeroScore(),
                         vcExperianKbvM1a());
 
         // Act

--- a/local-running/README.md
+++ b/local-running/README.md
@@ -74,12 +74,29 @@ All of the running containers expose a debug port to connect to. This allows you
 what's going on. The debug port is 2000 ports above the http port the services are listening on. Look at the Docker
 compose file to see which port to use for which service.
 
-## Using local CRIs
+## Using local stubs
 
 By default, the local configuration is set up to use deployed stubs for CRIs (and CIMIT, EVCS).
 
 To use a local version, the `core.local.params.yaml` configuration needs to be updated to point to your local instance.
 This typically means updating the URLs and possibly the dev signing and encryption keys.
+
+## Using stubs deployed to a developer environment
+
+By default, the local configuration is set up to use deployed stubs for CRIs (and CIMIT, EVCS).
+
+To use a dev env version, the `core.local.params.yaml` configuration needs to be updated to point to your dev env.
+This typically means updating the URLs and possibly the dev signing and encryption keys.
+
+e.g. to use a CIMIT stub deployed to a dev env you need to update:
+- `apiBaseUrl` in `core.local.params.yaml` to something like `https://cimit-api-dev-danc.02.core.dev.stubs.account.gov.uk`
+- `core/cimitApi/apiKey` in `core.local.secrets.yaml` to the internal API key of the dev env CIMIT stub (find this in AWS console - see below)
+
+### Finding API keys
+At time of writing, the process for this is so bad it deserves documenting. To find an API key for a specific API you need to go to
+`API Gateway / API Keys` in AWS Console and then filter by the key prefix (e.g. cimit). If you know when the key was created you can use
+the date to find the right one. Otherwise you will just need to click on each one until you find the one with the right
+`Associated Stage` value.
 
 ## Future improvements
 

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -101,6 +101,7 @@ core:
         - event: /journey/alternate-doc-invalid-passport
           document: passport
     apiBaseUrl: "https://cimit-api.stubs.account.gov.uk"
+    # example dev env URL apiBaseUrl: https://cimit-api-dev-danc.02.core.dev.stubs.account.gov.uk
   evcs:
     applicationUrl: "https://evcs.stubs.account.gov.uk"
   sis:


### PR DESCRIPTION
DO NOT MERGE until CIMIT stub updates are released: https://github.com/govuk-one-login/ipv-stubs/pull/1986
API tests should fail until the stub is updated anyway

## Proposed changes
### What changed

Added logic to allow incorrect mortality checks to be mitigateed

### Why did it change

Users with incorrect mortality checks are unable to prove their identity

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8913](https://govukverify.atlassian.net/browse/PYIC-8913)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated


[PYIC-8913]: https://govukverify.atlassian.net/browse/PYIC-8913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ