### PR TITLE
PYIC-8903: Replace string interpolation with direct referenceto the alias of ValidateAppConfigFunction

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2906,14 +2906,10 @@ Resources:
       Principal: "appconfig.amazonaws.com"
       SourceArn: !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/${AppConfigApplication}/configurationprofile/${AppConfigConfigurationProfile}"
 
-#  App Config Pipeline
-#  This may fail on first deployment due to not existing alias.
-#  Simply comment it out to deploy and then uncomment and update the stack to give app config pipeline permissions to invoke validation lambda
-#  When this comment is no longer needed please also remove the debugging instructions in ipv-core-common-infra/utils/dev-deploy/docs/cli-userguide.md
   AppConfigPipelineValidateFunctionInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Sub "${ValidateAppConfigFunction.Arn}:live"
+      FunctionName: !Ref ValidateAppConfigFunction.Alias
       Action: lambda:InvokeFunction
       Principal: appconfig.amazonaws.com
       SourceAccount: !Ref AWS::AccountId


### PR DESCRIPTION
## Proposed changes
### What changed

- Replace string interpolation with direct reference to the alias of ValidateAppConfigFunction

Tested deployment in dev and that config deployment still works.

### Why did it change

- By referencing the alias directly, CloudFormation will properly wait for the alias to be created before creating the permission.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8903](https://govukverify.atlassian.net/browse/PYIC-8903)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out


[PYIC-8903]: https://govukverify.atlassian.net/browse/PYIC-8903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ