### PR TITLE
PYIC-8928: clean up strategicAppEnabled feature flag

### DIFF
--- a/api-tests/features/cimit/p1-alternate-doc.feature
+++ b/api-tests/features/cimit/p1-alternate-doc.feature
@@ -140,54 +140,54 @@ Feature: P1 CIMIT - Alternate doc - Experian KBV
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity
 
-  Rule: Existing identity
-    Scenario: Mitigating when a user already has an identity should be subject to a COI check
-      Given the subject already has the following credentials
-        | CRI         | scenario               |
-        | ukPassport  | kenneth-passport-valid |
-        | address     | kenneth-current        |
-        | fraud       | kenneth-score-2        |
-        | experianKbv | kenneth-score-2        |
-      # TODO: update this to use the strategic app once PYIC-8769/8941 have been resolved
-      And I activate the 'disableStrategicApp' feature set
-
-      # First return journey that collects a CI
-      And I activate the 'drivingLicenceAuthCheck' feature set
-      When I start a new 'low-confidence' journey
-      Then I get a 'page-ipv-reuse' page response
-      When I submit an 'update-details' event
-      Then I get an 'update-details' page response
-      When I submit a 'given-names-only' event
-      Then I get a 'page-update-name' page response
-      When I submit an 'update-name' event
-      Then I get a 'dcmaw' CRI response
-      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
-      Then I get a 'drivingLicence' CRI response
-      When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
-        | Attribute | Values          |
-        | context   | "check_details" |
-      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-
-      # Second return journey to mitigate CI
-      Given I start a new 'low-confidence' journey
-      Then I get a 'pyi-driving-licence-no-match' page response
-      When I submit a 'next' event
-      Then I get a 'pyi-continue-with-passport' page response
-      When I submit a 'next' event
-      Then I get a 'ukPassport' CRI response
-      When I submit 'lora-passport-valid' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
-      Then I get an 'address' CRI response
-      When I submit 'lora-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'lora-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'end' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'experianKbv' CRI response
-      When I submit 'lora-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-      Then I get a 'pyi-no-match' page response
+  # TODO: uncomment the test below and update it to use the strategic app once PYIC-8769/8941 have been resolved
+#  Rule: Existing identity
+#    Scenario: Mitigating when a user already has an identity should be subject to a COI check
+#      Given the subject already has the following credentials
+#        | CRI         | scenario               |
+#        | ukPassport  | kenneth-passport-valid |
+#        | address     | kenneth-current        |
+#        | fraud       | kenneth-score-2        |
+#        | experianKbv | kenneth-score-2        |
+#      And I activate the 'disableStrategicApp' feature set
+#
+#      # First return journey that collects a CI
+#      And I activate the 'drivingLicenceAuthCheck' feature set
+#      When I start a new 'low-confidence' journey
+#      Then I get a 'page-ipv-reuse' page response
+#      When I submit an 'update-details' event
+#      Then I get an 'update-details' page response
+#      When I submit a 'given-names-only' event
+#      Then I get a 'page-update-name' page response
+#      When I submit an 'update-name' event
+#      Then I get a 'dcmaw' CRI response
+#      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+#      Then I get a 'drivingLicence' CRI response
+#      When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
+#        | Attribute | Values          |
+#        | context   | "check_details" |
+#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#
+#      # Second return journey to mitigate CI
+#      Given I start a new 'low-confidence' journey
+#      Then I get a 'pyi-driving-licence-no-match' page response
+#      When I submit a 'next' event
+#      Then I get a 'pyi-continue-with-passport' page response
+#      When I submit a 'next' event
+#      Then I get a 'ukPassport' CRI response
+#      When I submit 'lora-passport-valid' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+#      Then I get an 'address' CRI response
+#      When I submit 'lora-current' details to the CRI stub
+#      Then I get a 'fraud' CRI response
+#      When I submit 'lora-score-2' details with attributes to the CRI stub
+#        | Attribute          | Values                   |
+#        | evidence_requested | {"identityFraudScore":2} |
+#      Then I get a 'personal-independence-payment' page response
+#      When I submit a 'end' event
+#      Then I get a 'page-pre-experian-kbv-transition' page response
+#      When I submit a 'next' event
+#      Then I get a 'experianKbv' CRI response
+#      When I submit 'lora-score-2' details with attributes to the CRI stub
+#        | Attribute          | Values                                          |
+#        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
+#      Then I get a 'pyi-no-match' page response

--- a/api-tests/features/cimit/p2-alternate-doc.feature
+++ b/api-tests/features/cimit/p2-alternate-doc.feature
@@ -142,56 +142,56 @@ Feature: P2 CIMIT - Alternate doc - Experian KBV
       When I use the OAuth response to get my identity
       Then I get a 'P0' identity
 
-  Rule: Existing identity
-    Scenario: Mitigating when a user already has an identity should be subject to a COI check
-      Given the subject already has the following credentials
-        | CRI         | scenario               |
-        | ukPassport  | kenneth-passport-valid |
-        | address     | kenneth-current        |
-        | fraud       | kenneth-score-2        |
-        | experianKbv | kenneth-score-2        |
-
-      # First return journey that collects a CI
-      # TODO: update this to use the strategic app once PYIC-8769/8941 have been resolved
-      And I activate the 'drivingLicenceAuthCheck,disableStrategicApp' feature set
-      When I start a new 'medium-confidence' journey
-      Then I get a 'page-ipv-reuse' page response
-      When I submit an 'update-details' event
-      Then I get an 'update-details' page response
-      When I submit a 'given-names-only' event
-      Then I get a 'page-update-name' page response
-      When I submit an 'update-name' event
-      Then I get a 'dcmaw' CRI response
-      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
-      Then I get a 'drivingLicence' CRI response
-      When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
-        | Attribute | Values          |
-        | context   | "check_details" |
-      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-
-      # Seconds return journey to mitigate CI
-      Given I start a new 'medium-confidence' journey
-      Then I get a 'pyi-driving-licence-no-match' page response
-      When I submit a 'next' event
-      Then I get a 'pyi-continue-with-passport' page response
-      When I submit a 'next' event
-      Then I get a 'ukPassport' CRI response
-      When I submit 'lora-passport-valid' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
-      Then I get an 'address' CRI response
-      When I submit 'lora-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'lora-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'end' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'experianKbv' CRI response
-      When I submit 'lora-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-no-match' page response
+  # TODO: uncomment and update this to use the strategic app once PYIC-8769/8941 have been resolved
+#  Rule: Existing identity
+#    Scenario: Mitigating when a user already has an identity should be subject to a COI check
+#      Given the subject already has the following credentials
+#        | CRI         | scenario               |
+#        | ukPassport  | kenneth-passport-valid |
+#        | address     | kenneth-current        |
+#        | fraud       | kenneth-score-2        |
+#        | experianKbv | kenneth-score-2        |
+#
+#      # First return journey that collects a CI
+#      And I activate the 'drivingLicenceAuthCheck,disableStrategicApp' feature set
+#      When I start a new 'medium-confidence' journey
+#      Then I get a 'page-ipv-reuse' page response
+#      When I submit an 'update-details' event
+#      Then I get an 'update-details' page response
+#      When I submit a 'given-names-only' event
+#      Then I get a 'page-update-name' page response
+#      When I submit an 'update-name' event
+#      Then I get a 'dcmaw' CRI response
+#      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+#      Then I get a 'drivingLicence' CRI response
+#      When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
+#        | Attribute | Values          |
+#        | context   | "check_details" |
+#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#
+#      # Seconds return journey to mitigate CI
+#      Given I start a new 'medium-confidence' journey
+#      Then I get a 'pyi-driving-licence-no-match' page response
+#      When I submit a 'next' event
+#      Then I get a 'pyi-continue-with-passport' page response
+#      When I submit a 'next' event
+#      Then I get a 'ukPassport' CRI response
+#      When I submit 'lora-passport-valid' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+#      Then I get an 'address' CRI response
+#      When I submit 'lora-current' details to the CRI stub
+#      Then I get a 'fraud' CRI response
+#      When I submit 'lora-score-2' details with attributes to the CRI stub
+#        | Attribute          | Values                   |
+#        | evidence_requested | {"identityFraudScore":2} |
+#      Then I get a 'personal-independence-payment' page response
+#      When I submit a 'end' event
+#      Then I get a 'page-pre-experian-kbv-transition' page response
+#      When I submit a 'next' event
+#      Then I get a 'experianKbv' CRI response
+#      When I submit 'lora-score-2' details with attributes to the CRI stub
+#        | Attribute          | Values                                          |
+#        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+#      Then I get a 'pyi-no-match' page response
 
   Rule: High-medium confidence journey
     Scenario Outline: High-medium confidence journey - alternate-doc mitigation

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -1,10 +1,7 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Disabled CRI journeys
-  Background: Disable the strategic app
-    # TODO: remove this once strategicApp feature flag is removed in PYIC-8928
-    Given I activate the 'disableStrategicApp' feature set
 
-  Rule: DCMAW is disabled
+  Rule: Async DCMAW is disabled
 
     Scenario: A P1 journey takes the user down the no photo ID NINO route instead
       Given I activate the 'dcmawAsyncDisabled' feature set
@@ -120,8 +117,14 @@ Feature: Disabled CRI journeys
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'dcmaw' CRI response
-      When I submit an 'access-denied' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
       Then I get a 'page-multiple-doc-check' page response
       When I submit an 'end' event
       Then I get a 'pyi-escape' page response
@@ -133,8 +136,14 @@ Feature: Disabled CRI journeys
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'dcmaw' CRI response
-      When I submit an 'access-denied' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
       Then I get a 'page-multiple-doc-check' page response
       When I submit a '<cri>' event
       Then I get a '<cri>' CRI response
@@ -172,8 +181,14 @@ Feature: Disabled CRI journeys
       When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'dcmaw' CRI response
-      When I submit an 'access-denied' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
       Then I get a 'pyi-another-way' page response
 
   Rule: TICF is disabled
@@ -185,8 +200,20 @@ Feature: Disabled CRI journeys
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'dcmaw' CRI response
-      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone'
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
       Then I get a 'page-dcmaw-success' page response
       When I submit a 'next' event
       Then I get an 'address' CRI response
@@ -221,8 +248,14 @@ Feature: Disabled CRI journeys
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'dcmaw' CRI response
-      When I submit an 'access-denied' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
       Then I get a 'page-multiple-doc-check' page response
       When I submit an 'end' event
       Then I get a 'pyi-post-office' page response
@@ -236,8 +269,14 @@ Feature: Disabled CRI journeys
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
-      Then I get a 'dcmaw' CRI response
-      When I submit an 'access-denied' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
       Then I get a 'page-multiple-doc-check' page response
       When I submit a 'ukPassport' event
       Then I get a 'ukPassport' CRI response

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -104,54 +104,55 @@ Feature: Repeat fraud check failures
       When I submit a 'delete' event
       Then I get a 'delete-handover' page response
 
-    Scenario: Breaching CI received from DCMAW
-      # TODO: update this to use the strategic app once PYIC-8769/8941/8940 have been resolved
-      When I activate the 'disableStrategicApp' feature set
-      And I submit an 'update-name' event
-      Then I get a 'dcmaw' CRI response
-      When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-      When I submit a 'returnToRp' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-      When I start a new 'medium-confidence' journey
-      Then I get a 'pyi-no-match' page response
+    # TODO: uncomment and update this to use the strategic app once PYIC-8769/8941/8940 have been resolved
+#    Scenario: Breaching CI received from DCMAW
+#      When I activate the 'disableStrategicApp' feature set
+#      And I submit an 'update-name' event
+#      Then I get a 'dcmaw' CRI response
+#      When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#      When I submit a 'returnToRp' event
+#      Then I get an OAuth response
+#      When I use the OAuth response to get my identity
+#      Then I get a 'P0' identity
+#      When I start a new 'medium-confidence' journey
+#      Then I get a 'pyi-no-match' page response
 
-    Scenario: User is able to delete account from sorry-could-not-confirm-details screen
-      # TODO: update this to use the strategic app once PYIC-8940 has been resolved
-      When I activate the 'disableStrategicApp' feature set
-      And I submit an 'update-name' event
-      Then I get a 'dcmaw' CRI response
-      When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-      When I submit a 'delete' event
-      Then I get a 'delete-handover' page response
+    # TODO: uncommment and update this to use the strategic app once PYIC-8940 has been resolved
+#    Scenario: User is able to delete account from sorry-could-not-confirm-details screen
+#      # TODO: update this to use the strategic app once PYIC-8940 has been resolved
+#      When I activate the 'disableStrategicApp' feature set
+#      And I submit an 'update-name' event
+#      Then I get a 'dcmaw' CRI response
+#      When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#      When I submit a 'delete' event
+#      Then I get a 'delete-handover' page response
 
-    Scenario: Zero score in fraud CRI
-      # TODO: update this to use the strategic app once PYIC-8769/8941 have been resolved
-      When I activate the 'disableStrategicApp' feature set
-      And I submit an 'update-name' event
-      Then I get a 'dcmaw' CRI response
-      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-      Then I get a 'drivingLicence' CRI response
-      When I submit 'kenneth-changed-given-name-driving-permit-valid' details with attributes to the CRI stub
-        | Attribute | Values          |
-        | context   | "check_details" |
-      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
-      When I submit a 'next' event
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-      When I submit a 'returnToRp' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-
-      When I start a new 'medium-confidence' journey
-      Then I get a 'confirm-your-details' page response
+    # TODO: uncomment and update this to use the strategic app once PYIC-8769/8941 have been resolved
+#    Scenario: Zero score in fraud CRI
+#      When I activate the 'disableStrategicApp' feature set
+#      And I submit an 'update-name' event
+#      Then I get a 'dcmaw' CRI response
+#      When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+#      Then I get a 'drivingLicence' CRI response
+#      When I submit 'kenneth-changed-given-name-driving-permit-valid' details with attributes to the CRI stub
+#        | Attribute | Values          |
+#        | context   | "check_details" |
+#      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
+#      When I submit a 'next' event
+#      Then I get a 'fraud' CRI response
+#      When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
+#        | Attribute          | Values                   |
+#        | evidence_requested | {"identityFraudScore":2} |
+#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#      When I submit a 'returnToRp' event
+#      Then I get an OAuth response
+#      When I use the OAuth response to get my identity
+#      Then I get a 'P0' identity
+#
+#      When I start a new 'medium-confidence' journey
+#      Then I get a 'confirm-your-details' page response
 
     Scenario: Breaching CI received from fraud CRI
       When I submit an 'update-name' event
@@ -184,26 +185,26 @@ Feature: Repeat fraud check failures
       When I start a new 'medium-confidence' journey
       Then I get a 'pyi-no-match' page response
 
-    Scenario: Failed COI check
-      # TODO: update this to use the strategic app once PYIC-8769/8941 have been resolved
-      When I activate the 'disableStrategicApp' feature set
-      And I submit a 'update-name' event
-      Then I get a 'dcmaw' CRI response
-      When I submit 'alice-passport-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
-      When I submit a 'next' event
-      Then I get a 'fraud' CRI response
-      When I submit 'alice-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":1} |
-      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-      When I submit a 'returnToRp' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-
-      When I start a new 'medium-confidence' journey
-      Then I get a 'confirm-your-details' page response
+    # TODO: uncomment and update this to use the strategic app once PYIC-8769/8941 have been resolved
+#    Scenario: Failed COI check
+#      When I activate the 'disableStrategicApp' feature set
+#      And I submit a 'update-name' event
+#      Then I get a 'dcmaw' CRI response
+#      When I submit 'alice-passport-valid' details to the CRI stub
+#      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
+#      When I submit a 'next' event
+#      Then I get a 'fraud' CRI response
+#      When I submit 'alice-score-2' details with attributes to the CRI stub
+#        | Attribute          | Values                   |
+#        | evidence_requested | {"identityFraudScore":1} |
+#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#      When I submit a 'returnToRp' event
+#      Then I get an OAuth response
+#      When I use the OAuth response to get my identity
+#      Then I get a 'P0' identity
+#
+#      When I start a new 'medium-confidence' journey
+#      Then I get a 'confirm-your-details' page response
 
     Scenario: Breaching CI received from TICF CRI
       Given TICF CRI will respond with default parameters and
@@ -235,25 +236,25 @@ Feature: Repeat fraud check failures
         | cis  | BREACHING      |
         | type | RiskAssessment |
 
-    Scenario: Fraud access denied OAuth error
-      # TODO: update this to use the strategic app once PYIC-8769/8941 have been resolved
-      When I activate the 'disableStrategicApp' feature set
-      And I submit a 'update-name' event
-      Then I get a 'dcmaw' CRI response
-      When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
-      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
-      When I submit a 'next' event
-      Then I get a 'fraud' CRI response
-      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":1} |
-      Then I get an 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-      When I submit a 'returnToRp' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-      When I start a new 'medium-confidence' journey
-      Then I get a 'confirm-your-details' page response
+    # TODO: uncomment and update this to use the strategic app once PYIC-8769/8941 have been resolved
+#    Scenario: Fraud access denied OAuth error
+#      When I activate the 'disableStrategicApp' feature set
+#      And I submit a 'update-name' event
+#      Then I get a 'dcmaw' CRI response
+#      When I submit 'kenneth-changed-given-name-passport-valid' details to the CRI stub
+#      Then I get a 'page-dcmaw-success' page response with context 'coiNoAddress'
+#      When I submit a 'next' event
+#      Then I get a 'fraud' CRI response
+#      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+#        | Attribute          | Values                   |
+#        | evidence_requested | {"identityFraudScore":1} |
+#      Then I get an 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#      When I submit a 'returnToRp' event
+#      Then I get an OAuth response
+#      When I use the OAuth response to get my identity
+#      Then I get a 'P0' identity
+#      When I start a new 'medium-confidence' journey
+#      Then I get a 'confirm-your-details' page response
 
   Rule: Update address only
     Background:

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -88,47 +88,47 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'page-ipv-reuse' page response
 
-        Scenario: Breaching CI received from DCMAW - doesn't receive old identity
-            # TODO: update this to use the strategic app once PYIC-8769/8941/8940 have been resolved
-            When I activate the 'disableStrategicApp' feature set
-            And I submit an 'update-name' event
-            Then I get a 'dcmaw' CRI response
-            When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-            When I submit a 'returnToRp' event
-            Then I get an OAuth response
-            When I use the OAuth response to get my identity
-            Then I get a 'P0' identity
-            When I start a new 'medium-confidence' journey
-            Then I get a 'pyi-no-match' page response
+        # TODO: uncomment and update this to use the strategic app once PYIC-8769/8941/8940 have been resolved
+#        Scenario: Breaching CI received from DCMAW - doesn't receive old identity
+#            When I activate the 'disableStrategicApp' feature set
+#            And I submit an 'update-name' event
+#            Then I get a 'dcmaw' CRI response
+#            When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+#            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#            When I submit a 'returnToRp' event
+#            Then I get an OAuth response
+#            When I use the OAuth response to get my identity
+#            Then I get a 'P0' identity
+#            When I start a new 'medium-confidence' journey
+#            Then I get a 'pyi-no-match' page response
 
-        Scenario: Breaching CI from DL auth source check - doesn't receive old identity
-            # TODO: update this to use the strategic app once PYIC-8769/8941 have been resolved
-            When I activate the 'disableStrategicApp' feature set
-            When I submit a 'update-name' event
-            Then I get a 'dcmaw' CRI response
-            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
-            Then I get a 'drivingLicence' CRI response
-            When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
-                | Attribute | Values          |
-                | context   | "check_details" |
-            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-            When I submit a 'returnToRp' event
-            Then I get an OAuth response
-            When I use the OAuth response to get my identity
-            Then I get a 'P0' identity
-            When I start a new 'medium-confidence' journey
-            Then I get a 'pyi-driving-licence-no-match' page response
+        # TODO: uncomment and update this to use the strategic app once PYIC-8769/8941 have been resolved
+#        Scenario: Breaching CI from DL auth source check - doesn't receive old identity
+#            When I activate the 'disableStrategicApp' feature set
+#            When I submit a 'update-name' event
+#            Then I get a 'dcmaw' CRI response
+#            When I submit 'kenneth-changed-given-name-driving-permit-valid' details to the CRI stub
+#            Then I get a 'drivingLicence' CRI response
+#            When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
+#                | Attribute | Values          |
+#                | context   | "check_details" |
+#            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#            When I submit a 'returnToRp' event
+#            Then I get an OAuth response
+#            When I use the OAuth response to get my identity
+#            Then I get a 'P0' identity
+#            When I start a new 'medium-confidence' journey
+#            Then I get a 'pyi-driving-licence-no-match' page response
 
-        Scenario: User is able to delete account from sorry-could-not-confirm-details page
-            # TODO: update this to use the strategic app once PYIC-8940 has been resolved
-            When I activate the 'disableStrategicApp' feature set
-            And I submit an 'update-name' event
-            Then I get a 'dcmaw' CRI response
-            When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-            When I submit a 'delete' event
-            Then I get a 'delete-handover' page response
+        # TODO: uncomment and update this to use the strategic app once PYIC-8940 has been resolved
+#        Scenario: User is able to delete account from sorry-could-not-confirm-details page
+#            When I activate the 'disableStrategicApp' feature set
+#            And I submit an 'update-name' event
+#            Then I get a 'dcmaw' CRI response
+#            When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
+#            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#            When I submit a 'delete' event
+#            Then I get a 'delete-handover' page response
 
         Scenario: Zero score in fraud CRI - receives old identity (P2)
             When I submit an 'update-name' event

--- a/api-tests/features/stored-identity/failed-update-journeys.feature
+++ b/api-tests/features/stored-identity/failed-update-journeys.feature
@@ -39,22 +39,22 @@ Feature: Failed update details
       Then I get a 'P1' identity
       And I have a GPG45 stored identity record type with a 'P1' vot that is 'valid'
 
-    Scenario: Reuse journey - failed name change - fail with CI (invalid identity)
-      # TODO: Update to use strategic app once PYIC-8940 has been resolved
-      When I activate the 'disableStrategicApp' feature set
-      And I submit a 'given-names-only' event
-      Then I get a 'page-update-name' page response
-      When I submit a 'update-name' event
-      Then I get a 'dcmaw' CRI response
-      # SI record invalidated as part of reset-session-identity lambda
-      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
-      When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-      When I submit a 'returnToRp' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
+    # TODO: uncomment and update to use strategic app once PYIC-8940 has been resolved
+#    Scenario: Reuse journey - failed name change - fail with CI (invalid identity)
+#      When I activate the 'disableStrategicApp' feature set
+#      And I submit a 'given-names-only' event
+#      Then I get a 'page-update-name' page response
+#      When I submit a 'update-name' event
+#      Then I get a 'dcmaw' CRI response
+#      # SI record invalidated as part of reset-session-identity lambda
+#      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
+#      When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
+#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#      When I submit a 'returnToRp' event
+#      Then I get an OAuth response
+#      When I use the OAuth response to get my identity
+#      Then I get a 'P0' identity
+#      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
 
     Scenario: Reuse journey - failed name change - fail with no ci (valid identity)
       When I submit a 'given-names-only' event
@@ -129,20 +129,20 @@ Feature: Failed update details
       Then I get a 'P0' identity
       And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
 
-    Scenario: RFC - failed update name - fail with CI (invalid identity)
-      # TODO: Update to use strategic app once PYIC-8940 has been resolved
-      When I activate the 'disableStrategicApp' feature set
-      And I submit a 'given-names-only' event
-      Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
-      When I submit a 'update-name' event
-      Then I get a 'dcmaw' CRI response
-      When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
-      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-      When I submit a 'returnToRp' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I get a 'P0' identity
-      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
+    # TODO: uncomment and update to use strategic app once PYIC-8940 has been resolved
+#    Scenario: RFC - failed update name - fail with CI (invalid identity)
+#      When I activate the 'disableStrategicApp' feature set
+#      And I submit a 'given-names-only' event
+#      Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
+#      When I submit a 'update-name' event
+#      Then I get a 'dcmaw' CRI response
+#      When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
+#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+#      When I submit a 'returnToRp' event
+#      Then I get an OAuth response
+#      When I use the OAuth response to get my identity
+#      Then I get a 'P0' identity
+#      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
 
     Scenario: RFC - failed update name - fail with no CI (invalid identity)
       When I submit a 'given-names-only' event

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -106,8 +106,8 @@ states:
         targetState: STRATEGIC_APP_TRIAGE
         targetEntryEvent: appTriage
       error:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
   RESET_SESSION_IDENTITY:
     response:
@@ -234,57 +234,6 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
-
-  APP_DOC_CHECK:
-    nestedJourney: APP_DOC_CHECK
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_SUCCESS_PAGE
-      incomplete:
-        targetState: MULTIPLE_DOC_CHECK_PAGE
-        checkMitigation:
-          enhanced-verification:
-            targetState: MITIGATION_01_PYI_POST_OFFICE
-            checkIfDisabled:
-              f2f:
-                targetJourney: INELIGIBLE
-                targetState: INELIGIBLE
-      incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK
-      alternate-doc-invalid-dl:
-        targetState: WEB_DL_OR_PASSPORT
-        targetEntryEvent: alternate-doc-invalid-dl-another-way
-        checkMitigation:
-          enhanced-verification:
-            targetJourney: FAILED
-            targetState: FAILED
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: invalid-dl
-
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK:
-    response:
-      type: page
-      pageId: prove-identity-another-way
-    events:
-      anotherTypePhotoId:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-      postOffice:
-        targetState: F2F_START_PAGE
-        checkIfDisabled:
-          f2f:
-            targetState: PYI_ESCAPE
-            checkMitigation:
-              enhanced-verification:
-                targetJourney: INELIGIBLE
-                targetState: INELIGIBLE
-        checkMitigation:
-          enhanced-verification:
-            targetState: PYI_POST_OFFICE
-      returnToRp:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -639,40 +588,6 @@ states:
       anotherTypePhotoId:
         targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         targetEntryEvent: appTriage
-      postOffice:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      returnToRp:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
-
-  APP_DOC_CHECK_PYI_ESCAPE:
-    nestedJourney: APP_DOC_CHECK
-    exitEvents:
-      next:
-        targetState: PROCESS_NEW_IDENTITY
-      incomplete:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_PYI_ESCAPE
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_PYI_ESCAPE:
-    response:
-      type: page
-      pageId: prove-identity-another-way
-    events:
-      anotherTypePhotoId:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
       postOffice:
         targetState: PYI_POST_OFFICE
         checkIfDisabled:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -27,12 +27,8 @@ states:
   KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
     events:
       next:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-            targetEntryEvent: appTriage
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetEntryEvent: appTriage
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -107,12 +103,8 @@ states:
         resetType: ALL
     events:
       next:
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
       error:
         targetState: APP_DOC_CHECK
         targetEntryEvent: next
@@ -136,11 +128,7 @@ states:
       pageId: page-ipv-identity-document-start
     events:
       appTriage:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
+        targetState: STRATEGIC_APP_TRIAGE
         checkIfDisabled:
           dcmawAsync:
             targetState: NINO_START_PAGE
@@ -336,12 +324,8 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
       try-again-post-office:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp-cri-error:
@@ -365,11 +349,7 @@ states:
       context: dropout
     events:
       appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -552,11 +532,7 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -571,12 +547,8 @@ states:
       pageId: no-photo-id-abandon-find-another-way
     events:
       mobileApp:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -606,11 +578,7 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -720,11 +688,7 @@ states:
       pageId: photo-id-security-questions-find-another-way
     events:
       appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -106,8 +106,8 @@ states:
         targetState: STRATEGIC_APP_TRIAGE
         targetEntryEvent: appTriage
       error:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
 
   RESET_SESSION_IDENTITY:
     response:
@@ -138,54 +138,6 @@ states:
           f2f:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
-
-  APP_DOC_CHECK:
-    nestedJourney: APP_DOC_CHECK
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_SUCCESS_PAGE
-      incomplete:
-        targetState: MULTIPLE_DOC_CHECK_PAGE
-        checkMitigation:
-          enhanced-verification:
-            targetState: MITIGATION_01_PYI_POST_OFFICE
-            checkIfDisabled:
-              f2f:
-                targetJourney: INELIGIBLE
-                targetState: INELIGIBLE
-      incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK
-      alternate-doc-invalid-dl:
-        targetState: WEB_DL_OR_PASSPORT
-        targetEntryEvent: alternate-doc-invalid-dl-another-way
-        auditEvents:
-          - IPV_MITIGATION_START
-        auditContext:
-          mitigationType: invalid-dl
-
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK:
-    response:
-      type: page
-      pageId: prove-identity-another-way
-    events:
-      anotherTypePhotoId:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-      postOffice:
-        targetState: F2F_START_PAGE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-        checkMitigation:
-          enhanced-verification:
-            targetState: PYI_POST_OFFICE
-            checkIfDisabled:
-              f2f:
-                targetJourney: INELIGIBLE
-                targetState: INELIGIBLE
-      returnToRp:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   STRATEGIC_APP_TRIAGE:
     nestedJourney: STRATEGIC_APP_TRIAGE
@@ -699,40 +651,6 @@ states:
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
-  APP_DOC_CHECK_PYI_ESCAPE:
-    nestedJourney: APP_DOC_CHECK
-    exitEvents:
-      next:
-        targetState: PROCESS_NEW_IDENTITY
-      incomplete:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_PYI_ESCAPE
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED
-
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_PYI_ESCAPE:
-    response:
-      type: page
-      pageId: prove-identity-another-way
-    events:
-      anotherTypePhotoId:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-      postOffice:
-        targetState: PYI_POST_OFFICE
-        checkIfDisabled:
-          f2f:
-            targetJourney: INELIGIBLE
-            targetState: INELIGIBLE
-      returnToRp:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
-
   MITIGATION_KBV_FAIL_PHOTO_ID:
     response:
       type: page
@@ -767,17 +685,6 @@ states:
   # Common Mitigation states - invalid-dl/invalid-passport
 
   # International Address journey
-  APP_DOC_CHECK_INTERNATIONAL_ADDRESS:
-    nestedJourney: APP_DOC_CHECK
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_INTERNATIONAL_SUCCESS_PAGE
-      incomplete:
-        targetState: NON_UK_NO_APP_PAGE
-      incomplete-invalid-dl:
-        targetState: NON_UK_NO_APP_PAGE
-      alternate-doc-invalid-dl:
-        targetState: NON_UK_NO_APP_PAGE
 
   LIVE_IN_UK_PAGE:
     response:
@@ -815,30 +722,6 @@ states:
       useApp:
         targetState: STRATEGIC_APP_TRIAGE_INTERNATIONAL_ADDRESS
         targetEntryEvent: appTriage
-
-  NON_UK_APP_INTRO_PAGE:
-    response:
-      type: page
-      pageId: non-uk-app-intro
-    events:
-      useApp:
-        targetState: APP_DOC_CHECK_INTERNATIONAL_ADDRESS
-        targetEntryEvent: next
-        auditEvents:
-          - IPV_INTERNATIONAL_ADDRESS_START
-      returnToRp:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
-
-  NON_UK_NO_APP_PAGE:
-    response:
-      type: page
-      pageId: non-uk-no-app
-    events:
-      next:
-        targetState: APP_DOC_CHECK_INTERNATIONAL_ADDRESS
-        targetEntryEvent: next
-      end:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   POST_APP_DOC_CHECK_INTERNATIONAL_SUCCESS_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -27,12 +27,8 @@ states:
   KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
     events:
       next:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-            targetEntryEvent: appTriage
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetEntryEvent: appTriage
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -107,12 +103,8 @@ states:
         resetType: ALL
     events:
       next:
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
       error:
         targetState: APP_DOC_CHECK
         targetEntryEvent: next
@@ -136,11 +128,7 @@ states:
       pageId: page-ipv-identity-document-start
     events:
       appTriage:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
+        targetState: STRATEGIC_APP_TRIAGE
         checkIfDisabled:
           dcmawAsync:
             targetState: MULTIPLE_DOC_CHECK_PAGE
@@ -328,12 +316,8 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
       try-again-app:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
       try-again-post-office:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp-cri-error:
@@ -372,11 +356,7 @@ states:
       context: dropout
     events:
       appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -573,11 +553,7 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -605,12 +581,8 @@ states:
       pageId: no-photo-id-abandon-find-another-way
     events:
       mobileApp:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
-            targetEntryEvent: appTriage
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -640,11 +612,7 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
       appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -660,11 +628,7 @@ states:
       pageId: page-ipv-identity-document-start
     events:
       appTriage:
-        targetState: APP_DOC_CHECK
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE
+        targetState: STRATEGIC_APP_TRIAGE
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -775,11 +739,7 @@ states:
       pageId: photo-id-security-questions-find-another-way
     events:
       appTriage:
-        targetState: APP_DOC_CHECK_PYI_ESCAPE
-        targetEntryEvent: next
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         checkIfDisabled:
           dcmawAsync:
             targetJourney: TECHNICAL_ERROR
@@ -828,12 +788,8 @@ states:
         targetState: IDENTITY_START_PAGE
         journeyContextToUnset: internationalAddress
       international:
-        targetState: NON_UK_APP_INTRO_PAGE
+        targetState: NON_UK_PASSPORT
         journeyContextToSet: internationalAddress
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: NON_UK_PASSPORT
-            journeyContextToSet: internationalAddress
 
   NON_UK_PASSPORT:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -83,12 +83,9 @@ states:
         resetType: NAME_ONLY_CHANGE
     events:
       next:
-        targetState: APP_DOC_CHECK_NAMES_ONLY
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_NAMES_ONLY
-            targetEntryEvent: appTriage
-            journeyContextToSet: appOnly
+        targetState: STRATEGIC_APP_TRIAGE_NAMES_ONLY
+        targetEntryEvent: appTriage
+        journeyContextToSet: appOnly
 
   APP_DOC_CHECK_NAMES_ONLY:
     nestedJourney: APP_DOC_CHECK
@@ -230,12 +227,9 @@ states:
         resetType: ALL
     events:
       next:
-        targetState: APP_DOC_CHECK_NAMES_WITH_ADDRESS
-        checkFeatureFlag:
-          strategicAppEnabled:
-            targetState: STRATEGIC_APP_TRIAGE_NAMES_WITH_ADDRESS
-            targetEntryEvent: appTriage
-            journeyContextToSet: appOnly
+        targetState: STRATEGIC_APP_TRIAGE_NAMES_WITH_ADDRESS
+        targetEntryEvent: appTriage
+        journeyContextToSet: appOnly
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -87,32 +87,6 @@ states:
         targetEntryEvent: appTriage
         journeyContextToSet: appOnly
 
-  APP_DOC_CHECK_NAMES_ONLY:
-    nestedJourney: APP_DOC_CHECK
-    exitEvents:
-      next:
-        targetState: POST_APP_DOC_CHECK_NAMES_ONLY
-      incomplete:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS
-      incomplete-invalid-dl:
-        targetState: PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_ONLY
-      alternate-doc-invalid-dl:
-        targetJourney: FAILED
-        targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
-
-  PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_ONLY:
-    response:
-      type: page
-      pageId: prove-identity-another-way
-      context: noF2f
-    events:
-      anotherTypePhotoId:
-        targetState: APP_DOC_CHECK_NAMES_ONLY
-        targetEntryEvent: next
-      returnToRp:
-        targetState: RETURN_TO_RP
-
   STRATEGIC_APP_TRIAGE_NAMES_ONLY:
     nestedJourney: STRATEGIC_APP_TRIAGE
     exitEvents:

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -292,7 +292,7 @@ class AppConfigServiceTest {
 
     @Test
     void enabledTrueIfFeatureFlagEnabled() {
-        assertTrue(configService.enabled("strategicAppEnabled"));
+        assertTrue(configService.enabled("repeatFraudCheckEnabled"));
     }
 
     @Test

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -350,7 +350,6 @@ core:
   featureFlags:
     resetIdentity: false
     pendingF2FResetEnabled: false
-    strategicAppEnabled: true
     repeatFraudCheckEnabled: true
     parseVcClasses: true
     sqsAsync: true
@@ -379,12 +378,6 @@ core:
     pendingF2FResetEnabled:
       featureFlags:
         pendingF2FResetEnabled: true
-    strategicApp:
-      featureFlags:
-        strategicAppEnabled: true
-    disableStrategicApp:
-      featureFlags:
-        strategicAppEnabled: false
     zeroHourFraudVcExpiry:
       self:
         fraudCheckExpiryPeriodDays: 0

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -353,7 +353,6 @@ core:
   featureFlags:
     resetIdentity: false
     pendingF2FResetEnabled: false
-    strategicAppEnabled: true
     repeatFraudCheckEnabled: true
     parseVcClasses: true
     sqsAsync: true
@@ -379,12 +378,6 @@ core:
     pendingF2FResetEnabled:
       featureFlags:
         pendingF2FResetEnabled: true
-    strategicApp:
-      featureFlags:
-        strategicAppEnabled: true
-    disableStrategicApp:
-      featureFlags:
-        strategicAppEnabled: false
     zeroHourFraudVcExpiry:
       self:
         fraudCheckExpiryPeriodDays: 0


### PR DESCRIPTION
## Proposed changes
### What changed

- remove strategicAppEnabled feature check from the journey map
- remove unused v1 app-related states
- update config and tests to remove strategic app-related feature sets/flags
- comment out tests that need to be updated once referenced tickets are resolved

### Why did it change

- We're retiring the v1 app completely for all routes except MFA reset. We've already enabled the v2 app to replace the old app in all envs including prod so this cleans up related feature sets/flags and any unused routing.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8928](https://govukverify.atlassian.net/browse/PYIC-8928)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8928]: https://govukverify.atlassian.net/browse/PYIC-8928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ