### PR TITLE
PYIC-8940: route users to sorry-could-not-confirm-details screen if they fail update-name with a CI from v2 app

### DIFF
--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -73,6 +73,51 @@ Feature: P2 International Address
       When I use the OAuth response to get my identity
       Then I get a 'P2' identity
 
+    Scenario: User fails V2 app with CI - MAM
+      When I submit an 'international' event
+      Then I get a 'non-uk-passport' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+
+    Scenario: User fails V2 app with CI - DAD
+      When I submit an 'international' event
+      Then I get a 'non-uk-passport' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response with context 'android-appOnly'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+
     Scenario: User looks for alternative methods to prove identity without using the app
       When I submit an 'international' event
       Then I get a 'non-uk-passport' page response

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -118,16 +118,42 @@ Feature: Repeat fraud check failures
 #      When I start a new 'medium-confidence' journey
 #      Then I get a 'pyi-no-match' page response
 
-    # TODO: uncommment and update this to use the strategic app once PYIC-8940 has been resolved
-#    Scenario: User is able to delete account from sorry-could-not-confirm-details screen
-#      # TODO: update this to use the strategic app once PYIC-8940 has been resolved
-#      When I activate the 'disableStrategicApp' feature set
-#      And I submit an 'update-name' event
-#      Then I get a 'dcmaw' CRI response
-#      When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-#      When I submit a 'delete' event
-#      Then I get a 'delete-handover' page response
+    Scenario: User is able to delete account from sorry-could-not-confirm-details screen - MAM
+      And I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone-appOnly'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+      When I submit a 'delete' event
+      Then I get a 'delete-handover' page response
+
+    Scenario: User is able to delete account from sorry-could-not-confirm-details screen - DAD
+      And I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone-appOnly'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+      When I submit a 'delete' event
+      Then I get a 'delete-handover' page response
 
     # TODO: uncomment and update this to use the strategic app once PYIC-8769/8941 have been resolved
 #    Scenario: Zero score in fraud CRI

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -155,6 +155,28 @@ Feature: Repeat fraud check failures
       When I submit a 'delete' event
       Then I get a 'delete-handover' page response
 
+    Scenario: Failed update name due to CI from DCMAW Async - user does not have valid identity on return journey
+      And I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone-appOnly'
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+
+      When I start a new 'medium-confidence' journey
+      Then I get a 'pyi-no-match' page response
+
     # TODO: uncomment and update this to use the strategic app once PYIC-8769/8941 have been resolved
 #    Scenario: Zero score in fraud CRI
 #      When I activate the 'disableStrategicApp' feature set

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -157,6 +157,28 @@ Feature: Identity reuse update details failures
             When I submit a 'delete' event
             Then I get a 'delete-handover' page response
 
+        Scenario: Failed update name due to CI from DCMAW Async - user does not have a valid identity on return journey
+            And I submit an 'update-name' event
+            Then I get an 'identify-device' page response
+            When I submit an 'appTriage' event
+            Then I get a 'pyi-triage-select-device' page response
+            When I submit a 'computer-or-tablet' event
+            Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+            When I submit an 'iphone' event
+            Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone-appOnly'
+            When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a CI
+            And I poll for async DCMAW credential receipt
+            Then the poll returns a '201'
+            When I submit the returned journey event
+            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+            When I submit a 'returnToRp' event
+            Then I get an OAuth response
+            When I use the OAuth response to get my identity
+            Then I get a 'P0' identity
+
+            When I start a new 'medium-confidence' journey
+            Then I get a 'pyi-no-match' page response
+
         Scenario: Zero score in fraud CRI - receives old identity (P2)
             When I submit an 'update-name' event
             Then I get an 'identify-device' page response

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -120,15 +120,42 @@ Feature: Identity reuse update details failures
 #            When I start a new 'medium-confidence' journey
 #            Then I get a 'pyi-driving-licence-no-match' page response
 
-        # TODO: uncomment and update this to use the strategic app once PYIC-8940 has been resolved
-#        Scenario: User is able to delete account from sorry-could-not-confirm-details page
-#            When I activate the 'disableStrategicApp' feature set
-#            And I submit an 'update-name' event
-#            Then I get a 'dcmaw' CRI response
-#            When I submit 'kenneth-driving-permit-breaching-ci' details to the CRI stub
-#            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-#            When I submit a 'delete' event
-#            Then I get a 'delete-handover' page response
+        Scenario: User is able to delete account from sorry-could-not-confirm-details page - MAM
+            And I submit an 'update-name' event
+            Then I get an 'identify-device' page response
+            When I submit an 'appTriage' event
+            Then I get a 'pyi-triage-select-device' page response
+            When I submit a 'smartphone' event
+            Then I get a 'pyi-triage-select-smartphone' page response with context 'mam'
+            When I submit an 'android' event
+            Then I get a 'pyi-triage-mobile-download-app' page response with context 'android-appOnly'
+            When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+            # And the user returns from the app to core-front
+            And I pass on the DCMAW callback
+            Then I get a 'check-mobile-app-result' page response
+            When I poll for async DCMAW credential receipt
+            Then the poll returns a '201'
+            When I submit the returned journey event
+            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+            When I submit a 'delete' event
+            Then I get a 'delete-handover' page response
+
+        Scenario: User is able to delete account from sorry-could-not-confirm-details page - DAD
+            And I submit an 'update-name' event
+            Then I get an 'identify-device' page response
+            When I submit an 'appTriage' event
+            Then I get a 'pyi-triage-select-device' page response
+            When I submit a 'computer-or-tablet' event
+            Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+            When I submit an 'iphone' event
+            Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone-appOnly'
+            When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+            And I poll for async DCMAW credential receipt
+            Then the poll returns a '201'
+            When I submit the returned journey event
+            Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+            When I submit a 'delete' event
+            Then I get a 'delete-handover' page response
 
         Scenario: Zero score in fraud CRI - receives old identity (P2)
             When I submit an 'update-name' event

--- a/api-tests/features/stored-identity/failed-update-journeys.feature
+++ b/api-tests/features/stored-identity/failed-update-journeys.feature
@@ -39,22 +39,29 @@ Feature: Failed update details
       Then I get a 'P1' identity
       And I have a GPG45 stored identity record type with a 'P1' vot that is 'valid'
 
-    # TODO: uncomment and update to use strategic app once PYIC-8940 has been resolved
-#    Scenario: Reuse journey - failed name change - fail with CI (invalid identity)
-#      When I activate the 'disableStrategicApp' feature set
-#      And I submit a 'given-names-only' event
-#      Then I get a 'page-update-name' page response
-#      When I submit a 'update-name' event
-#      Then I get a 'dcmaw' CRI response
-#      # SI record invalidated as part of reset-session-identity lambda
-#      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
-#      When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
-#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-#      When I submit a 'returnToRp' event
-#      Then I get an OAuth response
-#      When I use the OAuth response to get my identity
-#      Then I get a 'P0' identity
-#      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
+    Scenario: Reuse journey - failed name change - fail with CI (invalid identity)
+      And I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response
+      When I submit a 'update-name' event
+      # SI record invalidated as part of reset-session-identity lambda
+      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response with context 'android-appOnly'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
 
     Scenario: Reuse journey - failed name change - fail with no ci (valid identity)
       When I submit a 'given-names-only' event
@@ -129,20 +136,30 @@ Feature: Failed update details
       Then I get a 'P0' identity
       And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
 
-    # TODO: uncomment and update to use strategic app once PYIC-8940 has been resolved
-#    Scenario: RFC - failed update name - fail with CI (invalid identity)
-#      When I activate the 'disableStrategicApp' feature set
-#      And I submit a 'given-names-only' event
-#      Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
-#      When I submit a 'update-name' event
-#      Then I get a 'dcmaw' CRI response
-#      When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
-#      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
-#      When I submit a 'returnToRp' event
-#      Then I get an OAuth response
-#      When I use the OAuth response to get my identity
-#      Then I get a 'P0' identity
-#      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
+    Scenario: RFC - failed update name - fail with CI (invalid identity)
+      And I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response with context 'repeatFraudCheck'
+      When I submit a 'update-name' event
+      # SI record invalidated as part of reset-session-identity lambda
+      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
+
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response with context 'dad'
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response with context 'android-appOnly'
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'sorry-could-not-confirm-details' page response with context 'existingIdentityInvalid'
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I get a 'P0' identity
+      And I have a GPG45 stored identity record type with a 'P1' vot that is 'invalid'
 
     Scenario: RFC - failed update name - fail with no CI (invalid identity)
       When I submit a 'given-names-only' event

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-handle-result.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-handle-result.yaml
@@ -23,8 +23,7 @@ nestedJourneyStates:
       fail-with-no-ci:
         exitEventToEmit: anotherWay
       fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED
+        exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -105,8 +105,7 @@ nestedJourneyStates:
       fail-with-no-ci:
         exitEventToEmit: anotherWay
       fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED
+        exitEventToEmit: failWithCiFromApp
       enhanced-verification:
         exitEventToEmit: anotherWay
       vcs-not-correlated:
@@ -139,8 +138,7 @@ nestedJourneyStates:
       fail-with-no-ci:
         exitEventToEmit: anotherWay
       fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED
+        exitEventToEmit: failWithCiFromApp
       enhanced-verification:
         exitEventToEmit: anotherWay
       vcs-not-correlated:
@@ -193,8 +191,7 @@ nestedJourneyStates:
       fail-with-no-ci:
         exitEventToEmit: anotherWay
       fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED
+        exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED
@@ -225,8 +222,7 @@ nestedJourneyStates:
       fail-with-no-ci:
         exitEventToEmit: anotherWay
       fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED
+        exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED
@@ -469,6 +465,8 @@ nestedJourneyStates:
         exitEventToEmit: incompleteDlAuthCheckInvalidDl
       failedDlAuthCheckInvalidDl:
         exitEventToEmit: failedDlAuthCheckInvalidDl
+      failWithCiFromApp:
+        exitEventToEmit: failWithCiFromApp
       retryApp:
         checkJourneyContext:
           mamIphone:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -173,6 +173,9 @@ states:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: invalid-dl
+      failWithCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
@@ -575,6 +578,9 @@ states:
       incompleteDlAuthCheckInvalidDl:
         targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_PYI_ESCAPE
       failedDlAuthCheckInvalidDl:
+        targetJourney: FAILED
+        targetState: FAILED
+      failWithCiFromApp:
         targetJourney: FAILED
         targetState: FAILED
       returnToRp:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -170,6 +170,9 @@ states:
           - IPV_MITIGATION_START
         auditContext:
           mitigationType: invalid-dl
+      failWithCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
         journeyContextToUnset: appOnly
@@ -631,6 +634,9 @@ states:
       failedDlAuthCheckInvalidDl:
         targetJourney: FAILED
         targetState: FAILED
+      failWithCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
@@ -743,6 +749,9 @@ states:
         targetState: STRATEGIC_APP_NON_UK_NO_APP_PAGE
       failedDlAuthCheckInvalidDl:
         targetState: STRATEGIC_APP_NON_UK_NO_APP_PAGE
+      failWithCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -103,6 +103,10 @@ states:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
         journeyContextToUnset: appOnly
+      failWithCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+        journeyContextToUnset: appOnly
       returnToRp:
         targetState: RETURN_TO_RP
         journeyContextToUnset: appOnly
@@ -221,6 +225,10 @@ states:
       incompleteDlAuthCheckInvalidDl:
         targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_WITH_ADDRESS
       failedDlAuthCheckInvalidDl:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+        journeyContextToUnset: appOnly
+      failWithCiFromApp:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
         journeyContextToUnset: appOnly


### PR DESCRIPTION
## Proposed changes
### What changed

- update journey map to route users to `sorry-could-not-confirm-details` screen if they fail update-name with a CI from v2 app
- update api tests to test CI failure from v2 app when on a MAM/DAD journey

### Why did it change

- Whilst retiring the V1 app, a bug was spotted where users were being incorrectly shown the `pyi-no-match` screen instead of the `sorry-could-not-confirm-details` screen if they failed an update-name journey (RFC/reuse) due to a CI from the v2 app. This PR fixes that so the user is routed correctly.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8940](https://govukverify.atlassian.net/browse/PYIC-8940)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8940]: https://govukverify.atlassian.net/browse/PYIC-8940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ