### PR TITLE
BAU: add the journey map to the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,29 @@ updates:
           - "eslint-*"
           - "typescript-eslint"
           - "@types/eslint__js"
+  - package-ecosystem: "npm"
+    directory: "/journey-map"
+    registries: "*"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+    target-branch: main
+    labels:
+      - dependabot
+    commit-message:
+      prefix: BAU
+    allow:
+      - dependency-type: "all"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
+    groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "typescript-eslint"
+          - "@types/eslint__js"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Proposed changes
### What changed

- add the journey map to the dependabot config

### Why did it change

- so dependabot knows to scan the journey-map directory for updates

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
