### PR TITLE
PYIC-8913: Include mortality check failure fraud VCs in user's VC bundle

### DIFF
--- a/api-tests/features/cimit/p2-mortality-mitigation.feature
+++ b/api-tests/features/cimit/p2-mortality-mitigation.feature
@@ -35,7 +35,7 @@ Feature: Mortality check failures
     When I submit a 'next' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity
-    Then I get a 'P2' identity
+    Then I get a 'P2' identity with a fraud VC
 
   Scenario: Unmitigated mortality check results in failure
     When I submit 'kenneth-score-0-mortality-breaching' details with attributes to the CRI stub

--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -71,7 +71,7 @@ Feature: P2 International Address
       When I submit a 'next' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
-      Then I get a 'P2' identity
+      Then I get a 'P2' identity with a fraud VC
 
     Scenario: User looks for alternative methods to prove identity without using the app
       When I submit an 'international' event

--- a/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
+++ b/libs/user-identity-service/src/main/java/uk/gov/di/ipv/core/library/useridentity/service/UserIdentityService.java
@@ -80,8 +80,7 @@ public class UserIdentityService {
                         .filter(
                                 vc ->
                                         VcHelper.isSuccessfulVc(vc)
-                                                || VcHelper.hasUnavailableOrNotApplicableFraudCheck(
-                                                        vc))
+                                                || VcHelper.hasNonFatalFraudCheckFailure(vc))
                         .map(VerifiableCredential::getVcString)
                         .toList();
 

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -234,24 +234,18 @@ public class VcHelper {
     public static boolean isFraudScoreOptionalForGpg45Evaluation(List<VerifiableCredential> vcs) {
         return vcs.stream()
                 .filter(vc -> vc.getCri() == Cri.EXPERIAN_FRAUD)
-                .anyMatch(
-                        vc ->
-                                hasUnavailableOrNotApplicableFraudCheck(vc)
-                                        || hasFailedMortalityCheck(vc));
+                .anyMatch(VcHelper::hasNonFatalFraudCheckFailure);
     }
 
-    public static boolean hasUnavailableOrNotApplicableFraudCheck(VerifiableCredential vc) {
+    public static boolean hasNonFatalFraudCheckFailure(VerifiableCredential vc) {
         return VcHelper.hasFailedFraudCheck(
-                vc, Set.of(APPLICABLE_AUTHORITATIVE_SOURCE, AVAILABLE_AUTHORITATIVE_SOURCE));
+                        vc, Set.of(APPLICABLE_AUTHORITATIVE_SOURCE, AVAILABLE_AUTHORITATIVE_SOURCE))
+                || (VcHelper.hasFailedFraudCheck(vc, Set.of(MORTALITY_CHECK))
+                        && getIdentityCheckFraudScore(vc) == 0);
     }
 
     public static boolean hasUnavailableFraudCheck(VerifiableCredential vc) {
         return hasFailedFraudCheck(vc, Set.of(AVAILABLE_AUTHORITATIVE_SOURCE));
-    }
-
-    private static boolean hasFailedMortalityCheck(VerifiableCredential vc) {
-        return VcHelper.hasFailedFraudCheck(vc, Set.of(MORTALITY_CHECK))
-                && getIdentityCheckFraudScore(vc) == 0;
     }
 
     private static int getIdentityCheckFraudScore(VerifiableCredential vc) {

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -361,13 +361,13 @@ class VcHelperTest {
 
     @Test
     void
-            hasUnavailableOrNotApplicableFraudCheckShouldReturnTrueForApplicableAuthoritativeSourceFailedFraudCheck() {
+            hasNonFatalFraudCheckFailureShouldReturnTrueForApplicableAuthoritativeSourceFailedFraudCheck() {
 
         // Arrange
         var vc = vcExperianFraudApplicableAuthoritativeSourceFailed();
 
         // Act
-        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vc);
+        var result = VcHelper.hasNonFatalFraudCheckFailure(vc);
 
         // Assert
         assertTrue(result);
@@ -375,13 +375,26 @@ class VcHelperTest {
 
     @Test
     void
-            hasUnavailableOrNotApplicableFraudCheckShouldReturnTrueForAuthoritativeAvailableSourceFailedFraudCheck() {
+            hasNonFatalFraudCheckFailureShouldReturnTrueForAuthoritativeAvailableSourceFailedFraudCheck() {
 
         // Arrange
         var vc = vcExperianFraudAvailableAuthoritativeSourceFailed();
 
         // Act
-        var result = VcHelper.hasUnavailableOrNotApplicableFraudCheck(vc);
+        var result = VcHelper.hasNonFatalFraudCheckFailure(vc);
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    void hasNonFatalFraudCheckFailureShouldReturnTrueForMortalityFailedFraudCheck() {
+
+        // Arrange
+        var vc = vcExperianFraudMortalityFailed();
+
+        // Act
+        var result = VcHelper.hasNonFatalFraudCheckFailure(vc);
 
         // Assert
         assertTrue(result);


### PR DESCRIPTION
## Proposed changes
### What changed

Include fraud VCs that have failed due to mortality checks in the user's VC bundle

### Why did it change

So that SPOT can see it for checking the identity

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8913](https://govukverify.atlassian.net/browse/PYIC-8913)



[PYIC-8913]: https://govukverify.atlassian.net/browse/PYIC-8913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ