### PR TITLE
PYIC-8713: add a stateHistoryStack

### DIFF
--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -445,6 +445,7 @@ class BuildClientOauthResponseHandlerTest {
         IpvSessionItem item = new IpvSessionItem();
         item.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         item.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"));
+        item.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"), null);
         item.setCreationDateTime(new Date().toString());
         return item;
     }

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -177,6 +177,7 @@ class BuildUserIdentityHandlerTest {
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(TEST_IPV_SESSION_ID);
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"));
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"), null);
         ipvSessionItem.setClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setAccessToken(TEST_ACCESS_TOKEN);
         ipvSessionItem.setAccessTokenMetadata(new AccessTokenMetadata());

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -375,6 +375,9 @@ public class ProcessJourneyEventHandler
         if (result.state() instanceof BasicState basicState) {
             ipvSessionItem.pushState(
                     new JourneyState(basicState.getJourneyType(), basicState.getName()));
+            ipvSessionItem.pushState(
+                    new JourneyState(basicState.getJourneyType(), basicState.getName()),
+                    journeyEvent);
         }
 
         return result.state();
@@ -432,6 +435,8 @@ public class ProcessJourneyEventHandler
         ipvSessionItem.setErrorCode(OAuth2Error.ACCESS_DENIED.getCode());
         ipvSessionItem.setErrorDescription(OAuth2Error.ACCESS_DENIED.getDescription());
         ipvSessionItem.pushState(new JourneyState(SESSION_TIMEOUT, CORE_SESSION_TIMEOUT_STATE));
+        ipvSessionItem.pushState(
+                new JourneyState(SESSION_TIMEOUT, CORE_SESSION_TIMEOUT_STATE), null);
 
         logStateChange(oldJourneyState, "timeout", ipvSessionItem);
         sendSubJourneyStartAuditEvent(auditEventUser, SESSION_TIMEOUT, deviceInformation);

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -446,6 +446,13 @@ class ProcessJourneyEventHandlerTest {
         assertEquals("core", capturedAuditEvent.getComponentId());
         assertEquals(TEST_USER_ID, capturedAuditEvent.getUser().getUserId());
         assertEquals("testjourneyid", capturedAuditEvent.getUser().getGovukSigninJourneyId());
+
+        assertEquals(
+                List.of(
+                        new StateHistoryEntry("INITIAL_JOURNEY_SELECTION/CRI_STATE", null),
+                        new StateHistoryEntry("SESSION_TIMEOUT/CORE_SESSION_TIMEOUT", "next"),
+                        new StateHistoryEntry("SESSION_TIMEOUT/TIMEOUT_UNRECOVERABLE_PAGE", null)),
+                capturedIpvSessionItem.getStateHistoryStack());
     }
 
     @Test
@@ -1274,14 +1281,14 @@ class ProcessJourneyEventHandlerTest {
         assertEquals("/journey/cri/build-oauth-request/aCriId", secondOutput.get("journey"));
 
         assertEquals(
-                spyIpvSessionItem.getStateHistoryStack(),
                 List.of(
                         new StateHistoryEntry(
                                 "INITIAL_JOURNEY_SELECTION/PAGE_STATE",
                                 "eventWithSetJourneyContext"),
                         new StateHistoryEntry(
                                 "INITIAL_JOURNEY_SELECTION/ANOTHER_PAGE_STATE", "next"),
-                        new StateHistoryEntry("INITIAL_JOURNEY_SELECTION/CRI_STATE", null)));
+                        new StateHistoryEntry("INITIAL_JOURNEY_SELECTION/CRI_STATE", null)),
+                spyIpvSessionItem.getStateHistoryStack());
     }
 
     @Tag(SKIP_CHECK_AUDIT_EVENT_WAIT_TAG)
@@ -1337,14 +1344,14 @@ class ProcessJourneyEventHandlerTest {
         assertEquals("/journey/a-lambda-to-invoke", secondOutput.get("journey"));
 
         assertEquals(
-                spyIpvSessionItem.getStateHistoryStack(),
                 List.of(
                         new StateHistoryEntry(
                                 "INITIAL_JOURNEY_SELECTION/PAGE_STATE",
                                 "eventWithUnsetJourneyContext"),
                         new StateHistoryEntry(
                                 "INITIAL_JOURNEY_SELECTION/ANOTHER_PAGE_STATE", "next"),
-                        new StateHistoryEntry("INITIAL_JOURNEY_SELECTION/PROCESS_STATE", null)));
+                        new StateHistoryEntry("INITIAL_JOURNEY_SELECTION/PROCESS_STATE", null)),
+                spyIpvSessionItem.getStateHistoryStack());
     }
 
     @Test

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -38,6 +38,7 @@ import uk.gov.di.ipv.core.library.journeys.Events;
 import uk.gov.di.ipv.core.library.journeys.JourneyUris;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
+import uk.gov.di.ipv.core.library.persistence.item.StateHistoryEntry;
 import uk.gov.di.ipv.core.library.service.AuditService;
 import uk.gov.di.ipv.core.library.service.CimitUtilityService;
 import uk.gov.di.ipv.core.library.service.ClientOAuthSessionDetailsService;
@@ -714,6 +715,11 @@ class ProcessJourneyEventHandlerTest {
                 .pushState(
                         new JourneyState(
                                 INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"));
+        inOrder.verify(ipvSessionItem)
+                .pushState(
+                        new JourneyState(
+                                INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"),
+                        "eventFour");
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
         assertEquals(
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"),
@@ -722,6 +728,10 @@ class ProcessJourneyEventHandlerTest {
         processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
         inOrder.verify(ipvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"));
+        inOrder.verify(ipvSessionItem)
+                .pushState(
+                        new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
+                        "anotherPageState");
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
         assertEquals(
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
@@ -959,7 +969,10 @@ class ProcessJourneyEventHandlerTest {
         mockIpvSessionItemAndTimeout("PAGE_STATE");
         IpvSessionItem ipvSession = mockIpvSessionService.getIpvSession("anyString");
         ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"));
+        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"), "eventTwo");
         ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
+        ipvSession.pushState(
+                new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), "parentEvent");
 
         ProcessJourneyEventHandler processJourneyEventHandler =
                 new ProcessJourneyEventHandler(
@@ -1046,7 +1059,10 @@ class ProcessJourneyEventHandlerTest {
         mockIpvSessionItemAndTimeout("PAGE_STATE");
         IpvSessionItem ipvSession = mockIpvSessionService.getIpvSession("anyString");
         ipvSession.pushState(new JourneyState(TECHNICAL_ERROR, "CRI_STATE"));
+        ipvSession.pushState(new JourneyState(TECHNICAL_ERROR, "CRI_STATE"), "next");
         ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
+        ipvSession.pushState(
+                new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), "parentEvent");
 
         ProcessJourneyEventHandler processJourneyEventHandler =
                 new ProcessJourneyEventHandler(
@@ -1235,9 +1251,15 @@ class ProcessJourneyEventHandlerTest {
         var initialOutput = processJourneyEventHandler.handleRequest(initialInput, mockContext);
         inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
+        inOrder.verify(spyIpvSessionItem)
+                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), null);
         inOrder.verify(spyIpvSessionItem, times(1)).setJourneyContext("someContext");
         inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"));
+        inOrder.verify(spyIpvSessionItem)
+                .pushState(
+                        new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
+                        "eventWithSetJourneyContext");
         inOrder.verify(mockIpvSessionService).updateIpvSession(spyIpvSessionItem);
         assertEquals("page-id-for-another-page-state", initialOutput.get("page"));
 
@@ -1246,8 +1268,20 @@ class ProcessJourneyEventHandlerTest {
                 processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
         inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"));
+        inOrder.verify(spyIpvSessionItem)
+                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"), "next");
         inOrder.verify(mockIpvSessionService).updateIpvSession(spyIpvSessionItem);
         assertEquals("/journey/cri/build-oauth-request/aCriId", secondOutput.get("journey"));
+
+        assertEquals(
+                spyIpvSessionItem.getStateHistoryStack(),
+                List.of(
+                        new StateHistoryEntry(
+                                "INITIAL_JOURNEY_SELECTION/PAGE_STATE",
+                                "eventWithSetJourneyContext"),
+                        new StateHistoryEntry(
+                                "INITIAL_JOURNEY_SELECTION/ANOTHER_PAGE_STATE", "next"),
+                        new StateHistoryEntry("INITIAL_JOURNEY_SELECTION/CRI_STATE", null)));
     }
 
     @Tag(SKIP_CHECK_AUDIT_EVENT_WAIT_TAG)
@@ -1282,9 +1316,13 @@ class ProcessJourneyEventHandlerTest {
         var initialOutput = processJourneyEventHandler.handleRequest(initialInput, mockContext);
         inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
+        inOrder.verify(spyIpvSessionItem)
+                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), null);
         inOrder.verify(spyIpvSessionItem, times(1)).unsetJourneyContext("someContext");
         inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"));
+                .pushState(
+                        new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
+                        "eventWithUnsetJourneyContext");
         inOrder.verify(mockIpvSessionService).updateIpvSession(spyIpvSessionItem);
         assertEquals("page-id-for-another-page-state", initialOutput.get("page"));
 
@@ -1293,8 +1331,20 @@ class ProcessJourneyEventHandlerTest {
                 processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
         inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PROCESS_STATE"));
+        inOrder.verify(spyIpvSessionItem)
+                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PROCESS_STATE"), "next");
         inOrder.verify(mockIpvSessionService).updateIpvSession(spyIpvSessionItem);
         assertEquals("/journey/a-lambda-to-invoke", secondOutput.get("journey"));
+
+        assertEquals(
+                spyIpvSessionItem.getStateHistoryStack(),
+                List.of(
+                        new StateHistoryEntry(
+                                "INITIAL_JOURNEY_SELECTION/PAGE_STATE",
+                                "eventWithUnsetJourneyContext"),
+                        new StateHistoryEntry(
+                                "INITIAL_JOURNEY_SELECTION/ANOTHER_PAGE_STATE", "next"),
+                        new StateHistoryEntry("INITIAL_JOURNEY_SELECTION/PROCESS_STATE", null)));
     }
 
     @Test
@@ -1390,6 +1440,7 @@ class ProcessJourneyEventHandlerTest {
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, userState));
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, userState), null);
         ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setSecurityCheckCredential(SIGNED_CONTRA_INDICATOR_VC_1);
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
@@ -42,6 +43,9 @@ public class IpvSessionItem implements PersistenceItem {
     private String emailAddress;
     private ReverificationStatus reverificationStatus;
     @Builder.Default private List<String> stateStack = new ArrayList<>();
+
+    // This is a more detailed version of stateStack above and will be used to replace it
+    @Builder.Default private List<StateHistoryEntry> stateHistoryStack = new ArrayList<>();
 
     // These are used as part of an unsuccessful reverification response
     private ReverificationFailureCode failureCode;
@@ -89,6 +93,17 @@ public class IpvSessionItem implements PersistenceItem {
     public void setFeatureSetFromList(List<String> featureSet) {
         this.featureSet =
                 (featureSet != null && !featureSet.isEmpty()) ? String.join(",", featureSet) : null;
+    }
+
+    public void pushState(JourneyState newJourneyState, String event) {
+        // Record event that moved the user out of the previous state
+        if (StringUtils.isNotBlank(event) && !stateHistoryStack.isEmpty()) {
+            stateHistoryStack.set(
+                    stateHistoryStack.size() - 1,
+                    new StateHistoryEntry(stateHistoryStack.getLast().getState(), event));
+        }
+        // Push the new state with no event
+        stateHistoryStack.add(new StateHistoryEntry(newJourneyState.toSessionItemString(), null));
     }
 
     public void pushState(JourneyState journeyState) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/StateHistoryEntry.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/StateHistoryEntry.java
@@ -1,0 +1,15 @@
+package uk.gov.di.ipv.core.library.persistence.item;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+@DynamoDbBean
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StateHistoryEntry {
+    private String state;
+    private String event;
+}

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -146,8 +146,14 @@ public class IpvSessionService {
                     new JourneyState(
                             isReverification ? REVERIFICATION : INITIAL_JOURNEY_SELECTION,
                             START_STATE));
+            ipvSessionItem.pushState(
+                    new JourneyState(
+                            isReverification ? REVERIFICATION : INITIAL_JOURNEY_SELECTION,
+                            START_STATE),
+                    null);
         } else {
             ipvSessionItem.pushState(new JourneyState(TECHNICAL_ERROR, ERROR_STATE));
+            ipvSessionItem.pushState(new JourneyState(TECHNICAL_ERROR, ERROR_STATE), null);
             ipvSessionItem.setErrorCode(errorObject.getCode());
             ipvSessionItem.setErrorDescription(errorObject.getDescription());
         }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -67,6 +67,7 @@ class IpvSessionServiceTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         when(mockDataStore.getItem(ipvSessionID)).thenReturn(ipvSessionItem);
@@ -78,6 +79,7 @@ class IpvSessionServiceTest {
         assertEquals(ipvSessionID, ipvSessionIDArgumentCaptor.getValue());
         assertEquals(ipvSessionItem.getIpvSessionId(), result.getIpvSessionId());
         assertEquals(ipvSessionItem.getState(), result.getState());
+        assertEquals(ipvSessionItem.getStateHistoryStack(), result.getStateHistoryStack());
         assertEquals(ipvSessionItem.getCreationDateTime(), result.getCreationDateTime());
     }
 
@@ -88,6 +90,7 @@ class IpvSessionServiceTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         when(mockDataStore.getItem(ipvSessionID)).thenReturn(ipvSessionItem);
@@ -99,6 +102,7 @@ class IpvSessionServiceTest {
         assertEquals(ipvSessionID, ipvSessionIDArgumentCaptor.getValue());
         assertEquals(ipvSessionItem.getIpvSessionId(), result.getIpvSessionId());
         assertEquals(ipvSessionItem.getState(), result.getState());
+        assertEquals(ipvSessionItem.getStateHistoryStack(), result.getStateHistoryStack());
         assertEquals(ipvSessionItem.getCreationDateTime(), result.getCreationDateTime());
     }
 
@@ -109,6 +113,7 @@ class IpvSessionServiceTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         when(mockDataStore.getItem(ipvSessionID))
@@ -273,6 +278,7 @@ class IpvSessionServiceTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         ipvSessionService.updateIpvSession(ipvSessionItem);
@@ -285,6 +291,7 @@ class IpvSessionServiceTest {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
+        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
         ipvSessionService.invalidateSession(ipvSessionItem, ACCOUNT_INTERVENTION_ERROR_DESCRIPTION);


### PR DESCRIPTION
## Proposed changes
### What changed

- add a stateHistoryStack which records a state and the event from that state.

<details>
  <summary>Example stateHistoryStack saved to DynamoDb</summary>
<code>
[
  {
    "M": {
      "event": {
        "S": "next"
      },
      "state": {
        "S": "INITIAL_JOURNEY_SELECTION/START"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "next"
      },
      "state": {
        "S": "INITIAL_JOURNEY_SELECTION/CHECK_EXISTING_IDENTITY"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "uk"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/LIVE_IN_UK_PAGE"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "appTriage"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/IDENTITY_START_PAGE"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "appTriage"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/STRATEGIC_APP_TRIAGE/IDENTIFY_DEVICE"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "computer-or-tablet"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/STRATEGIC_APP_TRIAGE/SELECT_DEVICE_PAGE"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "neither"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/STRATEGIC_APP_TRIAGE/DAD_SELECT_SMARTPHONE"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "anotherWay"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/STRATEGIC_APP_TRIAGE/DAD_SELECT_SMARTPHONE_EXIT_BUFFER"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "drivingLicence"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/MULTIPLE_DOC_CHECK_PAGE"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "next"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/WEB_DL_OR_PASSPORT/CRI_DRIVING_LICENCE"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "next"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/WEB_DL_OR_PASSPORT/ADDRESS_AND_FRAUD_AFTER_DL/CRI_ADDRESS"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "next"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/WEB_DL_OR_PASSPORT/ADDRESS_AND_FRAUD_AFTER_DL/CRI_FRAUD"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "met"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/CHECK_FRAUD_AFTER_DL"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "end"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/KBV_PHOTO_ID/PRE_DWP_KBV_PIP_PAGE"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "next"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/KBV_PHOTO_ID/PRE_EXPERIAN_PAGE"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "next"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/KBV_PHOTO_ID/EXPERIAN_KBV_CRI"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "next"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/PROCESS_NEW_IDENTITY"
      }
    }
  },
  {
    "M": {
      "event": {
        "S": "next"
      },
      "state": {
        "S": "NEW_P2_IDENTITY/IPV_SUCCESS_PAGE"
      }
    }
  },
  {
    "M": {
      "event": {
        "NULL": true
      },
      "state": {
        "S": "NEW_P2_IDENTITY/RETURN_TO_RP"
      }
    }
  }
]
</code>
</details>

Note: there will be more PRs to convert existing stateStack functionality to use the new stateHistoryStack but they need to be done deployed separately so we don't have any system downtime.

### Why did it change

- This will replace stateStack with a more detailed stack history where the state is recorded along with the exit event from that state.
- This prepares the journey-map move towards a more dynamic journey map and will also allow for further simplifications e.g. replacing the `journeyConxtextToSet/Unset` functionality.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8713](https://govukverify.atlassian.net/browse/PYIC-8713)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8713]: https://govukverify.atlassian.net/browse/PYIC-8713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ