### PR TITLE
PYIC-8713: update pop state to also pop the current state from stateStackHistory

### DIFF
--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -737,6 +737,7 @@ class ProcessJourneyEventHandlerTest {
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
                 ipvSessionItem.getState());
 
+        // User goes back once
         processJourneyEventHandler.handleRequest(backInput, mockContext);
         inOrder.verify(ipvSessionItem).popState();
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
@@ -744,12 +745,17 @@ class ProcessJourneyEventHandlerTest {
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"),
                 ipvSessionItem.getState());
 
+        // User goes back again
         processJourneyEventHandler.handleRequest(backInput, mockContext);
         inOrder.verify(ipvSessionItem).popState();
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
         assertEquals(
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"),
                 ipvSessionItem.getState());
+
+        assertEquals(
+                List.of(new StateHistoryEntry("INITIAL_JOURNEY_SELECTION/PAGE_STATE", null)),
+                ipvSessionItem.getStateHistoryStack());
     }
 
     @Test

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -111,7 +111,14 @@ public class IpvSessionItem implements PersistenceItem {
     }
 
     public void popState() {
-        stateStack.remove(stateStack.size() - 1);
+        stateStack.removeLast();
+
+        // Remove most recent state (which should have null event as the user
+        //  hasn't moved off it yet) and reset the last state
+        stateHistoryStack.removeLast();
+        stateHistoryStack.set(
+                stateHistoryStack.size() - 1,
+                new StateHistoryEntry(stateHistoryStack.getLast().getState(), null));
     }
 
     public JourneyState getState() {


### PR DESCRIPTION
❗ ❗ Only merge after [this PR](https://github.com/govuk-one-login/ipv-core-back/pull/3793) has been merged.

## Proposed changes
### What changed

- update pop state to also pop the current state from stateStackHistory

### Why did it change

- This is a follow-up PR to update the `ipvSessionItem.popState` function to update `stateStackHistory`. It needs to be done as a separate deployment because it's possible that different versions of `process-journey-engine` are used for a user's journey e.g. when core-front makes a call to the journey engine due to canary deployments.

Context:
`stateHistoryStack` will replace `stateStack` with a more detailed stack history where the state is recorded along with the exit event from that state. This prepares the journey-map move towards a more dynamic journey map and will also allow for further simplifications e.g. replacing the journeyConxtextToSet/Unset functionality.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8713](https://govukverify.atlassian.net/browse/PYIC-8713)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8713]: https://govukverify.atlassian.net/browse/PYIC-8713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ