### PR TITLE
PYIC-8713: update state getters to use stateHistoryStack

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -122,17 +122,17 @@ public class IpvSessionItem implements PersistenceItem {
     }
 
     public JourneyState getState() {
-        if (stateStack.isEmpty()) {
+        if (stateHistoryStack.isEmpty()) {
             throw new IllegalStateException();
         }
-        return new JourneyState(stateStack.get(stateStack.size() - 1));
+        return new JourneyState(stateHistoryStack.getLast().getState());
     }
 
     public JourneyState getPreviousState() {
-        if (stateStack.size() < 2) {
+        if (stateHistoryStack.size() < 2) {
             throw new IllegalStateException();
         }
-        return new JourneyState(stateStack.get(stateStack.size() - 2));
+        return new JourneyState(stateHistoryStack.get(stateHistoryStack.size() - 2).getState());
     }
 
     public void setJourneyContext(String journeyContext) {


### PR DESCRIPTION
❗ ❗ Only merge after [this PR](https://github.com/govuk-one-login/ipv-core-back/pull/3794) has been merged.
## Proposed changes
### What changed

- updates stateStack getters to use the stateStackHistory

### Why did it change

- this prepares for the replacement of `stateStack` with `stateStackHistory`

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8713](https://govukverify.atlassian.net/browse/PYIC-8713)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8713]: https://govukverify.atlassian.net/browse/PYIC-8713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ