### PR TITLE
PYIC-8713: remove use of stateStack from codebase

### DIFF
--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -444,7 +444,6 @@ class BuildClientOauthResponseHandlerTest {
     private IpvSessionItem generateIpvSessionItem() {
         IpvSessionItem item = new IpvSessionItem();
         item.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        item.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"));
         item.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"), null);
         item.setCreationDateTime(new Date().toString());
         return item;

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -176,7 +176,6 @@ class BuildUserIdentityHandlerTest {
 
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(TEST_IPV_SESSION_ID);
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"), null);
         ipvSessionItem.setClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setAccessToken(TEST_ACCESS_TOKEN);

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -374,8 +374,6 @@ public class ProcessJourneyEventHandler
 
         if (result.state() instanceof BasicState basicState) {
             ipvSessionItem.pushState(
-                    new JourneyState(basicState.getJourneyType(), basicState.getName()));
-            ipvSessionItem.pushState(
                     new JourneyState(basicState.getJourneyType(), basicState.getName()),
                     journeyEvent);
         }
@@ -434,7 +432,6 @@ public class ProcessJourneyEventHandler
 
         ipvSessionItem.setErrorCode(OAuth2Error.ACCESS_DENIED.getCode());
         ipvSessionItem.setErrorDescription(OAuth2Error.ACCESS_DENIED.getDescription());
-        ipvSessionItem.pushState(new JourneyState(SESSION_TIMEOUT, CORE_SESSION_TIMEOUT_STATE));
         ipvSessionItem.pushState(
                 new JourneyState(SESSION_TIMEOUT, CORE_SESSION_TIMEOUT_STATE), null);
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -721,10 +721,6 @@ class ProcessJourneyEventHandlerTest {
         inOrder.verify(ipvSessionItem)
                 .pushState(
                         new JourneyState(
-                                INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"));
-        inOrder.verify(ipvSessionItem)
-                .pushState(
-                        new JourneyState(
                                 INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"),
                         "eventFour");
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
@@ -733,8 +729,6 @@ class ProcessJourneyEventHandlerTest {
                 ipvSessionItem.getState());
 
         processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
-        inOrder.verify(ipvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"));
         inOrder.verify(ipvSessionItem)
                 .pushState(
                         new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
@@ -981,9 +975,7 @@ class ProcessJourneyEventHandlerTest {
 
         mockIpvSessionItemAndTimeout("PAGE_STATE");
         IpvSessionItem ipvSession = mockIpvSessionService.getIpvSession("anyString");
-        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"));
         ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"), "eventTwo");
-        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
         ipvSession.pushState(
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), "parentEvent");
 
@@ -1071,9 +1063,7 @@ class ProcessJourneyEventHandlerTest {
 
         mockIpvSessionItemAndTimeout("PAGE_STATE");
         IpvSessionItem ipvSession = mockIpvSessionService.getIpvSession("anyString");
-        ipvSession.pushState(new JourneyState(TECHNICAL_ERROR, "CRI_STATE"));
         ipvSession.pushState(new JourneyState(TECHNICAL_ERROR, "CRI_STATE"), "next");
-        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
         ipvSession.pushState(
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), "parentEvent");
 
@@ -1263,12 +1253,8 @@ class ProcessJourneyEventHandlerTest {
         // Initial transition
         var initialOutput = processJourneyEventHandler.handleRequest(initialInput, mockContext);
         inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
-        inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), null);
         inOrder.verify(spyIpvSessionItem, times(1)).setJourneyContext("someContext");
-        inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"));
         inOrder.verify(spyIpvSessionItem)
                 .pushState(
                         new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
@@ -1279,8 +1265,6 @@ class ProcessJourneyEventHandlerTest {
         // Second transition
         var secondOutput =
                 processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
-        inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"));
         inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"), "next");
         inOrder.verify(mockIpvSessionService).updateIpvSession(spyIpvSessionItem);
@@ -1328,8 +1312,6 @@ class ProcessJourneyEventHandlerTest {
         // Initial transition
         var initialOutput = processJourneyEventHandler.handleRequest(initialInput, mockContext);
         inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
-        inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), null);
         inOrder.verify(spyIpvSessionItem, times(1)).unsetJourneyContext("someContext");
         inOrder.verify(spyIpvSessionItem)
@@ -1342,8 +1324,6 @@ class ProcessJourneyEventHandlerTest {
         // Second transition
         var secondOutput =
                 processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
-        inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PROCESS_STATE"));
         inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PROCESS_STATE"), "next");
         inOrder.verify(mockIpvSessionService).updateIpvSession(spyIpvSessionItem);
@@ -1452,7 +1432,6 @@ class ProcessJourneyEventHandlerTest {
         IpvSessionItem ipvSessionItem = spy(IpvSessionItem.class);
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, userState));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, userState), null);
         ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setSecurityCheckCredential(SIGNED_CONTRA_INDICATOR_VC_1);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -106,13 +106,7 @@ public class IpvSessionItem implements PersistenceItem {
         stateHistoryStack.add(new StateHistoryEntry(newJourneyState.toSessionItemString(), null));
     }
 
-    public void pushState(JourneyState journeyState) {
-        stateStack.add(journeyState.toSessionItemString());
-    }
-
     public void popState() {
-        stateStack.removeLast();
-
         // Remove most recent state (which should have null event as the user
         //  hasn't moved off it yet) and reset the last state
         stateHistoryStack.removeLast();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -145,14 +145,9 @@ public class IpvSessionService {
             ipvSessionItem.pushState(
                     new JourneyState(
                             isReverification ? REVERIFICATION : INITIAL_JOURNEY_SELECTION,
-                            START_STATE));
-            ipvSessionItem.pushState(
-                    new JourneyState(
-                            isReverification ? REVERIFICATION : INITIAL_JOURNEY_SELECTION,
                             START_STATE),
                     null);
         } else {
-            ipvSessionItem.pushState(new JourneyState(TECHNICAL_ERROR, ERROR_STATE));
             ipvSessionItem.pushState(new JourneyState(TECHNICAL_ERROR, ERROR_STATE), null);
             ipvSessionItem.setErrorCode(errorObject.getCode());
             ipvSessionItem.setErrorDescription(errorObject.getDescription());

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -66,7 +66,6 @@ class IpvSessionServiceTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -89,7 +88,6 @@ class IpvSessionServiceTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -112,7 +110,6 @@ class IpvSessionServiceTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -277,7 +274,6 @@ class IpvSessionServiceTest {
     void shouldUpdateSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -290,7 +286,6 @@ class IpvSessionServiceTest {
     void shouldInvalidateSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 


### PR DESCRIPTION
❗ ❗ Don't merge until [this PR](https://github.com/govuk-one-login/ipv-core-back/pull/3795) is merged

## Proposed changes
### What changed

- remove use of state stack

Note: this is separate from the removal of `stateStack` from `IpvSessionItem` as that will need its own deployment

### Why did it change

- this prepares for the replacement of stateStack with stateStackHistory

Context:
stateHistoryStack will replace stateStack with a more detailed stack history where the state is recorded along with the exit event from that state. This prepares the journey-map move towards a more dynamic journey map and will also allow for further simplifications e.g. replacing the journeyConxtextToSet/Unset functionality.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8713](https://govukverify.atlassian.net/browse/PYIC-8713)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8713]: https://govukverify.atlassian.net/browse/PYIC-8713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ