### PR TITLE
PYIC-8713: remove state stack from ipv session item

### DIFF
--- a/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
+++ b/lambdas/build-client-oauth-response/src/test/java/uk/gov/di/ipv/core/buildclientoauthresponse/BuildClientOauthResponseHandlerTest.java
@@ -444,7 +444,6 @@ class BuildClientOauthResponseHandlerTest {
     private IpvSessionItem generateIpvSessionItem() {
         IpvSessionItem item = new IpvSessionItem();
         item.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        item.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"));
         item.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"), null);
         item.setCreationDateTime(new Date().toString());
         return item;

--- a/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
+++ b/lambdas/build-user-identity/src/test/java/uk/gov/di/ipv/core/builduseridentity/BuildUserIdentityHandlerTest.java
@@ -176,7 +176,6 @@ class BuildUserIdentityHandlerTest {
 
         ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(TEST_IPV_SESSION_ID);
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "test-state"), null);
         ipvSessionItem.setClientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID);
         ipvSessionItem.setAccessToken(TEST_ACCESS_TOKEN);

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandler.java
@@ -374,8 +374,6 @@ public class ProcessJourneyEventHandler
 
         if (result.state() instanceof BasicState basicState) {
             ipvSessionItem.pushState(
-                    new JourneyState(basicState.getJourneyType(), basicState.getName()));
-            ipvSessionItem.pushState(
                     new JourneyState(basicState.getJourneyType(), basicState.getName()),
                     journeyEvent);
         }
@@ -434,7 +432,6 @@ public class ProcessJourneyEventHandler
 
         ipvSessionItem.setErrorCode(OAuth2Error.ACCESS_DENIED.getCode());
         ipvSessionItem.setErrorDescription(OAuth2Error.ACCESS_DENIED.getDescription());
-        ipvSessionItem.pushState(new JourneyState(SESSION_TIMEOUT, CORE_SESSION_TIMEOUT_STATE));
         ipvSessionItem.pushState(
                 new JourneyState(SESSION_TIMEOUT, CORE_SESSION_TIMEOUT_STATE), null);
 

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -714,10 +714,6 @@ class ProcessJourneyEventHandlerTest {
         inOrder.verify(ipvSessionItem)
                 .pushState(
                         new JourneyState(
-                                INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"));
-        inOrder.verify(ipvSessionItem)
-                .pushState(
-                        new JourneyState(
                                 INITIAL_JOURNEY_SELECTION, "PAGE_STATE_AT_START_OF_NO_PHOTO_ID"),
                         "eventFour");
         inOrder.verify(mockIpvSessionService).updateIpvSession(ipvSessionItem);
@@ -726,8 +722,6 @@ class ProcessJourneyEventHandlerTest {
                 ipvSessionItem.getState());
 
         processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
-        inOrder.verify(ipvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"));
         inOrder.verify(ipvSessionItem)
                 .pushState(
                         new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
@@ -974,9 +968,7 @@ class ProcessJourneyEventHandlerTest {
 
         mockIpvSessionItemAndTimeout("PAGE_STATE");
         IpvSessionItem ipvSession = mockIpvSessionService.getIpvSession("anyString");
-        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"));
         ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"), "eventTwo");
-        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
         ipvSession.pushState(
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), "parentEvent");
 
@@ -1064,9 +1056,7 @@ class ProcessJourneyEventHandlerTest {
 
         mockIpvSessionItemAndTimeout("PAGE_STATE");
         IpvSessionItem ipvSession = mockIpvSessionService.getIpvSession("anyString");
-        ipvSession.pushState(new JourneyState(TECHNICAL_ERROR, "CRI_STATE"));
         ipvSession.pushState(new JourneyState(TECHNICAL_ERROR, "CRI_STATE"), "next");
-        ipvSession.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
         ipvSession.pushState(
                 new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), "parentEvent");
 
@@ -1256,12 +1246,8 @@ class ProcessJourneyEventHandlerTest {
         // Initial transition
         var initialOutput = processJourneyEventHandler.handleRequest(initialInput, mockContext);
         inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
-        inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), null);
         inOrder.verify(spyIpvSessionItem, times(1)).setJourneyContext("someContext");
-        inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"));
         inOrder.verify(spyIpvSessionItem)
                 .pushState(
                         new JourneyState(INITIAL_JOURNEY_SELECTION, "ANOTHER_PAGE_STATE"),
@@ -1272,8 +1258,6 @@ class ProcessJourneyEventHandlerTest {
         // Second transition
         var secondOutput =
                 processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
-        inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"));
         inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "CRI_STATE"), "next");
         inOrder.verify(mockIpvSessionService).updateIpvSession(spyIpvSessionItem);
@@ -1321,8 +1305,6 @@ class ProcessJourneyEventHandlerTest {
         // Initial transition
         var initialOutput = processJourneyEventHandler.handleRequest(initialInput, mockContext);
         inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"));
-        inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), null);
         inOrder.verify(spyIpvSessionItem, times(1)).unsetJourneyContext("someContext");
         inOrder.verify(spyIpvSessionItem)
@@ -1335,8 +1317,6 @@ class ProcessJourneyEventHandlerTest {
         // Second transition
         var secondOutput =
                 processJourneyEventHandler.handleRequest(secondTransitionInput, mockContext);
-        inOrder.verify(spyIpvSessionItem)
-                .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PROCESS_STATE"));
         inOrder.verify(spyIpvSessionItem)
                 .pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, "PROCESS_STATE"), "next");
         inOrder.verify(mockIpvSessionService).updateIpvSession(spyIpvSessionItem);
@@ -1445,7 +1425,6 @@ class ProcessJourneyEventHandlerTest {
         IpvSessionItem ipvSessionItem = spy(IpvSessionItem.class);
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setCreationDateTime(Instant.now().toString());
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, userState));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, userState), null);
         ipvSessionItem.setClientOAuthSessionId(SecureTokenHelper.getInstance().generate());
         ipvSessionItem.setSecurityCheckCredential(SIGNED_CONTRA_INDICATOR_VC_1);

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -122,17 +122,17 @@ public class IpvSessionItem implements PersistenceItem {
     }
 
     public JourneyState getState() {
-        if (stateStack.isEmpty()) {
+        if (stateHistoryStack.isEmpty()) {
             throw new IllegalStateException();
         }
-        return new JourneyState(stateStack.get(stateStack.size() - 1));
+        return new JourneyState(stateHistoryStack.getLast().getState());
     }
 
     public JourneyState getPreviousState() {
-        if (stateStack.size() < 2) {
+        if (stateHistoryStack.size() < 2) {
             throw new IllegalStateException();
         }
-        return new JourneyState(stateStack.get(stateStack.size() - 2));
+        return new JourneyState(stateHistoryStack.get(stateHistoryStack.size() - 2).getState());
     }
 
     public void setJourneyContext(String journeyContext) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -106,13 +106,7 @@ public class IpvSessionItem implements PersistenceItem {
         stateHistoryStack.add(new StateHistoryEntry(newJourneyState.toSessionItemString(), null));
     }
 
-    public void pushState(JourneyState journeyState) {
-        stateStack.add(journeyState.toSessionItemString());
-    }
-
     public void popState() {
-        stateStack.removeLast();
-
         // Remove most recent state (which should have null event as the user
         //  hasn't moved off it yet) and reset the last state
         stateHistoryStack.removeLast();

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/persistence/item/IpvSessionItem.java
@@ -42,9 +42,6 @@ public class IpvSessionItem implements PersistenceItem {
     private long ttl;
     private String emailAddress;
     private ReverificationStatus reverificationStatus;
-    @Builder.Default private List<String> stateStack = new ArrayList<>();
-
-    // This is a more detailed version of stateStack above and will be used to replace it
     @Builder.Default private List<StateHistoryEntry> stateHistoryStack = new ArrayList<>();
 
     // These are used as part of an unsuccessful reverification response

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/service/IpvSessionService.java
@@ -145,14 +145,9 @@ public class IpvSessionService {
             ipvSessionItem.pushState(
                     new JourneyState(
                             isReverification ? REVERIFICATION : INITIAL_JOURNEY_SELECTION,
-                            START_STATE));
-            ipvSessionItem.pushState(
-                    new JourneyState(
-                            isReverification ? REVERIFICATION : INITIAL_JOURNEY_SELECTION,
                             START_STATE),
                     null);
         } else {
-            ipvSessionItem.pushState(new JourneyState(TECHNICAL_ERROR, ERROR_STATE));
             ipvSessionItem.pushState(new JourneyState(TECHNICAL_ERROR, ERROR_STATE), null);
             ipvSessionItem.setErrorCode(errorObject.getCode());
             ipvSessionItem.setErrorDescription(errorObject.getDescription());

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/IpvSessionServiceTest.java
@@ -66,7 +66,6 @@ class IpvSessionServiceTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -89,7 +88,6 @@ class IpvSessionServiceTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -112,7 +110,6 @@ class IpvSessionServiceTest {
 
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(ipvSessionID);
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -277,7 +274,6 @@ class IpvSessionServiceTest {
     void shouldUpdateSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 
@@ -290,7 +286,6 @@ class IpvSessionServiceTest {
     void shouldInvalidateSessionItem() {
         IpvSessionItem ipvSessionItem = new IpvSessionItem();
         ipvSessionItem.setIpvSessionId(SecureTokenHelper.getInstance().generate());
-        ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE));
         ipvSessionItem.pushState(new JourneyState(INITIAL_JOURNEY_SELECTION, START_STATE), null);
         ipvSessionItem.setCreationDateTime(new Date().toString());
 


### PR DESCRIPTION
❗ ❗ All these PRs should be merged first before merging this one:
- https://github.com/govuk-one-login/ipv-core-back/pull/3793
- https://github.com/govuk-one-login/ipv-core-back/pull/3794
- https://github.com/govuk-one-login/ipv-core-back/pull/3795
- https://github.com/govuk-one-login/ipv-core-back/pull/3796

## Proposed changes
### What changed

- removes `stateStack` from ipv session item now that we are using `stateStackHistory`

### Why did it change

- `stateStackHistory` is now recording a more detailed stack history where the state is recorded along with the exit event from that state.
This prepares the journey-map move towards a more dynamic journey map and will also allow for further simplifications e.g. replacing the journeyConxtextToSet/Unset functionality.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8713](https://govukverify.atlassian.net/browse/PYIC-8713)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8713]: https://govukverify.atlassian.net/browse/PYIC-8713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ