### PR TITLE
PYIC-8896: Pull uk-driving-licence-details-not-correct out of strategic-app-handle-result and into strategic-app-triage

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-handle-result.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-handle-result.yaml
@@ -56,7 +56,7 @@ nestedJourneyStates:
         resetType: PENDING_DCMAW_ASYNC_ALL
     events:
       next:
-        targetState: DL_DETAILS_INCORRECT_PAGE
+        exitEventToEmit: incompleteDlAuthCheckInvalidDlv2
 
   RESET_SESSION_INVALID_DL:
     response:
@@ -68,6 +68,7 @@ nestedJourneyStates:
       next:
         exitEventToEmit: failedDlAuthCheckInvalidDl
 
+  # PYIC-8896 Remove this state once these changes have been live long enough that no-one should be in this state.
   DL_DETAILS_INCORRECT_PAGE:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -461,12 +461,16 @@ nestedJourneyStates:
         exitEventToEmit: next
       anotherWay:
         exitEventToEmit: anotherWay
+      # PYIC-8896 remove incompleteDlAuthCheckInvalidDl once no-one can be in strategic-app-handle-result / DL_DETAILS_INCORRECT_PAGE
       incompleteDlAuthCheckInvalidDl:
         exitEventToEmit: incompleteDlAuthCheckInvalidDl
+      incompleteDlAuthCheckInvalidDlv2:
+        targetState: DL_DETAILS_INCORRECT_PAGE
       failedDlAuthCheckInvalidDl:
         exitEventToEmit: failedDlAuthCheckInvalidDl
       failWithCiFromApp:
         exitEventToEmit: failWithCiFromApp
+      # PYIC-8896 remove retryApp once no-one can be in strategic-app-handle-result / DL_DETAILS_INCORRECT_PAGE
       retryApp:
         checkJourneyContext:
           mamIphone:
@@ -478,3 +482,23 @@ nestedJourneyStates:
           dadAndroid:
             targetState: DAD_ANDROID_START_SESSION
         targetState: IDENTIFY_DEVICE
+
+  DL_DETAILS_INCORRECT_PAGE:
+    response:
+      type: page
+      pageId: uk-driving-licence-details-not-correct
+      context: strategicApp
+    events:
+      next:
+        checkJourneyContext:
+          mamIphone:
+            targetState: MOBILE_IPHONE_START_SESSION
+          mamAndroid:
+            targetState: MOBILE_ANDROID_START_SESSION
+          dadIphone:
+            targetState: DAD_IPHONE_START_SESSION
+          dadAndroid:
+            targetState: DAD_ANDROID_START_SESSION
+        targetState: IDENTIFY_DEVICE
+      end:
+        exitEventToEmit: incompleteDlAuthCheckInvalidDl


### PR DESCRIPTION

## Proposed changes
### What changed

Pull uk-driving-licence-details-not-correct out of strategic-app-handle-result and into strategic-app-triage

### Why did it change

To allow re-use of strategic-app-handle-result in a future PR

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8896](https://govukverify.atlassian.net/browse/PYIC-8896)

## Checklists

- [x] Production changes appropriately staged out


[PYIC-8896]: https://govukverify.atlassian.net/browse/PYIC-8896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ