### PR TITLE
BAU Tune DWP KBV return rate alarm to reduce noise

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3893,11 +3893,11 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub ${AWS::StackName}-DwpKbvCriReturnRateAlarm
-      AlarmDescription: "Alarm if DWP KBV CRI return rate is 0 for 3 consecutive 5-minute windows"
+      AlarmDescription: "Alarm if DWP KBV CRI return rate is 0 in a 15-minute window (ignores low traffic)"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue alarm-alerts-topic
-      EvaluationPeriods: 3
+      EvaluationPeriods: 1
       Threshold: 0
       ComparisonOperator: LessThanOrEqualToThreshold
       TreatMissingData: notBreaching
@@ -3910,7 +3910,7 @@ Resources:
               Dimensions:
                 - Name: cri
                   Value: dwpKbv
-            Period: 300
+            Period: 900 # 15mins
             Stat: Sum
           ReturnData: false
         - Id: returned
@@ -3921,11 +3921,12 @@ Resources:
               Dimensions:
                 - Name: cri
                   Value: dwpKbv
-            Period: 300
+            Period: 900 # 15mins
             Stat: Sum
           ReturnData: false
         - Id: returnRate
-          Expression: "returned / redirect"
+          # Ignore low traffic - if redirects<=5 return '1' (healthy)
+          Expression: "IF(redirect > 5, returned / redirect, 1)"
           Label: "DWP KBV CRI Return Rate"
           ReturnData: true
 


### PR DESCRIPTION
## Proposed changes
### What changed

- Widens window to single 15 minutes
- Adds floor to ignore low-traffic false positives

### Why did it change

- We've seen a few recent false positive alerts during times of low traffic

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
