### PR TITLE
PYIC-8669: Remove unused AppConfig resources. 

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -124,11 +124,7 @@ Conditions:
     - !Equals [ !Ref Environment, build ]
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, production ]
-  IsBuildStagingIntProd: !Or
-    - !Equals [ !Ref Environment, build]
-    - !Equals [ !Ref Environment, staging]
-    - !Equals [ !Ref Environment, integration]
-    - !Equals [ !Ref Environment, production]
+
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -2889,15 +2885,6 @@ Resources:
       FilterPattern: ""
       LogGroupName: !Ref ValidateAppConfigFunctionLogGroup
 
-  ValidateAppConfigInvokePermission:
-    Type: AWS::Lambda::Permission
-    Condition: IsBuildStagingIntProd
-    Properties:
-      Action: "lambda:InvokeFunction"
-      FunctionName: !Ref ValidateAppConfigFunction
-      Principal: "appconfig.amazonaws.com"
-      SourceArn: !Sub "arn:aws:appconfig:${AWS::Region}:${AWS::AccountId}:application/${AppConfigApplication}/configurationprofile/${AppConfigConfigurationProfile}"
-
   AppConfigPipelineValidateFunctionInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -4565,42 +4552,6 @@ Resources:
       Threshold: 1
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
-
-  # App Config
-  AppConfigApplication:
-    Condition: IsBuildStagingIntProd
-    Type: AWS::AppConfig::Application
-    Properties:
-      Name: !Sub "core-back-${Environment}"
-
-  AppConfigEnvironment:
-    Condition: IsBuildStagingIntProd
-    Type: AWS::AppConfig::Environment
-    Properties:
-      Name: !Sub "core-back-${Environment}"
-      ApplicationId: !Ref AppConfigApplication
-
-  AppConfigConfigurationProfile:
-    Condition: IsBuildStagingIntProd
-    Type: AWS::AppConfig::ConfigurationProfile
-    Properties:
-      Name: !Sub "core-back-${Environment}"
-      ApplicationId: !Ref AppConfigApplication
-      LocationUri: "hosted"
-      Validators:
-        - Type: LAMBDA
-          Content: !GetAtt ValidateAppConfigFunction.Arn
-
-  AppConfigDeploymentStrategy:
-    Condition: IsBuildStagingIntProd
-    Type: AWS::AppConfig::DeploymentStrategy
-    Properties:
-      Name: !Sub "core-back-${Environment}"
-      DeploymentDurationInMinutes: 0
-      FinalBakeTimeInMinutes: 0
-      GrowthFactor: 100
-      GrowthType: LINEAR
-      ReplicateTo: NONE
 
 Outputs:
   IPVCorePrivateAPIGatewayID:


### PR DESCRIPTION
⚠️ THOSE PRs NEED TO BE MERGED IN ORDER ⚠️ 

- [PYIC-8669: Switch to AppConfig Pipelines.](https://github.com/govuk-one-login/ipv-core-back/pull/3807)
- [PYIC-8669: Remove AppConfig services from config management lambda.
](https://github.com/govuk-one-login/ipv-core-common-infra/pull/1499)
- [PYIC-8669: Remove core-back config from old file.](https://github.com/govuk-one-login/ipv-core-common-infra/pull/1500)
- [PYIC-8669: Remove unused AppConfig resources.](https://github.com/govuk-one-login/ipv-core-back/pull/3806)


## Proposed changes
### What changed

- Removed unused AppConfig resources

### Why did it change

- We already switched to AppConfig Pipeline and we should clean the previous leftover resources.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8669](https://govukverify.atlassian.net/browse/PYIC-8669)

## Checklists

- [x] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8669]: https://govukverify.atlassian.net/browse/PYIC-8669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ