### PR TITLE
PYIC-8669: Switch to AppConfig Pipelines.

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -15,18 +15,9 @@ Globals:
     Environment:
       Variables:
         ENVIRONMENT: !Sub "${Environment}"
-        APP_CONFIG_ID: !If
-          - IsDevelopment
-          - !Sub "core-${Environment}"
-          - !Sub "core-back-${Environment}"
-        APP_CONFIG_ENVIRONMENT_ID: !If
-          - IsDevelopment
-          - !Sub "core-${Environment}"
-          - !Sub "core-back-${Environment}"
-        APP_CONFIG_PROFILE_ID: !If
-          - IsDevelopment
-          - !Sub "core-${Environment}"
-          - !Sub "core-back-${Environment}"
+        APP_CONFIG_ID: !Sub "core-${Environment}"
+        APP_CONFIG_ENVIRONMENT_ID: !Sub "core-${Environment}"
+        APP_CONFIG_PROFILE_ID: !Sub "core-${Environment}"
         DT_CONNECTION_BASE_URL: !If
           - UseDynatrace
           - !Sub


### PR DESCRIPTION
⚠️ THOSE PRs NEED TO BE MERGED IN ORDER ⚠️ 

- [PYIC-8669: Switch to AppConfig Pipelines.](https://github.com/govuk-one-login/ipv-core-back/pull/3807)
- [PYIC-8669: Remove AppConfig services from config management lambda.
](https://github.com/govuk-one-login/ipv-core-common-infra/pull/1499)
- [PYIC-8669: Remove core-back config from old file.](https://github.com/govuk-one-login/ipv-core-common-infra/pull/1500)
- [PYIC-8669: Remove unused AppConfig resources.](https://github.com/govuk-one-login/ipv-core-back/pull/3806)

## Proposed changes
### What changed

- Change AppConfig Application/Environment/Profile environment variables to adjust them with those created by AppConfig Pipelines

### Why did it change

- To integrate core-back application with AppConfig Pipelines

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8669](https://govukverify.atlassian.net/browse/PYIC-8669)

## Checklists

- [x] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out


[PYIC-8669]: https://govukverify.atlassian.net/browse/PYIC-8669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ