### PR TITLE
BAU Dump script for Product Healthcheck jps stats

### DIFF
--- a/scripts/product_healthcheck_jps_stats.sh
+++ b/scripts/product_healthcheck_jps_stats.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Script to output prod JPS (journey starts per second) metrics for the previous full month for Product Healthchecks.
+# Prints Overall Average JPS and "Sustained Peak" Average JPS (average JPS in the busiest 5-min fixed window) for each of:
+#   - overall journey start (session created)
+#   - identity proving journey start
+#   - identity reuse journey start (read-only reuse).
+# Uses our CloudWatch custom metrics, queries via AWS CLI.
+# See MANUAL OVERRIDE if you want to set a different env/timeframe. Defaults to prod and previous full month.
+# To run, first export the relevant AWS access env vars into your terminal.
+
+export TZ="Europe/London"
+
+# Automatic date calculation - previous full month
+START_SEC=$(date -v1d -v-1m -v0H -v0M -v0S "+%s")
+END_SEC=$(date -v1d -v0H -v0M -v0S "+%s")
+
+# --- MANUAL OVERRIDE ---
+ENV=production
+# To override timeframe uncomment these:
+#START_SEC=$(date -j -f "%Y-%m-%d %H:%M:%S" "2026-01-01 00:00:00" "+%s")
+#END_SEC=$(date -j -f "%Y-%m-%d %H:%M:%S" "2026-02-01 00:00:00" "+%s")
+
+TOTAL_SEC=$(( END_SEC - START_SEC ))
+
+# Turn seconds into ISO format
+START_AWS=$(date -r "$START_SEC" "+%Y-%m-%dT%H:%M:%S%z")
+END_AWS=$(date -r "$END_SEC" "+%Y-%m-%dT%H:%M:%S%z")
+
+# Fix the timezone for AWS (Changes +0000 to +00:00)
+START_AWS="${START_AWS:0:22}:${START_AWS:22:2}"
+END_AWS="${END_AWS:0:22}:${END_AWS:22:2}"
+
+NAMESPACE="CoreBackEmbeddedMetrics-$ENV"
+
+echo "=========================================================="
+echo " PERIOD: $START_AWS to $END_AWS"
+echo " TOTAL SECONDS: $TOTAL_SEC"
+echo "=========================================================="
+
+echo "Metric: Journey Start (session created)"
+aws cloudwatch get-metric-data --start-time "$START_AWS" --end-time "$END_AWS" --metric-data-queries '[
+    {"Id": "m1", "MetricStat": {"Metric": {"Namespace": "'$NAMESPACE'", "MetricName": "identityJourneyStart", "Dimensions": [{"Name": "Service", "Value": "initialise-ipv-session-'$ENV'"}]}, "Period": 300, "Stat": "Sum"}}
+]' | jq -r --arg sec "$TOTAL_SEC" '.MetricDataResults[0].Values | if length > 0 then "  Average JPS:        \(add / ($sec|tonumber) * 100 | round / 100)\n  Sustained Peak JPS: \(max / 300 * 100 | round / 100)" else "  No data" end'
+
+echo -e "\nMetric: Identity Proving Start"
+aws cloudwatch get-metric-data --start-time "$START_AWS" --end-time "$END_AWS" --metric-data-queries '[
+    {"Id": "s1", "MetricStat": {"Metric": {"Namespace": "'$NAMESPACE'", "MetricName": "identityProving", "Dimensions": [{"Name": "Service", "Value": "process-journey-event-'$ENV'"}]}, "Period": 300, "Stat": "Sum"}},
+    {"Id": "s2", "MetricStat": {"Metric": {"Namespace": "'$NAMESPACE'", "MetricName": "identityProving", "Dimensions": [{"Name": "Service", "Value": "check-existing-identity-'$ENV'"}]}, "Period": 300, "Stat": "Sum"}},
+    {"Id": "s3", "MetricStat": {"Metric": {"Namespace": "'$NAMESPACE'", "MetricName": "identityProving", "Dimensions": [{"Name": "Service", "Value": "check-reverification-identity-'$ENV'"}]}, "Period": 300, "Stat": "Sum"}},
+    {"Id": "total", "Expression": "s1+s2+s3", "ReturnData": true}
+]' | jq -r --arg sec "$TOTAL_SEC" '.MetricDataResults[] | select(.Id=="total") | .Values | if length > 0 then "  Average JPS:        \(add / ($sec|tonumber) * 100 | round / 100)\n  Sustained Peak JPS: \(max / 300 * 100 | round / 100)" else "  No data" end'
+
+echo -e "\nMetric: Identity Reuse Start"
+aws cloudwatch get-metric-data --start-time "$START_AWS" --end-time "$END_AWS" --metric-data-queries '[
+    {"Id": "m1", "MetricStat": {"Metric": {"Namespace": "'$NAMESPACE'", "MetricName": "identityReuse", "Dimensions": [{"Name": "Service", "Value": "check-existing-identity-'$ENV'"}]}, "Period": 300, "Stat": "Sum"}}
+]' | jq -r --arg sec "$TOTAL_SEC" '.MetricDataResults[0].Values | if length > 0 then "  Average JPS:        \(add / ($sec|tonumber) * 100 | round / 100)\n  Sustained Peak JPS: \(max / 300 * 100 | round / 100)" else "  No data" end'
+
+echo -e "\n=========================================================="


### PR DESCRIPTION
## Proposed changes
### What changed

Dump script that outputs prod jps stats for Product Healthchecks (previous full month by default).
Example output:
```
==========================================================
 PERIOD: 2026-02-01T00:00:00+00:00 to 2026-03-01T00:00:00+00:00
 TOTAL SECONDS: 2419200
==========================================================
Metric: Journey Start (session created)
  Average JPS:        1.21
  Sustained Peak JPS: 3.38

Metric: Identity Proving Start
  Average JPS:        0.81
  Sustained Peak JPS: 2.48

Metric: Identity Reuse Start
  Average JPS:        0.29
  Sustained Peak JPS: 1.03

==========================================================
```
Raw queries here: https://govukverify.atlassian.net/wiki/spaces/DID/pages/6108709068/Journey+metrics?focusedCommentId=6321995897

### Why did it change

Putting this somewhere so it's not just on my local machine and anyone can use it.

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
