### PR TITLE
PYIC-8969: remove legacy config key fallback for OAuth signing

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidator.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.message.StringMapMessage;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.JarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidationException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
+import uk.gov.di.ipv.core.library.exceptions.ConfigParseException;
 import uk.gov.di.ipv.core.library.helpers.JwtHelper;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.oauthkeyservice.OAuthKeyService;
@@ -210,10 +211,14 @@ public class JarValidator {
                         OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
                                 "JWT signature validation failed"));
             }
-        } catch (JOSEException | ParseException e) {
+        } catch (JOSEException
+                | ParseException
+                | ConfigParseException
+                | ConfigParameterNotFoundException e) {
             LOGGER.error(
-                    LogHelper.buildLogMessage(
-                            "Failed to parse JWT when attempting signature validation"));
+                    LogHelper.buildErrorMessage(
+                                    "Failed to parse JWT when attempting signature validation", e)
+                            .with(LOG_CLIENT_ID.getFieldName(), clientId));
             throw new JarValidationException(
                     OAuth2Error.INVALID_REQUEST_OBJECT.setDescription(
                             "Failed to parse JWT when attempting signature validation"));

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/validation/JarValidatorTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.ipv.core.initialiseipvsession.domain.StringListClaim;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.JarValidationException;
 import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidationException;
 import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
+import uk.gov.di.ipv.core.library.exceptions.ConfigParseException;
 import uk.gov.di.ipv.core.library.oauthkeyservice.OAuthKeyService;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 
@@ -36,7 +37,6 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.text.ParseException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Base64;
@@ -384,7 +384,7 @@ class JarValidatorTest {
     void validateRequestJwtShouldFailValidationChecksOnInvalidPublicJwk() throws Exception {
         stubClientIssuer();
         when(mockOAuthKeyService.getClientSigningKey(eq(CLIENT_ID_CLAIM), any()))
-                .thenThrow(new ParseException("beep", 1));
+                .thenThrow(new ConfigParseException("beep"));
         SignedJWT signedJWT = generateJWT(getValidClaimsSetValues());
 
         JarValidationException thrown =

--- a/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/domain/OAuthKeyServiceClientCredentialsSelector.java
+++ b/lambdas/issue-client-access-token/src/main/java/uk/gov/di/ipv/core/issueclientaccesstoken/domain/OAuthKeyServiceClientCredentialsSelector.java
@@ -8,10 +8,11 @@ import com.nimbusds.oauth2.sdk.auth.verifier.ClientCredentialsSelector;
 import com.nimbusds.oauth2.sdk.auth.verifier.Context;
 import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import uk.gov.di.ipv.core.library.exceptions.ConfigParameterNotFoundException;
+import uk.gov.di.ipv.core.library.exceptions.ConfigParseException;
 import uk.gov.di.ipv.core.library.oauthkeyservice.OAuthKeyService;
 
 import java.security.PublicKey;
-import java.text.ParseException;
 import java.util.List;
 
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
@@ -51,11 +52,15 @@ public class OAuthKeyServiceClientCredentialsSelector implements ClientCredentia
         try {
             return List.of(
                     oAuthKeyService.getClientSigningKey(clientId, jwsHeader).toECPublicKey());
-        } catch (ParseException | JOSEException e) {
+        } catch (JOSEException e) {
             throw new InvalidClientException(
                     String.format(
                             "Could not parse public key material for client ID '%s': %s",
                             clientId, e.getMessage()));
+        } catch (ConfigParseException | ConfigParameterNotFoundException e) {
+            throw new InvalidClientException(
+                    String.format(
+                            "Invalid client configuration for '%s': %s", clientId, e.getMessage()));
         }
     }
 }

--- a/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/domain/OAuthKeyServiceClientCredentialsSelectorTest.java
+++ b/lambdas/issue-client-access-token/src/test/java/uk/gov/di/ipv/core/issueclientaccesstoken/domain/OAuthKeyServiceClientCredentialsSelectorTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.core.library.exceptions.ConfigParseException;
 import uk.gov.di.ipv.core.library.oauthkeyservice.OAuthKeyService;
 
 import java.security.PublicKey;
-import java.text.ParseException;
 
 import static com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_JWT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -78,9 +78,9 @@ class OAuthKeyServiceClientCredentialsSelectorTest {
     }
 
     @Test
-    void selectPublicKeysShouldThrowIfOAuthKeyServiceThrows() throws Exception {
+    void selectPublicKeysShouldThrowIfOAuthKeyServiceThrows() {
         when(mockOAuthKeyService.getClientSigningKey(eq(TEST_CLIENT_ID), any()))
-                .thenThrow(new ParseException("oops", 0));
+                .thenThrow(new ConfigParseException("oops"));
 
         assertThrows(
                 InvalidClientException.class,

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
@@ -11,7 +11,8 @@ import lombok.extern.jackson.Jacksonized;
 public class ClientConfig {
     @NonNull String id;
     @NonNull String issuer;
+    String publicKeyMaterialForCoreToVerify; // to be removed once PYIC-8969 is merged
     @NonNull String validRedirectUrls;
     @NonNull String validScopes;
-    String jwksUrl; // Null for API test client configs
+    String jwksUrl; // to be made @NonNull once PYIC-8969 is merged
 }

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
@@ -11,7 +11,6 @@ import lombok.extern.jackson.Jacksonized;
 public class ClientConfig {
     @NonNull String id;
     @NonNull String issuer;
-    @NonNull String publicKeyMaterialForCoreToVerify;
     @NonNull String validRedirectUrls;
     @NonNull String validScopes;
     String jwksUrl; // Null for API test client configs

--- a/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
+++ b/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
@@ -70,7 +70,7 @@ public class OAuthKeyService {
                 .orElseThrow();
     }
 
-    public ECKey getClientSigningKey(String clientId, JWSHeader jwsHeader) throws ParseException {
+    public ECKey getClientSigningKey(String clientId, JWSHeader jwsHeader) {
         var keyId = jwsHeader.getKeyID();
         if (keyId == null) {
             LOGGER.error(

--- a/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
+++ b/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
@@ -110,12 +110,21 @@ public class OAuthKeyService {
     private URI getClientJwksUrl(String clientId) {
         try {
             var clientConfig = configService.getConfiguration().getClientConfig(clientId);
+
             if (clientConfig == null) {
                 return null;
             }
-            String jwksUrl = clientConfig.getJwksUrl();
-            return URI.create(jwksUrl);
-        } catch (ConfigParameterNotFoundException e) {
+
+            return URI.create(clientConfig.getJwksUrl());
+
+        } catch (ConfigParameterNotFoundException
+                | NullPointerException
+                | IllegalArgumentException e) {
+            LOGGER.error(
+                    LogHelper.buildErrorMessage(
+                            "Could not retrieve a valid JWKS URI from client config: {}",
+                            clientId));
+
             return null;
         }
     }

--- a/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
+++ b/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
@@ -109,10 +109,11 @@ public class OAuthKeyService {
 
     private URI getClientJwksUrl(String clientId) {
         try {
-            var jwksUrl = configService.getConfiguration().getClientConfig(clientId).getJwksUrl();
-            if (jwksUrl == null) {
+            var clientConfig = configService.getConfiguration().getClientConfig(clientId);
+            if (clientConfig == null) {
                 return null;
             }
+            String jwksUrl = clientConfig.getJwksUrl();
             return URI.create(jwksUrl);
         } catch (ConfigParameterNotFoundException e) {
             return null;
@@ -124,18 +125,18 @@ public class OAuthKeyService {
                 cachedJwkSets.compute(
                         jwksUrl,
                         (key, existingCachedJWKSet) -> {
-                            if (existingCachedJWKSet == null || existingCachedJWKSet.isExpired()) {
-                                try {
-                                    return createCachedJWKSet(jwksUrl);
-                                } catch (Exception e) {
-                                    LOGGER.error(
-                                            LogHelper.buildErrorMessage(
-                                                            "Error creating cached JWK set", e)
-                                                    .with(LOG_JWKS_URL.getFieldName(), jwksUrl));
-                                    return existingCachedJWKSet;
-                                }
+                            if (existingCachedJWKSet != null && !existingCachedJWKSet.isExpired()) {
+                                return existingCachedJWKSet;
                             }
-                            return existingCachedJWKSet;
+                            try {
+                                return createCachedJWKSet(jwksUrl);
+                            } catch (Exception e) {
+                                LOGGER.error(
+                                        LogHelper.buildErrorMessage(
+                                                        "Error creating cached JWK set", e)
+                                                .with(LOG_JWKS_URL.getFieldName(), jwksUrl));
+                                return existingCachedJWKSet;
+                            }
                         });
         if (cachedJWKSet == null) {
             throw new ConfigParseException(

--- a/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
+++ b/libs/oauth-key-service/src/main/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyService.java
@@ -73,41 +73,31 @@ public class OAuthKeyService {
     public ECKey getClientSigningKey(String clientId, JWSHeader jwsHeader) throws ParseException {
         var keyId = jwsHeader.getKeyID();
         if (keyId == null) {
-            LOGGER.warn(
-                    LogHelper.buildLogMessage(
-                                    "No key ID found in header, returning key from config")
+            LOGGER.error(
+                    LogHelper.buildLogMessage("No key ID found in header")
                             .with(LOG_CLIENT_ID.getFieldName(), clientId));
-            return ECKey.parse(
-                    configService
-                            .getConfiguration()
-                            .getClientConfig(clientId)
-                            .getPublicKeyMaterialForCoreToVerify());
+            throw new ConfigParseException(
+                    String.format("No key ID found in header for client: %s", clientId));
         }
 
         var jwksUrl = getClientJwksUrl(clientId);
         if (jwksUrl == null) {
-            LOGGER.warn(
-                    LogHelper.buildLogMessage("JWKS URL not configured, returning key from config")
+            LOGGER.error(
+                    LogHelper.buildLogMessage("JWKS URL not configured")
                             .with(LOG_CLIENT_ID.getFieldName(), clientId));
-            return ECKey.parse(
-                    configService
-                            .getConfiguration()
-                            .getClientConfig(clientId)
-                            .getPublicKeyMaterialForCoreToVerify());
+            throw new ConfigParameterNotFoundException(
+                    String.format("JWKS URL not configured for client: %s", clientId));
         }
 
         var keyByKeyId = getCachedJWKSet(jwksUrl).filter(SIG_USE_MATCHER).getKeyByKeyId(keyId);
         if (keyByKeyId == null) {
             LOGGER.warn(
-                    LogHelper.buildLogMessage("Key not found by key ID, returning key from config")
+                    LogHelper.buildLogMessage("Key not found by key ID in JWKS")
                             .with(LOG_KEY_ID.getFieldName(), keyId)
                             .with(LOG_CLIENT_ID.getFieldName(), clientId)
                             .with(LOG_JWKS_URL.getFieldName(), jwksUrl));
-            return ECKey.parse(
-                    configService
-                            .getConfiguration()
-                            .getClientConfig(clientId)
-                            .getPublicKeyMaterialForCoreToVerify());
+            throw new ConfigParseException(
+                    String.format("Key %s not found in JWKS for client %s", keyId, clientId));
         }
 
         LOGGER.info(
@@ -142,6 +132,7 @@ public class OAuthKeyService {
                                             LogHelper.buildErrorMessage(
                                                             "Error creating cached JWK set", e)
                                                     .with(LOG_JWKS_URL.getFieldName(), jwksUrl));
+                                    return existingCachedJWKSet;
                                 }
                             }
                             return existingCachedJWKSet;

--- a/libs/oauth-key-service/src/test/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyServiceTest.java
+++ b/libs/oauth-key-service/src/test/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyServiceTest.java
@@ -268,11 +268,10 @@ class OAuthKeyServiceTest {
         }
 
         @Test
-        void shouldThrowIfJwksUrlNotConfiguredForClient() {
+        void shouldThrowIfClientConfigNotFound() {
             // Arrange
             when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
-            when(mockConfig.getClientConfig(TEST_CLIENT_ID)).thenReturn(mockClientConfig);
-            when(mockClientConfig.getJwksUrl()).thenReturn(null);
+            when(mockConfig.getClientConfig(TEST_CLIENT_ID)).thenReturn(null);
 
             // Act & Assert
             assertThrows(

--- a/libs/oauth-key-service/src/test/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyServiceTest.java
+++ b/libs/oauth-key-service/src/test/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyServiceTest.java
@@ -33,6 +33,7 @@ import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -138,7 +139,7 @@ class OAuthKeyServiceTest {
 
         @Test
         @MockitoSettings(strictness = LENIENT)
-        void getEncryptionKeyShouldReturnKeyFromConfigIfNoJwksUrlAndNoCache() throws Exception {
+        void getEncryptionKeyShouldThrowIfNoJwksUrlAndNoCache() throws Exception {
             // Arrange
             var oauthConfigNoJwksUrl =
                     OauthCriConfig.builder()
@@ -158,9 +159,7 @@ class OAuthKeyServiceTest {
                     assertThrows(
                             ConfigParameterNotFoundException.class,
                             () -> oAuthKeyService.getEncryptionKey(oauthConfigNoJwksUrl));
-            assertEquals(
-                    "Parameter not found in config: JWKS URL is not set in CRI config",
-                    exception.getMessage());
+            assertTrue(exception.getMessage().contains("JWKS URL is not set in CRI config"));
         }
 
         @Test
@@ -171,6 +170,7 @@ class OAuthKeyServiceTest {
             // Second call returns cached key; HTTP not called again
             var secondKey = oAuthKeyService.getEncryptionKey(oauthCriConfig);
 
+            // Assert
             verify(mockHttpClient, times(1)).send(httpRequestCaptor.capture(), any());
             assertEquals(RSAKey.parse(RSA_ENCRYPTION_PUBLIC_JWK), secondKey);
         }
@@ -212,18 +212,19 @@ class OAuthKeyServiceTest {
     }
 
     @Nested
+    @MockitoSettings(strictness = LENIENT)
     class GetClientSigningKey {
         @BeforeEach
         void beforeEach() throws Exception {
-            when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
-            when(mockConfig.getClientConfig(TEST_CLIENT_ID)).thenReturn(mockClientConfig);
-
             when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
             when(mockHttpResponse.statusCode()).thenReturn(200);
         }
 
         @Test
         void shouldReturnKeyByKeyId() throws Exception {
+            // Arrange
+            when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
+            when(mockConfig.getClientConfig(TEST_CLIENT_ID)).thenReturn(mockClientConfig);
             when(mockClientConfig.getJwksUrl()).thenReturn(TEST_JWKS_ENDPOINT);
             when(mockHttpResponse.body())
                     .thenReturn(
@@ -233,46 +234,72 @@ class OAuthKeyServiceTest {
                                     EC_PRIVATE_KEY_JWK_WITH_DIFFERENT_KID,
                                     RSA_ENCRYPTION_PUBLIC_JWK));
 
+            // Act
             var signingKey =
                     oAuthKeyService.getClientSigningKey(TEST_CLIENT_ID, JWS_HEADER_WITH_KID);
+
+            // Assert
             assertEquals(ECKey.parse(EC_PRIVATE_KEY_JWK), signingKey);
         }
 
         @Test
-        @MockitoSettings(strictness = LENIENT)
-        void shouldReturnConfigKeyWhenNoKeyIdInHeader() throws Exception {
-            when(mockClientConfig.getPublicKeyMaterialForCoreToVerify())
-                    .thenReturn(EC_PRIVATE_KEY_JWK_WITH_DIFFERENT_KID);
-
+        void shouldThrowWhenNoKeyIdInHeader() throws Exception {
+            // Arrange
             var headerNoKid = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(null).build();
-            var signingKey = oAuthKeyService.getClientSigningKey(TEST_CLIENT_ID, headerNoKid);
 
-            assertEquals(ECKey.parse(EC_PRIVATE_KEY_JWK_WITH_DIFFERENT_KID), signingKey);
+            // Act & Assert
+            assertThrows(
+                    ConfigParseException.class,
+                    () -> oAuthKeyService.getClientSigningKey(TEST_CLIENT_ID, headerNoKid));
         }
 
         @Test
-        void shouldReturnConfigKeyWhenKeyIdNotFoundInJwkSet() throws Exception {
+        void shouldThrowWhenKeyIdNotFoundInJwkSet() throws Exception {
+            // Arrange
+            when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
+            when(mockConfig.getClientConfig(TEST_CLIENT_ID)).thenReturn(mockClientConfig);
             when(mockClientConfig.getJwksUrl()).thenReturn(TEST_JWKS_ENDPOINT);
             when(mockHttpResponse.body()).thenReturn("{\"keys\":[]}");
-            when(mockClientConfig.getPublicKeyMaterialForCoreToVerify())
-                    .thenReturn(EC_PRIVATE_KEY_JWK_WITH_DIFFERENT_KID);
 
-            var signingKey =
-                    oAuthKeyService.getClientSigningKey(TEST_CLIENT_ID, JWS_HEADER_WITH_KID);
-            assertEquals(ECKey.parse(EC_PRIVATE_KEY_JWK_WITH_DIFFERENT_KID), signingKey);
+            // Act & Assert
+            assertThrows(
+                    ConfigParseException.class,
+                    () -> oAuthKeyService.getClientSigningKey(TEST_CLIENT_ID, JWS_HEADER_WITH_KID));
         }
 
         @Test
-        @MockitoSettings(strictness = LENIENT)
-        void shouldReturnConfigKeyIfJwksUrlNotConfiguredForClient() throws Exception {
-            when(mockClientConfig.getJwksUrl())
-                    .thenThrow(new ConfigParameterNotFoundException("boop"));
-            when(mockClientConfig.getPublicKeyMaterialForCoreToVerify())
-                    .thenReturn(EC_PRIVATE_KEY_JWK_WITH_DIFFERENT_KID);
+        void shouldThrowIfJwksUrlNotConfiguredForClient() throws Exception {
+            // Arrange
+            when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
+            when(mockConfig.getClientConfig(TEST_CLIENT_ID)).thenReturn(mockClientConfig);
+            when(mockClientConfig.getJwksUrl()).thenReturn(null);
 
-            var signingKey =
+            // Act & Assert
+            assertThrows(
+                    ConfigParameterNotFoundException.class,
+                    () -> oAuthKeyService.getClientSigningKey(TEST_CLIENT_ID, JWS_HEADER_WITH_KID));
+        }
+
+        @Test
+        void shouldReturnExpiredCacheIfJwksFetchFails() throws Exception {
+            // Arrange
+            when(mockConfigService.getOauthKeyCacheDurationMins()).thenReturn(0L);
+            when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
+            when(mockConfig.getClientConfig(TEST_CLIENT_ID)).thenReturn(mockClientConfig);
+            when(mockClientConfig.getJwksUrl()).thenReturn(TEST_JWKS_ENDPOINT);
+            when(mockHttpResponse.body())
+                    .thenReturn(String.format("{\"keys\":[%s]}", EC_PRIVATE_KEY_JWK));
+
+            // Act
+            oAuthKeyService.getClientSigningKey(
+                    TEST_CLIENT_ID, JWS_HEADER_WITH_KID); // First call caches
+
+            when(mockHttpResponse.statusCode()).thenReturn(500);
+            var secondKey =
                     oAuthKeyService.getClientSigningKey(TEST_CLIENT_ID, JWS_HEADER_WITH_KID);
-            assertEquals(ECKey.parse(EC_PRIVATE_KEY_JWK_WITH_DIFFERENT_KID), signingKey);
+
+            // Assert
+            assertEquals(ECKey.parse(EC_PRIVATE_KEY_JWK), secondKey);
         }
     }
 }

--- a/libs/oauth-key-service/src/test/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyServiceTest.java
+++ b/libs/oauth-key-service/src/test/java/uk/gov/di/ipv/core/library/oauthkeyservice/OAuthKeyServiceTest.java
@@ -243,7 +243,7 @@ class OAuthKeyServiceTest {
         }
 
         @Test
-        void shouldThrowWhenNoKeyIdInHeader() throws Exception {
+        void shouldThrowWhenNoKeyIdInHeader() {
             // Arrange
             var headerNoKid = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(null).build();
 
@@ -254,7 +254,7 @@ class OAuthKeyServiceTest {
         }
 
         @Test
-        void shouldThrowWhenKeyIdNotFoundInJwkSet() throws Exception {
+        void shouldThrowWhenKeyIdNotFoundInJwkSet() {
             // Arrange
             when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
             when(mockConfig.getClientConfig(TEST_CLIENT_ID)).thenReturn(mockClientConfig);
@@ -268,7 +268,7 @@ class OAuthKeyServiceTest {
         }
 
         @Test
-        void shouldThrowIfJwksUrlNotConfiguredForClient() throws Exception {
+        void shouldThrowIfJwksUrlNotConfiguredForClient() {
             // Arrange
             when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
             when(mockConfig.getClientConfig(TEST_CLIENT_ID)).thenReturn(mockClientConfig);

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -62,29 +62,27 @@ core:
     orchStub:
       id: orchStub
       issuer: orchStub
-      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "openid"
       jwksUrl: "http://host.docker.internal:4500/.well-known/jwks.json"
     authStub:
       id: authStub
       issuer: authStub
-      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "reverification"
       jwksUrl: "http://host.docker.internal:4500/.well-known/jwks.json"
     orchApiTest:
       id: orchApiTest
       issuer: orchApiTest
-      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "openid"
+      jwksUrl: "https://orch.stubs.account.gov.uk/.well-known/jwks.json" # Use orch stub URL for CI/CD compatibility
     authApiTest:
       id: authApiTest
       issuer: authApiTest
-      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "reverification"
+      jwksUrl: "https://orch.stubs.account.gov.uk/.well-known/jwks.json" # Use orch stub URL for CI/CD compatibility
   ais:
     apiBaseUrl: "https://ais.stubs.account.gov.uk"
   cimit:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -63,29 +63,27 @@ core:
     orchStub:
       id: orchStub
       issuer: orchStub
-      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "openid"
       jwksUrl: "http://host.docker.internal:4500/.well-known/jwks.json"
     authStub:
       id: authStub
       issuer: authStub
-      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "reverification"
       jwksUrl: "http://host.docker.internal:4500/.well-known/jwks.json"
     orchApiTest:
       id: orchApiTest
       issuer: orchApiTest
-      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "openid"
+      jwksUrl: "https://orch.stubs.account.gov.uk/.well-known/jwks.json" # Use orch stub URL for CI/CD compatibility
     authApiTest:
       id: authApiTest
       issuer: authApiTest
-      publicKeyMaterialForCoreToVerify: "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM\",\"y\":\"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04\"}"
       validRedirectUrls: "http://localhost:4500/callback"
       validScopes: "reverification"
+      jwksUrl: "https://orch.stubs.account.gov.uk/.well-known/jwks.json" # Use orch stub URL for CI/CD compatibility
   ais:
     apiBaseUrl: "https://ais.stubs.account.gov.uk"
   cimit:


### PR DESCRIPTION
## Proposed changes
### What changed

- Remove fallback to hardcoded getPublicKeyMaterialForCoreToVerify in OAuthKeyService. 
- Enforce JWKS URL as the source of truth for client signing keys. 
- Return existing cached JWKS (even if expired) on fetch failure, otherwise fail outright.
- Update unit tests to assert ConfigException when JWKS keys or URLs are missing. 

### Why did it change

- A bit we seem to have missed in PYIC-7623, cleaning up the hardcoded signing keys for our OAuth clients Orch and Auth (for MFA Reset). They are both hosting JWKS endpoints we are consuming and the keys in staging have been rotated so the fallback config is now out of date anyway.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8969](https://govukverify.atlassian.net/browse/PYIC-8969)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-8969]: https://govukverify.atlassian.net/browse/PYIC-8969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ