### PR TITLE
BAU: Update Jackson to resolve vulnerability in versions >= 2.19.0, <2.21.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 awsSdk = "2.42.6"
-jackson = "2.21.0"
+jackson = "2.21.2"
 log4j = "2.25.3"
 mockito = "5.21.0"
 pact = "4.6.19"


### PR DESCRIPTION
## Proposed changes
### What changed

Update Jackson

### Why did it change

To resolve this vulnerability: https://github.com/govuk-one-login/ipv-core-back/security/dependabot/115

