### PR TITLE
PYIC-8718: refine page context object

### DIFF
--- a/api-tests/features/account-intervention/fail-open.feature
+++ b/api-tests/features/account-intervention/fail-open.feature
@@ -19,6 +19,7 @@ Feature: Fail open scenarios
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
   # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -61,6 +62,7 @@ Feature: Fail open scenarios
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
   # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/account-intervention/journey-ending-interventions.feature
+++ b/api-tests/features/account-intervention/journey-ending-interventions.feature
@@ -19,6 +19,7 @@ Feature: Journey ending interventions
     Then I get a 'pyi-triage-desktop-download-app' page response with context 'android' and pageContext
       | Context    | Value   |
       | smartphone | android |
+      | isAppOnly  | false   |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     And I poll for async DCMAW credential receipt
     Then the poll returns a '201'
@@ -61,6 +62,7 @@ Feature: Journey ending interventions
     Then I get a 'pyi-triage-desktop-download-app' page response with context 'android' and pageContext
       | Context    | Value   |
       | smartphone | android |
+      | isAppOnly  | false   |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     And I poll for async DCMAW credential receipt
     Then the poll returns a '201'
@@ -100,6 +102,7 @@ Feature: Journey ending interventions
     Then I get a 'pyi-triage-desktop-download-app' page response with context 'android' and pageContext
       | Context    | Value   |
       | smartphone | android |
+      | isAppOnly  | false   |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     And I poll for async DCMAW credential receipt
     Then the poll returns a '201'

--- a/api-tests/features/account-intervention/reprove-identity.feature
+++ b/api-tests/features/account-intervention/reprove-identity.feature
@@ -27,6 +27,7 @@ Feature: Reprove Identity Journey
       Then I get a 'pyi-triage-desktop-download-app' page response with context 'android' and pageContext
         | Context    | Value   |
         | smartphone | android |
+        | isAppOnly  | false   |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'

--- a/api-tests/features/app-cross-browser/p1-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p1-cross-browser.feature
@@ -18,6 +18,7 @@ Feature: P1 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context '<device>' and pageContext
         | Context    | Value    |
         | smartphone | <device> |
+        | isAppOnly  | false    |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
@@ -57,6 +58,7 @@ Feature: P1 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
@@ -95,6 +97,7 @@ Feature: P1 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
@@ -141,6 +144,7 @@ Feature: P1 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
@@ -184,6 +188,7 @@ Feature: P1 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
 
     Scenario: Successful mitigation with DL auth source check
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
@@ -301,6 +306,7 @@ Feature: P1 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback in a separate session
       Then I get a 'problem-different-browser' page response
@@ -333,6 +339,7 @@ Feature: P1 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/app-cross-browser/p2-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p2-cross-browser.feature
@@ -20,6 +20,7 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
@@ -56,6 +57,7 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
@@ -94,6 +96,7 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
@@ -138,6 +141,7 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback in a separate session
@@ -204,6 +208,7 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
 
     Scenario: Successful mitigation with DL auth source check
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
@@ -291,6 +296,7 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
 
     Scenario: Separate session DCMAW enhanced verification mitigation - successful - DL
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
@@ -407,6 +413,7 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -427,6 +434,7 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -19,6 +19,7 @@ Feature: Audit Events
     Then I get a 'pyi-triage-desktop-download-app' page response with context 'android' and pageContext
       | Context    | Value   |
       | smartphone | android |
+      | isAppOnly  | false   |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     And I poll for async DCMAW credential receipt
     Then the poll returns a '201'
@@ -332,6 +333,7 @@ Feature: Audit Events
     Then I get a 'pyi-triage-desktop-download-app' page response with context 'android' and pageContext
       | Context    | Value   |
       | smartphone | android |
+      | isAppOnly  | false   |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     And I poll for async DCMAW credential receipt
     Then the poll returns a '201'
@@ -485,6 +487,7 @@ Feature: Audit Events
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     And audit events for 'strategic-app-journey' are recorded [local only]
 
   @InitialisesDCMAWSessionState @QualityGateRegressionTest
@@ -506,6 +509,7 @@ Feature: Audit Events
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session

--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
@@ -50,6 +50,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -76,6 +77,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces an 'access_denied' error response
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
@@ -103,6 +105,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC with a CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -140,6 +143,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
 
     Scenario: Separate session DCMAW enhanced verification mitigation - successful - passport
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI

--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-f2f.feature
@@ -245,6 +245,7 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
@@ -47,6 +47,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a '<document-details>' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -116,6 +117,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -192,6 +194,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces an 'access_denied' error response
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
@@ -219,6 +222,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -247,6 +251,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
@@ -245,6 +245,7 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/cimit/p2-mortality-mitigation.feature
+++ b/api-tests/features/cimit/p2-mortality-mitigation.feature
@@ -17,6 +17,7 @@ Feature: Mortality check failures
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
           # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -225,6 +225,7 @@ Feature: Disabled CRI journeys
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/dl-auth-source-checks/p1-dl-auth-source-check.feature
+++ b/api-tests/features/dl-auth-source-checks/p1-dl-auth-source-check.feature
@@ -16,6 +16,7 @@ Feature: P1 Journeys with DL authoritative source check
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -54,6 +55,7 @@ Feature: P1 Journeys with DL authoritative source check
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -74,6 +76,7 @@ Feature: P1 Journeys with DL authoritative source check
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -114,6 +117,7 @@ Feature: P1 Journeys with DL authoritative source check
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/dl-auth-source-checks/p1-enhanced-verification-mitigation.feature
+++ b/api-tests/features/dl-auth-source-checks/p1-enhanced-verification-mitigation.feature
@@ -49,6 +49,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
 
     Scenario: Same session DCMAW enhanced verification mitigation - successful
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
@@ -126,6 +127,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -146,6 +148,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -190,6 +193,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
 
     Scenario: Separate session DCMAW enhanced verification mitigation - successful - DL
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
@@ -308,6 +312,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -345,6 +350,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
+++ b/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
@@ -17,6 +17,7 @@ Feature: P2 Journeys with DL authoritative source check
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -66,6 +67,7 @@ Feature: P2 Journeys with DL authoritative source check
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -96,6 +98,7 @@ Feature: P2 Journeys with DL authoritative source check
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -116,6 +119,7 @@ Feature: P2 Journeys with DL authoritative source check
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -146,6 +150,7 @@ Feature: P2 Journeys with DL authoritative source check
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -166,6 +171,7 @@ Feature: P2 Journeys with DL authoritative source check
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -343,6 +349,7 @@ Feature: P2 Journeys with DL authoritative source check
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -392,6 +399,7 @@ Feature: P2 Journeys with DL authoritative source check
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -432,6 +440,7 @@ Feature: P2 Journeys with DL authoritative source check
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-dva-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/dl-auth-source-checks/p2-enhanced-verification-mitigation.feature
+++ b/api-tests/features/dl-auth-source-checks/p2-enhanced-verification-mitigation.feature
@@ -49,6 +49,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
 
     Scenario: Same session DCMAW enhanced verification mitigation - successful
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
@@ -125,6 +126,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -145,6 +147,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -189,6 +192,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
 
     Scenario: Separate session DCMAW enhanced verification mitigation - successful - DL
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
@@ -307,6 +311,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -349,6 +354,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/dwp-kbv/p1-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p1-web-journey.feature
@@ -201,6 +201,7 @@ Feature: P1 Web Journeys - DWP KBV
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/dwp-kbv/p2-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p2-web-journey.feature
@@ -106,6 +106,7 @@ Feature: P2 Web document journey - DWP KBV
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -148,6 +149,7 @@ Feature: P2 Web document journey - DWP KBV
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/expired-driving-permit.feature
+++ b/api-tests/features/expired-driving-permit.feature
@@ -29,6 +29,7 @@ Feature: Expired DCMAW/Async DCMAW Driving Permits
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -69,6 +70,7 @@ Feature: Expired DCMAW/Async DCMAW Driving Permits
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     # This step will enqueue a VC with NBF set to whenever this test is ran
     # but driving permit expiry date set before the nbf (2022-01-18). This
     # means that, at reuse, the test will trigger the expired DL check but

--- a/api-tests/features/m1c-journeys.feature
+++ b/api-tests/features/m1c-journeys.feature
@@ -20,6 +20,7 @@ Feature: M1C Unavailable Journeys
       Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a '<details>' VC
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
@@ -81,6 +82,7 @@ Feature: M1C Unavailable Journeys
       Then I get a 'pyi-triage-desktop-download-app' page response with context 'android' and pageContext
         | Context    | Value   |
         | smartphone | android |
+        | isAppOnly  | false   |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'

--- a/api-tests/features/p1-app-journey.feature
+++ b/api-tests/features/p1-app-journey.feature
@@ -18,6 +18,7 @@ Feature: P1 app journey
     Then I get a 'pyi-triage-mobile-download-app' page response with context '<device>' and pageContext
       | Context    | Value    |
       | smartphone | <device> |
+      | isAppOnly  | false    |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -55,6 +56,7 @@ Feature: P1 app journey
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -77,6 +79,7 @@ Feature: P1 app journey
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -109,6 +112,7 @@ Feature: P1 app journey
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
 
   Scenario: MAM journey detected iphone - invalid OS version
     When I submit an 'appTriageSmartphone' event
@@ -119,8 +123,9 @@ Feature: P1 app journey
   Scenario: MAM journey detected android
     When I submit an 'mobileDownloadAndroid' event
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'android' and pageContext
-      | Context    | Value  |
+      | Context    | Value   |
       | smartphone | android |
+      | isAppOnly  | false   |
 
   Scenario Outline: : DAD successful app journey
     When I submit an 'appTriage' event
@@ -133,6 +138,7 @@ Feature: P1 app journey
     Then I get a 'pyi-triage-desktop-download-app' page response with context '<device>' and pageContext
       | Context    | Value    |
       | smartphone | <device> |
+      | isAppOnly  | false    |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
     And I poll for async DCMAW credential receipt
     Then the poll returns a '201'

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -146,6 +146,7 @@ Feature: P1 No Photo Id Journey
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -19,6 +19,7 @@ Feature: P2 App journey
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a '<details>' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -66,6 +67,7 @@ Feature: P2 App journey
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-driving-permit-with-breaching-ci' VC
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -104,6 +106,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -123,6 +126,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       # And the user returns from the app to core-front
       When I pass on the DCMAW callback
       Then I get an 'check-mobile-app-result' page response
@@ -137,6 +141,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
 
     Scenario: MAM journey detected iphone - invalid OS version
       When I submit an 'appTriageSmartphone' event
@@ -155,12 +160,14 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'android' and pageContext
         | Context    | Value   |
         | smartphone | android |
+        | isAppOnly  | false   |
 
     Scenario: MAM journey detected android
       When I submit an 'mobileDownloadAndroid' event
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'android' and pageContext
         | Context    | Value   |
         | smartphone | android |
+        | isAppOnly  | false   |
 
     Scenario: MAM Fail DCMAW with no CI - route to alternative IPV method
       When I submit an 'appTriage' event
@@ -173,6 +180,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -212,6 +220,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -248,6 +257,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -272,6 +282,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-desktop-download-app' page response with context '<device>' and pageContext
         | Context    | Value    |
         | smartphone | <device> |
+        | isAppOnly  | false    |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
@@ -306,6 +317,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
@@ -323,6 +335,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
@@ -364,6 +377,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces an '<error>' error response
       When I wait for 1 seconds for the async credential to be processed
       And I pass on the DCMAW callback

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -201,6 +201,7 @@ Feature: P2 App journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces an 'access_denied' error response
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response

--- a/api-tests/features/p2-reuse-journey.feature
+++ b/api-tests/features/p2-reuse-journey.feature
@@ -20,6 +20,7 @@ Feature: P2 Reuse journey
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -338,6 +338,7 @@ Feature: P2 Web document journey
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/recovery-journeys.feature
+++ b/api-tests/features/recovery-journeys.feature
@@ -24,6 +24,7 @@ Feature: Recovery journeys
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
 
     Scenario: Recovery event from CRI state - the same CRI is returned

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check.feature
@@ -224,70 +224,60 @@ Feature: Repeat fraud check journeys
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
       When I submit a 'back' event
       Then I get a 'confirm-your-details' page response
       When I submit a 'address-dob' event
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
       When I submit a 'back' event
       Then I get a 'confirm-your-details' page response
       When I submit a 'dob-family' event
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
       When I submit a 'back' event
       Then I get a 'confirm-your-details' page response
       When I submit a 'dob-given' event
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
       When I submit a 'back' event
       Then I get a 'confirm-your-details' page response
       When I submit a 'family-given' event
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
       When I submit a 'back' event
       Then I get a 'confirm-your-details' page response
       When I submit a 'address-family-given' event
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
       When I submit a 'back' event
       Then I get a 'confirm-your-details' page response
       When I submit a 'address-dob-family-given' event
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
       When I submit a 'back' event
       Then I get a 'confirm-your-details' page response
       When I submit a 'address-dob-family' event
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
       When I submit a 'back' event
       Then I get a 'confirm-your-details' page response
       When I submit a 'address-dob-given' event
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
       When I submit a 'back' event
       Then I get a 'confirm-your-details' page response
       When I submit a 'address-family-given' event
       Then I get a 'update-name-date-birth' page response with context 'rfcAccountDeletion' and pageContext
         | Context              | Value |
         | journeyType          | rfc   |
-        | allowAccountDeletion | true  |
 
   Rule: Match M1C Fraud Check Not Applicable
     Background:

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -17,6 +17,7 @@ Feature: Return exit codes
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -128,6 +129,7 @@ Feature: Return exit codes
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -163,6 +165,7 @@ Feature: Return exit codes
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -247,6 +250,7 @@ Feature: Return exit codes
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -286,6 +290,7 @@ Feature: Return exit codes
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/stored-identity/m1c-journeys.feature
+++ b/api-tests/features/stored-identity/m1c-journeys.feature
@@ -23,6 +23,7 @@ Feature: Stored Identity - M1C Outcomes
       Then I get a 'pyi-triage-desktop-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a '<details>' VC
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'

--- a/api-tests/features/stored-identity/p1-journeys.feature
+++ b/api-tests/features/stored-identity/p1-journeys.feature
@@ -18,6 +18,7 @@ Feature: Stored Identity - P1 journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -57,6 +58,7 @@ Feature: Stored Identity - P1 journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -92,6 +94,7 @@ Feature: Stored Identity - P1 journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -102,6 +102,7 @@ Feature: Stored Identity - P2 journeys
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -206,6 +207,7 @@ Feature: Stored Identity - P2 journeys
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/strategic-app-retry-routing.feature
+++ b/api-tests/features/strategic-app-retry-routing.feature
@@ -20,6 +20,7 @@ Feature: Strategic App Retry Journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context '<device-type>' and pageContext
       | Context    | Value         |
       | smartphone | <device-type> |
+      | isAppOnly  | false         |
     When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -36,6 +37,7 @@ Feature: Strategic App Retry Journeys
     Then I get a 'pyi-triage-mobile-download-app' page response with context '<device-type>' and pageContext
       | Context    | Value         |
       | smartphone | <device-type> |
+      | isAppOnly  | false         |
 
     Examples:
       | device-type |
@@ -57,6 +59,7 @@ Feature: Strategic App Retry Journeys
     Then I get a 'pyi-triage-desktop-download-app' page response with context '<device-type>' and pageContext
       | Context    | Value         |
       | smartphone | <device-type> |
+      | isAppOnly  | false         |
     When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
     And I poll for async DCMAW credential receipt
     Then the poll returns a '201'
@@ -70,6 +73,7 @@ Feature: Strategic App Retry Journeys
     Then I get a 'pyi-triage-desktop-download-app' page response with context '<device-type>' and pageContext
       | Context    | Value         |
       | smartphone | <device-type> |
+      | isAppOnly  | false         |
 
     Examples:
       | device-type |

--- a/api-tests/features/ticf/failed-ticf-responses.feature
+++ b/api-tests/features/ticf/failed-ticf-responses.feature
@@ -19,6 +19,7 @@ Feature: Failed TICF responses
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback
@@ -64,6 +65,7 @@ Feature: Failed TICF responses
     Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
       | Context    | Value  |
       | smartphone | iphone |
+      | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -50,6 +50,7 @@ Feature: TICF failed/error journeys
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/ticf/ticf-successful-responses.feature
+++ b/api-tests/features/ticf/ticf-successful-responses.feature
@@ -20,6 +20,7 @@ Feature: TICF successful responses
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -110,6 +111,7 @@ Feature: TICF successful responses
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -151,6 +153,7 @@ Feature: TICF successful responses
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -189,6 +192,7 @@ Feature: TICF successful responses
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -235,6 +239,7 @@ Feature: TICF successful responses
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -69,6 +69,7 @@ Feature: Handling unexpected CRI errors
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -327,6 +328,7 @@ Feature: Handling unexpected CRI errors
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -424,6 +426,7 @@ Feature: Handling unexpected CRI errors
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -532,6 +535,7 @@ Feature: Handling unexpected CRI errors
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
         # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -599,6 +603,7 @@ Feature: Handling unexpected CRI errors
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When I submit a 'preferNoApp' event
       Then I get a 'pyi-triage-buffer' page response
       When I submit an 'anotherWay' event
@@ -650,6 +655,7 @@ Feature: Handling unexpected CRI errors
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -700,6 +706,7 @@ Feature: Handling unexpected CRI errors
       Then I get a 'pyi-triage-mobile-download-app' page response with context 'iphone' and pageContext
         | Context    | Value  |
         | smartphone | iphone |
+        | isAppOnly  | false  |
       When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/AbstractPageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/AbstractPageContextValidator.java
@@ -21,12 +21,21 @@ public abstract class AbstractPageContextValidator implements IPageContextValida
                             .formatted(pageId));
         }
 
-        for (var key : pageContext.keySet()) {
-            if (!allowedContexts.contains(key)) {
-                throw new StepResponseException(
-                        "Context '%s' is not allowed for page '%s'. If required, please add to ALLOWED_CONTEXTS_BY_PAGE."
-                                .formatted(key, pageId));
-            }
+        var contextKeys = pageContext.keySet();
+        var disallowedKeys =
+                contextKeys.stream().filter(key -> !allowedContexts.contains(key)).findFirst();
+        if (disallowedKeys.isPresent()) {
+            throw new StepResponseException(
+                    "Context '%s' is not allowed for page '%s'. If required, please add to ALLOWED_CONTEXTS_BY_PAGE."
+                            .formatted(disallowedKeys.get(), pageId));
+        }
+
+        var missingKeys =
+                allowedContexts.stream().filter(key -> !contextKeys.contains(key)).findFirst();
+        if (missingKeys.isPresent()) {
+            throw new StepResponseException(
+                    "Required context '%s' is missing for page '%s'."
+                            .formatted(missingKeys.get(), pageId));
         }
     }
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -7,6 +7,8 @@ public class PageContextValidator extends AbstractPageContextValidator {
     private static final Map<String, Set<String>> ALLOWED_CONTEXTS_BY_PAGE =
             Map.ofEntries(
                     Map.entry("delete-handover", Set.of("journeyType")),
+                    Map.entry(
+                            "need-more-information-confirm-change-details", Set.of("journeyType")),
                     Map.entry("no-photo-id-security-questions-find-another-way", Set.of("reason")),
                     Map.entry("page-dcmaw-success", Set.of("noAddress")),
                     Map.entry("page-ipv-pending", Set.of("allowDeleteDetails")),

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -22,6 +22,7 @@ public class PageContextValidator extends AbstractPageContextValidator {
                     Map.entry("prove-identity-no-photo-id", Set.of("ninoOnly")),
                     Map.entry("pyi-details-deleted", Set.of("journeyType")),
                     Map.entry("pyi-no-match", Set.of("reason")),
+                    Map.entry("pyi-technical", Set.of("isUnrecoverable")),
                     Map.entry("pyi-triage-desktop-download-app", Set.of("smartphone", "isAppOnly")),
                     Map.entry("pyi-triage-mobile-download-app", Set.of("smartphone", "isAppOnly")),
                     Map.entry("pyi-triage-select-smartphone", Set.of("deviceType")),

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -28,9 +28,7 @@ public class PageContextValidator extends AbstractPageContextValidator {
                     Map.entry(
                             "uk-driving-licence-details-not-correct", Set.of("isFromStrategicApp")),
                     Map.entry("update-details-failed", Set.of("isExistingIdentityInvalid")),
-                    Map.entry(
-                            "update-name-date-birth",
-                            Set.of("journeyType", "allowAccountDeletion")));
+                    Map.entry("update-name-date-birth", Set.of("journeyType")));
 
     @Override
     Map<String, Set<String>> getAllowedContextsByPage() {

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -103,6 +103,7 @@ nestedJourneyStates:
       context: iphone
       pageContext:
         smartphone: iphone
+        isAppOnly: false
     events:
       next:
         exitEventToEmit: next
@@ -190,6 +191,7 @@ nestedJourneyStates:
       context: android
       pageContext:
         smartphone: android
+        isAppOnly: true
     events:
       next:
         exitEventToEmit: next
@@ -329,6 +331,7 @@ nestedJourneyStates:
       context: iphone
       pageContext:
         smartphone: iphone
+        isAppOnly: false
     events:
       next:
         targetState: STRATEGIC_APP_HANDLE_RESULT
@@ -402,6 +405,7 @@ nestedJourneyStates:
       context: android
       pageContext:
         smartphone: android
+        isAppOnly: false
     events:
       next:
         targetState: STRATEGIC_APP_HANDLE_RESULT

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -191,7 +191,7 @@ nestedJourneyStates:
       context: android
       pageContext:
         smartphone: android
-        isAppOnly: true
+        isAppOnly: false
     events:
       next:
         exitEventToEmit: next

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -185,7 +185,6 @@ states:
       pageId: update-name-date-birth
       context: rfcAccountDeletion
       pageContext:
-        allowAccountDeletion: true
         journeyType: rfc
     events:
       continue:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/journey-map-with-missing-page-contexts.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/journey-map-with-missing-page-contexts.yaml
@@ -1,0 +1,12 @@
+states:
+  PAGE_STATE:
+    response:
+      type: page
+      pageId: page-with-missing-context
+      context: test
+      pageContext:
+        reason: dropout
+    parent: PARENT_STATE
+    events:
+      eventOne:
+        targetState: ANOTHER_PAGE_STATE

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachineInitializerTest.java
@@ -56,9 +56,22 @@ class StateMachineInitializerTest {
     }
 
     @Test
-    void initializeShouldThrowIfPageContextValidationFails() {
+    void initializeShouldThrowIfPageContextValidationFailsDueToUnregisteredContext() {
         var journeyTypeMock = mock(IpvJourneyTypes.class);
         when(journeyTypeMock.getPath()).thenReturn("journey-map-with-invalid-page-contexts");
+        StateMachineInitializer initializer =
+                new StateMachineInitializer(
+                        journeyTypeMock,
+                        StateMachineInitializerMode.TEST,
+                        TEST_NESTED_JOURNEY_TYPES,
+                        testPageContextValidator);
+        assertThrows(StepResponseException.class, initializer::initialize);
+    }
+
+    @Test
+    void initializeShouldThrowIfPageContextValidationFailsDueToMissingRequiredContext() {
+        var journeyTypeMock = mock(IpvJourneyTypes.class);
+        when(journeyTypeMock.getPath()).thenReturn("journey-map-with-missing-page-contexts");
         StateMachineInitializer initializer =
                 new StateMachineInitializer(
                         journeyTypeMock,

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/TestPageContextValidator.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/TestPageContextValidator.java
@@ -5,7 +5,9 @@ import java.util.Set;
 
 public class TestPageContextValidator extends AbstractPageContextValidator {
     private static final Map<String, Set<String>> ALLOWED_CONTEXTS_BY_PAGE =
-            Map.ofEntries(Map.entry("page-id-for-page-state", Set.of("reason")));
+            Map.ofEntries(
+                    Map.entry("page-id-for-page-state", Set.of("reason")),
+                    Map.entry("page-with-missing-context", Set.of("reason", "journeyType")));
 
     @Override
     Map<String, Set<String>> getAllowedContextsByPage() {


### PR DESCRIPTION
## Proposed changes
### What changed/Why did it change

- remove unnecessary context for `update-name-date-birth` (`repeatFraudCheck` isn't used so there's really only two valid variants: rfc/reuse)
- add validation to make sure that, if a page defines a `pageContext`, it has a value for all the keys. This is so that we know the exact shape of the pageContext when using it in core-front
- remove accidentally committed empty pages

This is a follow-up PR of: https://github.com/govuk-one-login/ipv-core-back/pull/3821

Context:
We currently use a string `context` for routing to variants of a page. However, this has limitations because it is only a string. For example, [pyi-triage-desktop-download-app](https://identity.build.account.gov.uk/dev/template/pyi-triage-desktop-download-app/en?context=android) has four different context values: android, iphone, android-appOnly and iphone-appOnly which could make the logic in core-front messy/confusing. Instead, we can turn it into an object:
```
{
  isAppOnly: true/false,
  smartphone: iphone/android
}
```

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8718](https://govukverify.atlassian.net/browse/PYIC-8718)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-8718]: https://govukverify.atlassian.net/browse/PYIC-8718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ