### PR TITLE
PYIC-9018: Add temporary routing for notification banner.

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -211,6 +211,10 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -221,6 +225,10 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   NINO_START_PAGE:
     response:
@@ -239,6 +247,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -261,6 +273,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -558,6 +574,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -569,6 +589,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
 
@@ -641,6 +665,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -213,6 +213,10 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -226,6 +230,10 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   BANK_ACCOUNT_START_PAGE:
     response:
@@ -238,6 +246,10 @@ states:
           - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: PYI_ESCAPE_NO_PHOTO_ID
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -253,6 +265,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -609,6 +625,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -620,6 +640,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
   STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
@@ -691,6 +715,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # Common Mitigation states - invalid-dl/invalid-passport
 


### PR DESCRIPTION
## Proposed changes
### What changed

- Added temporary routing for links in notification banner that will navigate user to device sniffing page v2

### Why did it change

Experian will be undertaking its annual scheduled maintenance on Sunday, 29 March 2026, resulting in a 100% service outage within the planned window. All Experian services will be unavailable between 01:00 AM GMT (2am BST) and and 2.15 AM BST on Sunday 29 March.

The only ways users will be able to prove their identity (and to achieve an M1C profile in absence of Fraud checks ) during this period are :

- using the GOV.UK one login app with a chipped biometric passport

- using the GOV.UK  one login app with a chipped BRP

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9018](https://govukverify.atlassian.net/browse/PYIC-9018)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9018]: https://govukverify.atlassian.net/browse/PYIC-9018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ