### PR TITLE
BAU: log request size for TICF calls

### DIFF
--- a/libs/ticf-cri-service/src/main/java/uk/gov/di/ipv/core/library/ticf/TicfCriService.java
+++ b/libs/ticf-cri-service/src/main/java/uk/gov/di/ipv/core/library/ticf/TicfCriService.java
@@ -98,13 +98,19 @@ public class TicfCriService {
                                     .map(VerifiableCredential::getVcString)
                                     .toList());
 
+            var requestBody = OBJECT_MAPPER.writeValueAsString(ticfCriRequest);
+            LOGGER.info(
+                    LogHelper.buildLogMessage("TICF CRI request body size")
+                            .with(
+                                    "requestBodyBytes",
+                                    requestBody.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+                                            .length));
+
             var httpRequestBuilder =
                     HttpRequest.newBuilder()
                             .uri(ticfCriConfig.getCredentialUrl())
                             .timeout(Duration.ofSeconds(ticfCriConfig.getRequestTimeout()))
-                            .POST(
-                                    HttpRequest.BodyPublishers.ofString(
-                                            OBJECT_MAPPER.writeValueAsString(ticfCriRequest)));
+                            .POST(HttpRequest.BodyPublishers.ofString(requestBody));
             if (ticfCriConfig.isRequiresApiKey()) {
                 httpRequestBuilder.header(
                         X_API_KEY_HEADER,

--- a/libs/ticf-cri-service/src/main/java/uk/gov/di/ipv/core/library/ticf/TicfCriService.java
+++ b/libs/ticf-cri-service/src/main/java/uk/gov/di/ipv/core/library/ticf/TicfCriService.java
@@ -99,12 +99,7 @@ public class TicfCriService {
                                     .toList());
 
             var requestBody = OBJECT_MAPPER.writeValueAsString(ticfCriRequest);
-            LOGGER.info(
-                    LogHelper.buildLogMessage("TICF CRI request body size")
-                            .with(
-                                    "requestBodyBytes",
-                                    requestBody.getBytes(java.nio.charset.StandardCharsets.UTF_8)
-                                            .length));
+            logTicfRequestSize(requestBody);
 
             var httpRequestBuilder =
                     HttpRequest.newBuilder()
@@ -157,6 +152,20 @@ public class TicfCriService {
                     LogHelper.buildErrorMessage(
                             "Request to TICF CRI failed. Allowing user journey to continue", e));
             return List.of();
+        }
+    }
+
+    @ExcludeFromGeneratedCoverageReport
+    private void logTicfRequestSize(String requestBody) {
+        try {
+            LOGGER.info(
+                    LogHelper.buildLogMessage("TICF CRI request body size")
+                            .with(
+                                    "requestBodyBytes",
+                                    requestBody.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+                                            .length));
+        } catch (Exception e) {
+            LOGGER.warn(LogHelper.buildErrorMessage("Failed to log TICF CRI request body size", e));
         }
     }
 


### PR DESCRIPTION
## Proposed changes
### What changed

- log request byte size for TICF calls

### Why did it change

- TICF are looking to update their WAF rule to increase their payload size limit so we get less 403s. To help them get a better idea of how much to increase it by, we can temporarily log the request size

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>
