### PR TITLE
PYIC-8969: Remove unused variable and make jwkUrl NonNull

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/domain/ClientConfig.java
@@ -11,8 +11,7 @@ import lombok.extern.jackson.Jacksonized;
 public class ClientConfig {
     @NonNull String id;
     @NonNull String issuer;
-    String publicKeyMaterialForCoreToVerify; // to be removed once PYIC-8969 is merged
     @NonNull String validRedirectUrls;
     @NonNull String validScopes;
-    String jwksUrl; // to be made @NonNull once PYIC-8969 is merged
+    @NonNull String jwksUrl;
 }


### PR DESCRIPTION

## Proposed changes
### What changed

- Now the config PR has been merged we can tidy up the unused variable and make the jwksUrl @NonNull
- Subsequent PR: https://github.com/govuk-one-login/ipv-core-common-infra/pull/1504

### Why did it change

- This change had to come after staging out the previous PR's
- publicKeyMaterialForCoreToVerify is no longer used
- jwksUrl needs to be @NonNull

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8969](https://govukverify.atlassian.net/browse/PYIC-8969)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-8969]: https://govukverify.atlassian.net/browse/PYIC-8969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ