### PR TITLE
PYIC-9003: Add EVCS api updates featureFlag

### DIFF
--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -8,7 +8,8 @@ public enum CoreFeatureFlag implements FeatureFlag {
     STORED_IDENTITY_SERVICE("storedIdentityServiceEnabled"),
     SIS_VERIFICATION("sisVerificationEnabled"),
     AIS_STATE_CHECK("aisStateCheckEnabled"),
-    INTERVENTION_REPROVE_VIA_APP_ONLY("reproveViaAppOnlyEnabled");
+    INTERVENTION_REPROVE_VIA_APP_ONLY("reproveViaAppOnlyEnabled"),
+    EVCS_API_UPDATES("evcsApiUpdatesEnabled");
 
     private final String name;
 

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -356,6 +356,7 @@ core:
     storedIdentityServiceEnabled: true
     sisVerificationEnabled: true
     testFeatureFlag: false
+    evcsApiUpdatesEnabled: false
   features:
     testFeature:
       self:
@@ -366,6 +367,9 @@ core:
     disableTestFeatureFlag:
       featureFlags:
         testFeatureFlag: false
+    evcsApiUpdates:
+      featureFlags:
+        evcsApiUpdatesEnabled: true
     reproveViaAppOnly:
       featureFlags:
         reproveViaAppOnlyEnabled: true

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -359,8 +359,12 @@ core:
     drivingLicenceAuthCheck: true
     storedIdentityServiceEnabled: true
     sisVerificationEnabled: true
+    evcsApiUpdatesEnabled: false
 
   features:
+    evcsApiUpdates:
+        featureFlags:
+          evcsApiUpdatesEnabled: true
     storedIdentityService:
       featureFlags:
         storedIdentityServiceEnabled: true


### PR DESCRIPTION

## Proposed changes
### What changed

- Add a new feature flag to our config and local-running so we can safely test the EVCS API updates in Core.

### Why did it change

-  to hide the EVCS API changes in Core so we can test

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9003](https://govukverify.atlassian.net/browse/PYIC-9003)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9003]: https://govukverify.atlassian.net/browse/PYIC-9003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ