### PR TITLE
PYIC-8718: update journey-map to pass pageContext instead of context for displaying core-front pages

### DIFF
--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -141,11 +141,22 @@ const loadJourneyMaps = async <T>(
   return maps;
 };
 
-const getPageUrl = (id: string, context?: string): string => {
+const getPageUrl = (
+  id: string,
+  pageContext?: Record<string, unknown>,
+): string => {
   const baseUrl = `https://identity.build.account.gov.uk/dev/template/${encodeURIComponent(id)}/en`;
-  return context
-    ? `${baseUrl}?context=${encodeURIComponent(context)}`
+  return pageContext
+    ? `${baseUrl}?${buildQueryParamsFromPageContext(pageContext)}`
     : baseUrl;
+};
+
+const buildQueryParamsFromPageContext = (
+  pageContext: Record<string, unknown>,
+) => {
+  return Object.entries(pageContext)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
 };
 
 const getJourneyUrl = (id: string): string =>
@@ -500,7 +511,7 @@ const setupMermaidClickHandlers = (): void => {
     // Clicking a node twice opens the link
     if (selectedState === state) {
       if (def.pageId) {
-        window.open(getPageUrl(def.pageId, def.context), "_blank");
+        window.open(getPageUrl(def.pageId, def.pageContext), "_blank");
         return;
       }
       if (def.targetJourney) {
@@ -540,7 +551,7 @@ const setupMermaidClickHandlers = (): void => {
       nodeDesc.append(
         createLink(
           "Click here to view the page in build",
-          getPageUrl(def.pageId, def.context),
+          getPageUrl(def.pageId, def.pageContext),
         ),
       );
     }

--- a/journey-map/src/types.ts
+++ b/journey-map/src/types.ts
@@ -35,7 +35,7 @@ export interface JourneyResponse {
 
   // Page states
   pageId?: string;
-  context?: string;
+  pageContext?: Record<string, unknown>;
 
   // Process states
   lambda?: string;
@@ -43,6 +43,7 @@ export interface JourneyResponse {
 
   // CRI states
   criId?: string;
+  context?: string;
 
   // Error states
   statusCode?: number;


### PR DESCRIPTION
❗ ❗ **Must be merged after the core-front PR has been merged: https://github.com/govuk-one-login/ipv-core-front/pull/2698** ❗ ❗ 

I'm planning on merging this in once the core-front changes are live in build. This means that for a short period of time, when selecting a page state from the journey map, the pages won't show the correct variant. Since this is an internal tool and the time between each PR going live will be small, I figured it's not worth doing two separate deployments to make it backward compatible.

### What changed

- update journey-map so that we're passing the pageContext in the URL instead of the old `context`

This was tested locally by pointing the URL to my dev-deployed core-front.

### Why did it change

core-back is now sending a pageContext object intended to replace the existing context for page step responses.

We currently use a string context for routing to variants of a page. However, this has limitations because it is only a string. For example, [pyi-triage-desktop-download-app](https://identity.build.account.gov.uk/dev/template/pyi-triage-desktop-download-app/en?context=android) has four different context values: android, iphone, android-appOnly and iphone-appOnly which could make the logic in core-front messy/confusing. Instead, we can turn it into an object:
```
{
  isAppOnly: true/false,
  smartphone: iphone/android
}
```
### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8718](https://govukverify.atlassian.net/browse/PYIC-8718)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-8718]: https://govukverify.atlassian.net/browse/PYIC-8718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ