### PR TITLE
PYIC-9024: upgrade pact packages to latest version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ awsSdk = "2.42.6"
 jackson = "2.21.2"
 log4j = "2.25.3"
 mockito = "5.21.0"
-pact = "4.6.19"
+pact = "4.6.20"
 powertools = "2.10.0"
 
 [libraries]


### PR DESCRIPTION
## Proposed changes
### What changed

- upgrade packages packages to latest version

### Why did it change

to try and resolve these dependabot alerts: 
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/68
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/89
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/38
- https://github.com/govuk-one-login/ipv-core-back/security/dependabot/71

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9024](https://govukverify.atlassian.net/browse/PYIC-9024)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9024]: https://govukverify.atlassian.net/browse/PYIC-9024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ