### PR TITLE
PYIC-9010: Use new URL for SI invalidation when EVCS_API_UPDATES flag is enabled

### DIFF
--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hc.core5.http.HttpHeaders.AUTHORIZATION;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_RESPONSE_MESSAGE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_STATUS_CODE;
 
@@ -250,10 +251,14 @@ public class EvcsClient {
             throws EvcsServiceException {
         LOGGER.info(
                 LogHelper.buildLogMessage("Preparing to invalidate user's stored identity record"));
+
+        var invalidateEndPoint =
+                configService.enabled(EVCS_API_UPDATES) ? "invalidate/si" : "invalidate";
+
         try {
             HttpRequest.Builder httpRequestBuilder =
                     HttpRequest.newBuilder()
-                            .uri(getIdentityUri("invalidate"))
+                            .uri(getIdentityUri(invalidateEndPoint))
                             .POST(
                                     HttpRequest.BodyPublishers.ofString(
                                             OBJECT_MAPPER.writeValueAsString(

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
@@ -58,6 +58,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.evcs.client.EvcsClient.AFTER_KEY_PARAM;
 import static uk.gov.di.ipv.core.library.evcs.client.EvcsClient.VC_STATE_PARAM;
 import static uk.gov.di.ipv.core.library.evcs.client.EvcsClient.X_API_KEY_HEADER;
@@ -128,6 +129,7 @@ class EvcsClientTest {
         when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
         when(mockConfig.getEvcs()).thenReturn(mockEvcs);
         stubEvcsBaseUrl(EVCS_APPLICATION_URL);
+        lenient().when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(false);
         lenient()
                 .when(mockConfigService.getSecret(ConfigurationVariable.EVCS_API_KEY))
                 .thenReturn(EVCS_API_KEY);
@@ -625,6 +627,38 @@ class EvcsClientTest {
             assertFalse(httpRequest.headers().map().containsKey(AUTHORIZATION));
             assertTrue(httpRequest.headers().map().containsKey(X_API_KEY_HEADER));
             assertEquals("/v1/identity/invalidate", httpRequest.uri().getPath());
+
+            mockedBodyPublishers.verify(
+                    () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
+            var evcsInvalidateSiDto =
+                    OBJECT_MAPPER.readValue(
+                            stringCaptor.getAllValues().get(0),
+                            new TypeReference<EvcsInvalidateStoredIdentityDto>() {});
+            assertEquals(TEST_USER_ID, evcsInvalidateSiDto.userId());
+        }
+    }
+
+    @Test
+    void invalidateStoredIdentityRecordShouldSendRequestToNewUrlIfFlagEnabled() throws Exception {
+        // Arrange
+        when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.NO_CONTENT);
+        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
+
+        // Act
+        try (MockedStatic<HttpRequest.BodyPublishers> mockedBodyPublishers =
+                mockStatic(HttpRequest.BodyPublishers.class, CALLS_REAL_METHODS)) {
+            var res = evcsClient.invalidateStoredIdentityRecord(TEST_USER_ID);
+
+            // Assert
+            assertEquals(HttpStatusCode.NO_CONTENT, res.statusCode());
+            verify(mockHttpClient).send(httpRequestCaptor.capture(), any());
+            HttpRequest httpRequest = httpRequestCaptor.getValue();
+            assertEquals("POST", httpRequest.method());
+            assertTrue(httpRequest.bodyPublisher().isPresent());
+            assertFalse(httpRequest.headers().map().containsKey(AUTHORIZATION));
+            assertTrue(httpRequest.headers().map().containsKey(X_API_KEY_HEADER));
+            assertEquals("/v1/identity/invalidate/si", httpRequest.uri().getPath());
 
             mockedBodyPublishers.verify(
                     () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));


### PR DESCRIPTION
## Proposed changes
### What changed

Add ability to use new endpoint when invalidating stored identities

### Why did it change

The endpoint is changing

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9019](https://govukverify.atlassian.net/browse/PYIC-9010)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated


[PYIC-9019]: https://govukverify.atlassian.net/browse/PYIC-9019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ