### PR TITLE
Revert "PYIC-9034: Add temporary routing for notification banner"

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -211,10 +211,6 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -225,10 +221,6 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   NINO_START_PAGE:
     response:
@@ -246,10 +238,6 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -271,10 +259,6 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -570,10 +554,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -585,10 +565,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
 
@@ -661,10 +637,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -213,10 +213,6 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -230,10 +226,6 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   BANK_ACCOUNT_START_PAGE:
     response:
@@ -246,10 +238,6 @@ states:
           - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: PYI_ESCAPE_NO_PHOTO_ID
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -265,10 +253,6 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -623,10 +607,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -638,10 +618,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
   STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
@@ -713,10 +689,6 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
 
   # Common Mitigation states - invalid-dl/invalid-passport
 


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-back#3864