### PR TITLE
PYIC-8885: Add pageContext to document-start page

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -557,7 +557,9 @@ Feature: Audit Events
     When I start a new 'reverification' journey
     Then I get a 'you-can-change-security-code-method' page response
     When I submit a 'next' event
-    Then I get a 'page-ipv-identity-document-start' page response
+    Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -14,7 +14,9 @@ Feature: MFA reset journey
 
     Scenario: Successful MFA reset journey
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -26,7 +28,9 @@ Feature: MFA reset journey
 
     Scenario: Successful MFA reset journey - with DL auth source check
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -42,7 +46,9 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey with breaching CI - user can still reuse existing identity
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
@@ -56,7 +62,9 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - DCMAW error
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error
@@ -72,7 +80,9 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - failed verification score
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-verification-zero' details to the CRI stub
@@ -82,7 +92,9 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - non-matching identity
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'alice-passport-valid' details to the CRI stub
@@ -92,7 +104,9 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - failed DL auth source check
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -106,7 +120,9 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - incorrect DL details from DL auth source check - prove identity another way
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -126,7 +142,9 @@ Feature: MFA reset journey
 
     Scenario: Incorrect DL details from DL auth source check - allowed retry through the app
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -155,7 +173,9 @@ Feature: MFA reset journey
 
     Scenario: Successful MFA reset journey still using v1 app
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -183,7 +203,9 @@ Feature: MFA reset journey
       When I start a new 'reverification' journey
       Then I get a 'you-can-change-security-code-method' page response
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response
+      Then I get a 'page-ipv-identity-document-start' page response and pageContext
+        | Context       | Value |
+        | allowMfaReset | true  |
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -11,6 +11,7 @@ public class PageContextValidator extends AbstractPageContextValidator {
                             "need-more-information-confirm-change-details", Set.of("journeyType")),
                     Map.entry("no-photo-id-security-questions-find-another-way", Set.of("reason")),
                     Map.entry("page-dcmaw-success", Set.of("noAddress")),
+                    Map.entry("page-ipv-identity-document-start", Set.of("allowMfaReset")),
                     Map.entry("page-ipv-pending", Set.of("allowDeleteDetails")),
                     Map.entry("page-ipv-success", Set.of("journeyType")),
                     Map.entry("page-multiple-doc-check", Set.of("allowNino")),

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -77,6 +77,8 @@ states:
     response:
       type: page
       pageId: page-ipv-identity-document-start
+      pageContext:
+        allowMfaReset: true
     events:
       appTriage:
         targetState: APP_DOC_CHECK


### PR DESCRIPTION


## Proposed changes
### What changed

- Main triage page dynamic, but the V1 users would see a version of the page as it is in production today and V2 users would see a version of the page with the new content
- Subsequent PR: https://github.com/govuk-one-login/ipv-core-front/pull/2733

### Why did it change

- In preperaation for expired DL

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8885](https://govukverify.atlassian.net/browse/PYIC-8885)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-8885]: https://govukverify.atlassian.net/browse/PYIC-8885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ