### PR TITLE
PYIC-9047 Fix DCMAW-DL VC treated as expired when proved on day of expiry

### DIFF
--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -202,6 +202,9 @@ public class VcHelper {
         var nbf = drivingPermitVc.getClaimsSet().getNotBeforeTime();
 
         if (validityDurationInDays != null && nbf != null) {
+            // We pin both the VC issue time and DL expiry to the start of the day, for consistency
+            // with the hasExpired check and to ensure a licence is treated as valid until the very
+            // end of its expiry day.
             var vcIssueTime = nbf.toInstant();
             var startOfIssueDay = getLocalStartOfDay(vcIssueTime);
 
@@ -222,6 +225,9 @@ public class VcHelper {
 
     private static boolean hasExpired(
             Instant vcIssueTime, int validityDurationInDays, Clock clock) {
+        // We deliberately pin issue time to the start of the day. This ensures that all VCs issued
+        // on the same calendar day (e.g. Fraud and DCMAW-DL VCs) share the exact same 6-month
+        // expiry point.
         var endOfValidity =
                 getLocalStartOfDay(vcIssueTime)
                         .atZone(LONDON_TIMEZONE)

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelper.java
@@ -203,6 +203,7 @@ public class VcHelper {
 
         if (validityDurationInDays != null && nbf != null) {
             var vcIssueTime = nbf.toInstant();
+            var startOfIssueDay = getLocalStartOfDay(vcIssueTime);
 
             var dlExpiryDateString =
                     ((IdentityCheckCredential) drivingPermitVc.getCredential())
@@ -210,11 +211,10 @@ public class VcHelper {
                             .getDrivingPermit()
                             .getFirst()
                             .getExpiryDate();
-
-            var dlExpiryDate =
+            var startOfDlExpiryDay =
                     LocalDate.parse(dlExpiryDateString).atStartOfDay(LONDON_TIMEZONE).toInstant();
 
-            return dlExpiryDate.isBefore(vcIssueTime)
+            return startOfDlExpiryDay.isBefore(startOfIssueDay) // still valid on day of DL expiry
                     && hasExpired(vcIssueTime, validityDurationInDays, clock);
         }
         return false;
@@ -222,13 +222,16 @@ public class VcHelper {
 
     private static boolean hasExpired(
             Instant vcIssueTime, int validityDurationInDays, Clock clock) {
-        var startOfIssueDay =
-                vcIssueTime.atZone(LONDON_TIMEZONE).toLocalDate().atStartOfDay(LONDON_TIMEZONE);
-
-        var endOfValidity = startOfIssueDay.plusDays(validityDurationInDays);
+        var endOfValidity =
+                getLocalStartOfDay(vcIssueTime)
+                        .atZone(LONDON_TIMEZONE)
+                        .plusDays(validityDurationInDays);
         var now = ZonedDateTime.now(clock);
-
         return endOfValidity.isBefore(now) || endOfValidity.isEqual(now);
+    }
+
+    private static Instant getLocalStartOfDay(Instant time) {
+        return time.atZone(LONDON_TIMEZONE).toLocalDate().atStartOfDay(LONDON_TIMEZONE).toInstant();
     }
 
     public static boolean isFraudScoreOptionalForGpg45Evaluation(List<VerifiableCredential> vcs) {

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/helpers/VcHelperTest.java
@@ -578,7 +578,7 @@ class VcHelperTest {
                         vcDcmawDrivingPermitDvaExpiredSameDayAsNbf(), // expiry: 2020-10-01, nbf:
                         // 2020-10-01T13:30:00
                         180,
-                        "2020-10-02 00:00:00+0000",
+                        "2024-01-24 00:10:00+0100",
                         false),
                 Arguments.of(
                         "expired DL but within validity period, BST current time",


### PR DESCRIPTION
## Proposed changes
### What changed

- Updated DL expiry check to exclude DCMAW-DL VCs with issue date same as DL expiry date. Also corrected test case that failed to catch this scenario

### Why did it change

-  DL expiry lasts until the end of the day of expiry

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9047](https://govukverify.atlassian.net/browse/PYIC-9047)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9047]: https://govukverify.atlassian.net/browse/PYIC-9047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ