### PR TITLE
PYIC-8459: Update call to EVCS POST /identity endpoint to accept VCs.

### DIFF
--- a/api-tests/features/evcs-api-updates/p1-journey.feature
+++ b/api-tests/features/evcs-api-updates/p1-journey.feature
@@ -1,0 +1,128 @@
+@Build @QualityGateIntegrationTest @QualityGateRegressionTest
+Feature: P1 EvcsUpdates Journeys
+  Scenario: P1 No Photo Id Journey
+    Given I activate the 'evcsApiUpdates' feature set
+    And I start a new 'low-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-no-photo-id' page response and pageContext
+      | Context  | Value |
+      | ninoOnly | true  |
+    When I submit an 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details with attributes to the CRI stub
+      | Attribute | Values         |
+      | context   | "hmrc_check"   |
+    Then I get a 'nino' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'experianKbv' CRI response
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a 'P1' identity
+    And I have a stored identity record with a 'P1' max vot
+
+  Scenario: P1 Face to Face after DCMAW dropout
+    Given I activate the 'evcsApiUpdates' feature set
+    And I start a new 'low-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+    When I submit a 'neither' event
+    Then I get a 'pyi-triage-buffer' page response
+    When I submit an 'anotherWay' event
+    Then I get a 'page-multiple-doc-check' page response and pageContext
+      | Context   | Value |
+      | allowNino | true  |
+    When I submit an 'end' event
+    Then I get a 'pyi-post-office' page response
+    When I submit a 'next' event
+    Then I get a 'claimedIdentity' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get a 'f2f' CRI response
+    When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+    Then I get a 'page-face-to-face-handoff' page response
+
+  Rule: CIMIT
+    Background:
+      Given I activate the 'evcsApiUpdates' feature set
+      And I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response and pageContext
+        | Context   | Value |
+        | allowNino | true  |
+
+    Scenario Outline: Alternate doc mitigation via passport or DL
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-1' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P1' identity
+      And I have a stored identity record with a 'P1' max vot
+
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |

--- a/api-tests/features/evcs-api-updates/p2-journey.feature
+++ b/api-tests/features/evcs-api-updates/p2-journey.feature
@@ -1,0 +1,204 @@
+@Build @QualityGateIntegrationTest @QualityGateRegressionTest
+Feature: P2 EvcsUpdates journeys
+  Rule: Medium-confidence journeys
+    Background:
+      Given I activate the 'evcsApiUpdates' feature set
+      And I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+
+    Scenario: Successful M1C P2 identity
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+  Rule: Successful F2F journeys
+    Scenario Outline: Successful P2 identity via F2F using <doc> - <journey-type>
+      # Initial journey
+      Given I activate the 'evcsApiUpdates' feature set
+      And I start a new '<journey-type>' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit '<details>' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new '<journey-type>' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | journey-type           | doc      | details                      |
+        | high-medium-confidence | passport | kenneth-passport-valid       |
+        | medium-confidence      | DL       | kenneth-driving-permit-valid |
+
+  Rule: Reuse journey
+    Scenario: Successful P2 reuse journey
+    # First identity proving journey
+      Given I activate the 'evcsApiUpdates' feature set
+      And I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+    # Reuse journey
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-reuse' page response
+      And my proven user details match
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+  Rule: Match M1B
+    Background: Start journey with expired fraud check
+      Given the subject already has the following credentials
+        | CRI     | scenario                     |
+        | dcmaw   | kenneth-driving-permit-valid |
+        | address | kenneth-current              |
+      And the subject already has the following expired credentials
+        | CRI   | scenario        |
+        | fraud | kenneth-score-2 |
+      And I activate the 'evcsApiUpdates' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
+
+    Scenario: Fraud 6 Months Expiry + No Update
+      # Repeat fraud check with no update
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit expired 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-ipv-success' page response and pageContext
+        | Context     | Value |
+        | journeyType | coi   |
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Fraud 6 Months Expiry + Given Name Update
+      # Repeat fraud check with update name
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response and pageContext
+        | Context     | Value            |
+        | journeyType | repeatFraudCheck |
+      When I submit a 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-changed-given-name-passport-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response and pageContext
+        | Context   | Value |
+        | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response and pageContext
+        | Context     | Value |
+        | journeyType | coi   |
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And my identity 'GivenName' is 'Ken'
+      And my identity 'FamilyName' is 'Decerqueira'
+      And I have a stored identity record with a 'P3' max vot

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandler.java
@@ -35,6 +35,7 @@ import uk.gov.di.ipv.core.library.enums.TicfCode;
 import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
+import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
 import uk.gov.di.ipv.core.library.evcs.service.EvcsService;
 import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
@@ -82,6 +83,7 @@ import java.util.stream.Stream;
 import static java.lang.Boolean.TRUE;
 import static uk.gov.di.ipv.core.library.domain.Cri.TICF;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.ERROR_PROCESSING_TICF_CRI_RESPONSE;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
@@ -301,6 +303,14 @@ public class ProcessCandidateIdentityHandler
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();
+        } catch (FailedToCreateStoredIdentityForEvcsException e) {
+            LOGGER.error(
+                    LogHelper.buildErrorMessage("Failed to construct stored identity record", e));
+            return new JourneyErrorResponse(
+                            JOURNEY_ERROR_PATH,
+                            HttpStatusCode.INTERNAL_SERVER_ERROR,
+                            FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS)
+                    .toObjectMap();
         } catch (CredentialParseException e) {
             LOGGER.error(LogHelper.buildErrorMessage("Failed to parse credentials", e));
             return new JourneyErrorResponse(
@@ -351,7 +361,8 @@ public class ProcessCandidateIdentityHandler
                     HttpResponseExceptionWithErrorBody,
                     CredentialParseException,
                     CiExtractionException,
-                    AccountInterventionException {
+                    AccountInterventionException,
+                    FailedToCreateStoredIdentityForEvcsException {
         List<EvcsGetUserVCDto> evcsUserVcs = null;
         var userId = clientOAuthSessionItem.getUserId();
         var auditEventParameters =
@@ -463,7 +474,7 @@ public class ProcessCandidateIdentityHandler
             List<EvcsGetUserVCDto> evcsUserVcs,
             CandidateIdentityType processIdentityType,
             SharedAuditEventParameters auditEventParameters)
-            throws EvcsServiceException {
+            throws EvcsServiceException, FailedToCreateStoredIdentityForEvcsException {
         var achievedVot = ipvSessionItem.getVot();
         VotMatchingResult.VotAndProfile strongestMatchedVot =
                 Objects.isNull(votMatchingResult)

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -112,8 +112,7 @@ public class StoreIdentityService {
                             sessionCredentials,
                             evcsVcs,
                             strongestMatchedVot,
-                            achievedVot,
-                            false);
+                            achievedVot);
 
             return response.statusCode() == HttpStatusCode.ACCEPTED;
         } catch (FailedToCreateStoredIdentityForEvcsException e) {

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -55,7 +55,7 @@ public class StoreIdentityService {
             VotMatchingResult.VotAndProfile strongestMatchedVot,
             CandidateIdentityType identityType,
             SharedAuditEventParameters auditEventParameters)
-            throws EvcsServiceException {
+            throws EvcsServiceException, FailedToCreateStoredIdentityForEvcsException {
 
         var govukSigninJourneyId = auditEventParameters.auditEventUser().getGovukSigninJourneyId();
         var isPendingIdentity = identityType.equals(CandidateIdentityType.PENDING);
@@ -95,7 +95,7 @@ public class StoreIdentityService {
             Vot achievedVot,
             VotMatchingResult.VotAndProfile strongestMatchedVot,
             boolean isPendingIdentity)
-            throws EvcsServiceException {
+            throws EvcsServiceException, FailedToCreateStoredIdentityForEvcsException {
 
         if (isPendingIdentity) {
             LOGGER.info(LogHelper.buildLogMessage("Storing user VCs with POST"));
@@ -104,30 +104,19 @@ public class StoreIdentityService {
             return false;
         }
 
-        try {
-            var response =
-                    evcsService.storeStoredIdentityRecordAndVcs(
-                            userId,
-                            govukSigninJourneyId,
-                            sessionCredentials,
-                            evcsVcs,
-                            strongestMatchedVot,
-                            achievedVot);
+        LOGGER.info(
+                LogHelper.buildLogMessage(
+                        "Storing user identity records and VCs in one transaction."));
+        var response =
+                evcsService.storeStoredIdentityRecordAndVcs(
+                        userId,
+                        govukSigninJourneyId,
+                        sessionCredentials,
+                        evcsVcs,
+                        strongestMatchedVot,
+                        achievedVot);
 
-            return response.statusCode() == HttpStatusCode.ACCEPTED;
-
-            // TODO: IF we fail to store SI should we continue the journey or throw an exception?
-        } catch (FailedToCreateStoredIdentityForEvcsException e) {
-            LOGGER.warn(
-                    LogHelper.buildLogMessage(
-                            "Failed to create stored identity record. Stored identity record was not saved to EVCS."));
-        } catch (EvcsServiceException e) {
-            LOGGER.warn(
-                    LogHelper.buildLogMessage(
-                            "Failed to store stored identity record to EVCS. Continuing user journey."));
-        }
-
-        return false;
+        return response.statusCode() == HttpStatusCode.ACCEPTED;
     }
 
     private boolean storeIdentityLegacy(

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -57,37 +57,111 @@ public class StoreIdentityService {
             SharedAuditEventParameters auditEventParameters)
             throws EvcsServiceException {
 
-        var hasStoredSiObject = false;
+        var govukSigninJourneyId = auditEventParameters.auditEventUser().getGovukSigninJourneyId();
         var isPendingIdentity = identityType.equals(CandidateIdentityType.PENDING);
+        var hasStoredSiObject = false;
+
+        if (configService.enabled(CoreFeatureFlag.EVCS_API_UPDATES)) {
+            hasStoredSiObject =
+                    storeIdentityUpdated(
+                            userId,
+                            govukSigninJourneyId,
+                            sessionCredentials,
+                            evcsVcs,
+                            achievedVot,
+                            strongestMatchedVot,
+                            isPendingIdentity);
+        } else {
+            hasStoredSiObject =
+                    storeIdentityLegacy(
+                            userId,
+                            sessionCredentials,
+                            evcsVcs,
+                            achievedVot,
+                            strongestMatchedVot,
+                            isPendingIdentity);
+        }
+
+        LOGGER.info(LogHelper.buildLogMessage("Identity successfully stored"));
+        sendIdentityStoredEvent(
+                strongestMatchedVot, identityType, auditEventParameters, hasStoredSiObject);
+    }
+
+    private boolean storeIdentityUpdated(
+            String userId,
+            String govukSigninJourneyId,
+            List<VerifiableCredential> sessionCredentials,
+            List<EvcsGetUserVCDto> evcsVcs,
+            Vot achievedVot,
+            VotMatchingResult.VotAndProfile strongestMatchedVot,
+            boolean isPendingIdentity)
+            throws EvcsServiceException {
+
+        if (isPendingIdentity) {
+            LOGGER.info(LogHelper.buildLogMessage("Storing user VCs with POST"));
+            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
+                    userId, sessionCredentials, evcsVcs, true);
+            return false;
+        }
+
+        try {
+            var response =
+                    evcsService.storeStoredIdentityRecordAndVcs(
+                            userId,
+                            govukSigninJourneyId,
+                            sessionCredentials,
+                            evcsVcs,
+                            strongestMatchedVot,
+                            achievedVot,
+                            false);
+
+            return response.statusCode() == HttpStatusCode.ACCEPTED;
+        } catch (FailedToCreateStoredIdentityForEvcsException e) {
+            LOGGER.warn(
+                    LogHelper.buildLogMessage(
+                            "Failed to create stored identity record. Stored identity record was not saved to EVCS."));
+        } catch (EvcsServiceException e) {
+            LOGGER.warn(
+                    LogHelper.buildLogMessage(
+                            "Failed to store stored identity record to EVCS. Continuing user journey."));
+        }
+
+        return false;
+    }
+
+    private boolean storeIdentityLegacy(
+            String userId,
+            List<VerifiableCredential> sessionCredentials,
+            List<EvcsGetUserVCDto> evcsVcs,
+            Vot achievedVot,
+            VotMatchingResult.VotAndProfile strongestMatchedVot,
+            boolean isPendingIdentity)
+            throws EvcsServiceException {
 
         LOGGER.info(LogHelper.buildLogMessage("Storing user VCs with POST"));
         evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                 userId, sessionCredentials, evcsVcs, isPendingIdentity);
 
-        if (configService.enabled(CoreFeatureFlag.EVCS_API_UPDATES) && !isPendingIdentity) {
-            // TODO Store SI with vcs
-
-        } else if (!isPendingIdentity) {
-            try {
-                var httpResponse =
-                        evcsService.storeStoredIdentityRecord(
-                                userId, sessionCredentials, strongestMatchedVot, achievedVot);
-                hasStoredSiObject = httpResponse.statusCode() == HttpStatusCode.ACCEPTED;
-            } catch (FailedToCreateStoredIdentityForEvcsException e) {
-                LOGGER.warn(
-                        LogHelper.buildLogMessage(
-                                "Failed to create stored identity record. Stored identity record was not saved to EVCS."));
-            } catch (EvcsServiceException e) {
-                LOGGER.warn(
-                        LogHelper.buildLogMessage(
-                                "Failed to store stored identity record to EVCS. Continuing user journey."));
-            }
+        if (isPendingIdentity) {
+            return false;
         }
 
-        LOGGER.info(LogHelper.buildLogMessage("Identity successfully stored"));
+        try {
+            var response =
+                    evcsService.storeStoredIdentityRecord(
+                            userId, sessionCredentials, strongestMatchedVot, achievedVot);
+            return response.statusCode() == HttpStatusCode.ACCEPTED;
+        } catch (FailedToCreateStoredIdentityForEvcsException e) {
+            LOGGER.warn(
+                    LogHelper.buildLogMessage(
+                            "Failed to create stored identity record. Stored identity record was not saved to EVCS."));
+        } catch (EvcsServiceException e) {
+            LOGGER.warn(
+                    LogHelper.buildLogMessage(
+                            "Failed to store stored identity record to EVCS. Continuing user journey."));
+        }
 
-        sendIdentityStoredEvent(
-                strongestMatchedVot, identityType, auditEventParameters, hasStoredSiObject);
+        return false;
     }
 
     private void sendIdentityStoredEvent(

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -7,6 +7,7 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionCandidateIdentityType;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
+import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.CandidateIdentityType;
 import uk.gov.di.ipv.core.library.enums.Vot;
@@ -58,11 +59,15 @@ public class StoreIdentityService {
 
         var hasStoredSiObject = false;
         var isPendingIdentity = identityType.equals(CandidateIdentityType.PENDING);
+
         LOGGER.info(LogHelper.buildLogMessage("Storing user VCs with POST"));
         evcsService.storeCompletedOrPendingIdentityWithPostVcs(
                 userId, sessionCredentials, evcsVcs, isPendingIdentity);
 
-        if (!isPendingIdentity) {
+        if (configService.enabled(CoreFeatureFlag.EVCS_API_UPDATES) && !isPendingIdentity) {
+            // TODO Store SI with vcs
+
+        } else if (!isPendingIdentity) {
             try {
                 var httpResponse =
                         evcsService.storeStoredIdentityRecord(

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -115,6 +115,8 @@ public class StoreIdentityService {
                             achievedVot);
 
             return response.statusCode() == HttpStatusCode.ACCEPTED;
+
+            // TODO: IF we fail to store SI should we continue the journey or throw an exception?
         } catch (FailedToCreateStoredIdentityForEvcsException e) {
             LOGGER.warn(
                     LogHelper.buildLogMessage(

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/ProcessCandidateIdentityHandlerTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.ipv.core.library.dto.AccountInterventionState;
 import uk.gov.di.ipv.core.library.enums.CandidateIdentityType;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
+import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
 import uk.gov.di.ipv.core.library.evcs.service.EvcsService;
 import uk.gov.di.ipv.core.library.exceptions.CiExtractionException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
@@ -76,6 +77,7 @@ import static uk.gov.di.ipv.core.library.ais.TestData.createResetPasswordAisStat
 import static uk.gov.di.ipv.core.library.ais.TestData.createSuspendedIdentityAisState;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.ERROR_PROCESSING_TICF_CRI_RESPONSE;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_AT_EVCS_HTTP_REQUEST_SEND;
+import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_GET_CREDENTIAL;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
@@ -1419,6 +1421,57 @@ class ProcessCandidateIdentityHandlerTest {
             assertEquals(500, response.get("statusCode"));
             assertEquals(
                     RECEIVED_NON_200_RESPONSE_STATUS_CODE.getMessage(), response.get("message"));
+        }
+
+        @Test
+        void shouldReturnJourneyErrorWhenFailingToCreateStoredIdentityRecord() throws Exception {
+            // Arrange
+            var ticfVcs = List.of(vcTicf());
+            when(evcsService.getUserVCs(
+                            USER_ID,
+                            EVCS_ACCESS_TOKEN,
+                            EvcsVCState.CURRENT,
+                            EvcsVCState.PENDING_RETURN))
+                    .thenReturn(List.of());
+            when(checkCoiService.isCoiCheckSuccessful(
+                            eq(ipvSessionItem),
+                            eq(clientOAuthSessionItem),
+                            eq(STANDARD),
+                            eq(List.of()),
+                            any(),
+                            any()))
+                    .thenReturn(true);
+            when(votMatcher.findStrongestMatches(anyList(), eq(List.of()), eq(List.of()), eq(true)))
+                    .thenReturn(P2_M1A_VOT_MATCH_RESULT);
+            when(userIdentityService.areVcsCorrelated(List.of())).thenReturn(true);
+            when(configService.isCredentialIssuerEnabled(Cri.TICF.getId())).thenReturn(true);
+            when(ticfCriService.getTicfVc(clientOAuthSessionItem, ipvSessionItem))
+                    .thenReturn(ticfVcs);
+            when(cimitUtilityService.getContraIndicatorsFromVc(any(), any()))
+                    .thenReturn(List.of())
+                    .thenReturn(List.of());
+            when(cimitUtilityService.isBreachingCiThreshold(any(), any())).thenReturn(false);
+            doThrow(
+                            new FailedToCreateStoredIdentityForEvcsException(
+                                    "Failed to create stored identity record."))
+                    .when(storeIdentityService)
+                    .storeIdentity(any(), anyList(), anyList(), any(), any(), any(), any());
+
+            var request =
+                    requestBuilder
+                            .lambdaInput(
+                                    Map.of(PROCESS_IDENTITY_TYPE, CandidateIdentityType.NEW.name()))
+                            .build();
+
+            // Act
+            var response = processCandidateIdentityHandler.handleRequest(request, context);
+
+            // Assert
+            assertEquals(JOURNEY_ERROR_PATH, response.get("journey"));
+            assertEquals(500, response.get("statusCode"));
+            assertEquals(
+                    FAILED_TO_CREATE_STORED_IDENTITY_FOR_EVCS.getMessage(),
+                    response.get("message"));
         }
 
         @Test

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionCandidateIdentityType;
+import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.CandidateIdentityType;
@@ -45,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -449,5 +451,105 @@ class StoreIdentityServiceTest {
                                 STRONGEST_MATCHED_VOT,
                                 CandidateIdentityType.NEW,
                                 sharedAuditEventParameters));
+    }
+
+    @Nested
+    class StoreIdentityWithEvcsApiUpdates {
+
+        @BeforeEach
+        void setup() {
+            when(configService.enabled(CoreFeatureFlag.EVCS_API_UPDATES)).thenReturn(true);
+            when(configService.getComponentId()).thenReturn("https://core-component.example");
+        }
+
+        private static Stream<Arguments> identityTypes() {
+            return Stream.of(
+                    Arguments.of(CandidateIdentityType.NEW),
+                    Arguments.of(CandidateIdentityType.UPDATE),
+                    Arguments.of(CandidateIdentityType.EXISTING));
+        }
+
+        @ParameterizedTest
+        @MethodSource("identityTypes")
+        void shouldSuccessfullyStoreNewIdentityAndSiAndSendAuditEvent(
+                CandidateIdentityType candidateIdentityType) throws Exception {
+            // Arrange
+            when(evcsService.storeStoredIdentityRecordAndVcs(
+                            any(), any(), any(), any(), any(), any()))
+                    .thenReturn(httpResponse);
+            when(httpResponse.statusCode()).thenReturn(HttpStatusCode.ACCEPTED);
+
+            // Act
+            storeIdentityService.storeIdentity(
+                    USER_ID,
+                    VCS,
+                    List.of(),
+                    P2,
+                    STRONGEST_MATCHED_VOT,
+                    candidateIdentityType,
+                    sharedAuditEventParameters);
+
+            // Assert
+            verify(evcsService, never())
+                    .storeCompletedOrPendingIdentityWithPostVcs(any(), any(), any(), anyBoolean());
+            verify(evcsService, times(1))
+                    .storeStoredIdentityRecordAndVcs(
+                            USER_ID, GOVUK_JOURNEY_ID, VCS, List.of(), STRONGEST_MATCHED_VOT, P2);
+
+            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
+            var auditEvent = auditEventCaptor.getValue();
+
+            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
+            assertEquals(
+                    P2,
+                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
+            assertEquals(
+                    candidateIdentityType,
+                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
+                            .identityType());
+            assertTrue(
+                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
+                            .sisRecordCreated());
+            assertEquals(COMPONENT_ID, auditEvent.getComponentId());
+            assertEquals(testAuditEventUser, auditEvent.getUser());
+        }
+
+        @Test
+        void
+                shouldSuccessfullyStorePendingIdentityWithPostPatchEndpointAndNotStoreSiAndSendAuditEvent()
+                        throws Exception {
+            // Act
+            storeIdentityService.storeIdentity(
+                    USER_ID,
+                    VCS,
+                    List.of(),
+                    P2,
+                    STRONGEST_MATCHED_VOT,
+                    CandidateIdentityType.PENDING,
+                    sharedAuditEventParameters);
+
+            // Assert
+            verify(evcsService, times(1))
+                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), true);
+            verify(evcsService, never())
+                    .storeStoredIdentityRecordAndVcs(any(), any(), any(), any(), any(), any());
+
+            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
+            var auditEvent = auditEventCaptor.getValue();
+
+            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
+            assertEquals(
+                    P2,
+                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
+            assertEquals(
+                    CandidateIdentityType.PENDING,
+                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
+                            .identityType());
+            assertFalse(
+                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
+                            .sisRecordCreated());
+            assertEquals(COMPONENT_ID, auditEvent.getComponentId());
+            assertEquals(testAuditEventUser, auditEvent.getUser());
+        }
     }
 }

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
@@ -459,7 +459,6 @@ class StoreIdentityServiceTest {
         @BeforeEach
         void setup() {
             when(configService.enabled(CoreFeatureFlag.EVCS_API_UPDATES)).thenReturn(true);
-            when(configService.getComponentId()).thenReturn("https://core-component.example");
         }
 
         private static Stream<Arguments> identityTypes() {
@@ -478,6 +477,7 @@ class StoreIdentityServiceTest {
                             any(), any(), any(), any(), any(), any()))
                     .thenReturn(httpResponse);
             when(httpResponse.statusCode()).thenReturn(HttpStatusCode.ACCEPTED);
+            when(configService.getComponentId()).thenReturn("https://core-component.example");
 
             // Act
             storeIdentityService.storeIdentity(
@@ -518,6 +518,9 @@ class StoreIdentityServiceTest {
         void
                 shouldSuccessfullyStorePendingIdentityWithPostPatchEndpointAndNotStoreSiAndSendAuditEvent()
                         throws Exception {
+            // Arrange
+            when(configService.getComponentId()).thenReturn("https://core-component.example");
+
             // Act
             storeIdentityService.storeIdentity(
                     USER_ID,
@@ -550,6 +553,49 @@ class StoreIdentityServiceTest {
                             .sisRecordCreated());
             assertEquals(COMPONENT_ID, auditEvent.getComponentId());
             assertEquals(testAuditEventUser, auditEvent.getUser());
+        }
+
+        @Test
+        void shouldThrowIfFailedToStoreVcsForPendingIdentity() throws Exception {
+            // Arrange
+            doThrow(EvcsServiceException.class)
+                    .when(evcsService)
+                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), true);
+
+            // Act/Assert
+            assertThrows(
+                    EvcsServiceException.class,
+                    () ->
+                            storeIdentityService.storeIdentity(
+                                    USER_ID,
+                                    VCS,
+                                    List.of(),
+                                    P2,
+                                    STRONGEST_MATCHED_VOT,
+                                    CandidateIdentityType.PENDING,
+                                    sharedAuditEventParameters));
+        }
+
+        @Test
+        void shouldThrowIfFailedToStoreVcsAndSiObjectInOneTransaction() throws Exception {
+            // Arrange
+            doThrow(FailedToCreateStoredIdentityForEvcsException.class)
+                    .when(evcsService)
+                    .storeStoredIdentityRecordAndVcs(
+                            USER_ID, GOVUK_JOURNEY_ID, VCS, List.of(), STRONGEST_MATCHED_VOT, P2);
+
+            // Act/Assert
+            assertThrows(
+                    FailedToCreateStoredIdentityForEvcsException.class,
+                    () ->
+                            storeIdentityService.storeIdentity(
+                                    USER_ID,
+                                    VCS,
+                                    List.of(),
+                                    P2,
+                                    STRONGEST_MATCHED_VOT,
+                                    CandidateIdentityType.NEW,
+                                    sharedAuditEventParameters));
         }
     }
 }

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPostIdentityDto.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/dto/EvcsPostIdentityDto.java
@@ -6,4 +6,7 @@ import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record EvcsPostIdentityDto(
-        String userId, List<EvcsCreateUserVCsDto> vcs, EvcsStoredIdentityDto si) {}
+        String userId,
+        String govuk_signin_journey_id,
+        List<EvcsCreateUserVCsDto> vcs,
+        EvcsStoredIdentityDto si) {}

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/exception/EvcsServiceException.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/exception/EvcsServiceException.java
@@ -1,10 +1,11 @@
 package uk.gov.di.ipv.core.library.evcs.exception;
 
+import lombok.Getter;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.ErrorResponseException;
 
 public class EvcsServiceException extends Exception implements ErrorResponseException {
-    private final ErrorResponse errorResponse;
+    @Getter private final ErrorResponse errorResponse;
 
     private final int responseCode;
 
@@ -12,10 +13,6 @@ public class EvcsServiceException extends Exception implements ErrorResponseExce
         super(errorResponse.getMessage());
         this.errorResponse = errorResponse;
         this.responseCode = responseCode;
-    }
-
-    public ErrorResponse getErrorResponse() {
-        return errorResponse;
     }
 
     @Override

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -172,10 +172,10 @@ public class EvcsService {
             boolean isPendingIdentity)
             throws EvcsServiceException {
 
-        var newUserVcs = findNewUserVcs(credentials, existingEvcsUserVCs);
         var evcsCreateUserVCsDtos =
                 mapNewVcsToEvcsCreateUserVCsDto(
-                        newUserVcs, isPendingIdentity ? PENDING_RETURN : CURRENT);
+                        findNewUserVcs(credentials, existingEvcsUserVCs),
+                        isPendingIdentity ? PENDING_RETURN : CURRENT);
 
         if (!CollectionUtils.isEmpty(existingEvcsUserVCs)) {
             var existingVcsToUpdate =
@@ -236,7 +236,10 @@ public class EvcsService {
                         .toList();
         var evcsStoreIdentityDto =
                 new EvcsPostIdentityDto(
-                        userId, govukSigninJourneyId, vcToCreateAndUpdate, storedIdentityJwt);
+                        userId,
+                        vcToCreateAndUpdate.isEmpty() ? null : govukSigninJourneyId,
+                        vcToCreateAndUpdate.isEmpty() ? null : vcToCreateAndUpdate,
+                        storedIdentityJwt);
 
         return evcsClient.storeUserIdentity(evcsStoreIdentityDto);
     }
@@ -275,7 +278,7 @@ public class EvcsService {
             List<VerifiableCredential> credentials,
             List<EvcsGetUserVCDto> existingEvcsUserVCs,
             BiFunction<List<EvcsGetUserVCDto>, EvcsVCState, List<T>> mapper,
-            Boolean isPendingIdentity) {
+            boolean isPendingIdentity) {
         var existingPendingReturnUserVcsNotInSessionToUpdate =
                 mapper.apply(
                         findExistingVcsNotInSessionCredentials(

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -254,16 +254,6 @@ public class EvcsService {
                 .toList();
     }
 
-    private List<EvcsUpdateUserVCsDto> mapExistingVcsToEvcsUpdateUserVCsDto(
-            List<EvcsGetUserVCDto> existingVcs, EvcsVCState newState) {
-        return existingVcs.stream()
-                .map(
-                        existingVc ->
-                                new EvcsUpdateUserVCsDto(
-                                        getVcSignature(existingVc.vc()), newState, null))
-                .toList();
-    }
-
     private List<EvcsCreateUserVCsDto> mapExistingVcsToEvcsCreateUserVCsDto(
             List<EvcsGetUserVCDto> existingVcs, EvcsVCState newState) {
         return existingVcs.stream()
@@ -271,6 +261,16 @@ public class EvcsService {
                         existingVc ->
                                 new EvcsCreateUserVCsDto(
                                         existingVc.vc(), newState, existingVc.metadata(), null))
+                .toList();
+    }
+
+    private List<EvcsUpdateUserVCsDto> mapExistingVcsToEvcsUpdateUserVCsDto(
+            List<EvcsGetUserVCDto> existingVcs, EvcsVCState newState) {
+        return existingVcs.stream()
+                .map(
+                        existingVc ->
+                                new EvcsUpdateUserVCsDto(
+                                        getVcSignature(existingVc.vc()), newState, null))
                 .toList();
     }
 

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -161,60 +161,6 @@ public class EvcsService {
         return evcsClient.getUserVcs(userId, evcsAccessToken, List.of(states)).vcs();
     }
 
-    //    public void storePendingIdentityWithPostIdentity(
-    //            String userId, List<VerifiableCredential> credentials) throws EvcsServiceException
-    // {
-    //        var postIdentityDto = createPendingPostIdentityDto(userId, credentials);
-    //        evcsClient.storeUserIdentity(postIdentityDto);
-    //    }
-    //
-    //    public HttpResponse<String> storeCompletedIdentityWithPostIdentity(
-    //            String userId,
-    //            List<VerifiableCredential> credentials,
-    //            VotMatchingResult.VotAndProfile strongestAchievedVot,
-    //            Vot achievedVot)
-    //            throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
-    //        var postIdentityDto =
-    //                createCompletedPostIdentityDto(
-    //                        userId, credentials, strongestAchievedVot, achievedVot);
-    //        return evcsClient.storeUserIdentity(postIdentityDto);
-    //    }
-    //
-    //    private EvcsPostIdentityDto createCompletedPostIdentityDto(
-    //            String userId,
-    //            List<VerifiableCredential> credentials,
-    //            VotMatchingResult.VotAndProfile strongestAchievedVot,
-    //            Vot achievedVot)
-    //            throws FailedToCreateStoredIdentityForEvcsException {
-    //        var storedIdentityJwt =
-    //                storedIdentityService.getStoredIdentityForEvcs(
-    //                        userId, credentials, strongestAchievedVot, achievedVot);
-    //
-    //        return new EvcsPostIdentityDto(
-    //                userId,
-    //                credentials.stream()
-    //                        .map(
-    //                                vc ->
-    //                                        new EvcsCreateUserVCsDto(
-    //                                                vc.getVcString(), CURRENT, null, ONLINE))
-    //                        .toList(),
-    //                storedIdentityJwt);
-    //    }
-    //
-    //    private EvcsPostIdentityDto createPendingPostIdentityDto(
-    //            String userId, List<VerifiableCredential> credentials) {
-    //        return new EvcsPostIdentityDto(
-    //                userId,
-    //                credentials.stream()
-    //                        .map(
-    //                                vc ->
-    //                                        new EvcsCreateUserVCsDto(
-    //                                                vc.getVcString(), PENDING_RETURN, null,
-    // ONLINE))
-    //                        .toList(),
-    //                null);
-    //    }
-
     public void storeCompletedOrPendingIdentityWithPostVcs(
             String userId,
             List<VerifiableCredential> credentials,

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -12,6 +12,7 @@ import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsPostIdentityDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
+import uk.gov.di.ipv.core.library.evcs.enums.EvcsVcProvenance;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
@@ -21,16 +22,19 @@ import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
 import java.net.http.HttpResponse;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.ABANDONED;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.CURRENT;
+import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.HISTORIC;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.PENDING_RETURN;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVcProvenance.OFFLINE;
-import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVcProvenance.ONLINE;
 
 public class EvcsService {
     private final EvcsClient evcsClient;
@@ -167,29 +171,23 @@ public class EvcsService {
             List<EvcsGetUserVCDto> existingEvcsUserVCs,
             boolean isPendingIdentity)
             throws EvcsServiceException {
-        List<EvcsCreateUserVCsDto> newUserVcsToStore =
-                credentials.stream()
-                        .filter(
-                                credential ->
-                                        existingEvcsUserVCs.stream()
-                                                .noneMatch(
-                                                        evcsVC ->
-                                                                evcsVC.vc()
-                                                                        .equals(
-                                                                                credential
-                                                                                        .getVcString())))
-                        .map(
-                                vc ->
-                                        new EvcsCreateUserVCsDto(
-                                                vc.getVcString(),
-                                                isPendingIdentity ? PENDING_RETURN : CURRENT,
-                                                null,
-                                                ONLINE))
-                        .toList();
-        if (!CollectionUtils.isEmpty(existingEvcsUserVCs))
-            updateExistingUserVCs(userId, credentials, existingEvcsUserVCs, isPendingIdentity);
-        if (!newUserVcsToStore.isEmpty()) {
-            evcsClient.storeUserVCs(userId, newUserVcsToStore);
+
+        var newUserVcs = findNewUserVcs(credentials, existingEvcsUserVCs);
+        var evcsCreateUserVCsDtos = mapVcsToEvcsCreateUserVCsDto(newUserVcs, isPendingIdentity);
+
+        if (!CollectionUtils.isEmpty(existingEvcsUserVCs)) {
+            var existingVcsToUpdate =
+                    mapAndUpdateStateOfExistingUserVcs(
+                            credentials,
+                            existingEvcsUserVCs,
+                            this::mapExistingVcToEvcsUpdateUserVCsDto,
+                            isPendingIdentity);
+            if (!existingVcsToUpdate.isEmpty()) {
+                evcsClient.updateUserVCs(userId, existingVcsToUpdate);
+            }
+        }
+        if (!evcsCreateUserVCsDtos.isEmpty()) {
+            evcsClient.storeUserVCs(userId, evcsCreateUserVCsDtos);
         }
     }
 
@@ -220,12 +218,20 @@ public class EvcsService {
                 storedIdentityService.getStoredIdentityForEvcs(
                         userId, credentials, strongestAchievedVot, achievedVot);
 
-        var newUserVcsToStore =
-                mapNewUsersVcsToEvcsCreateUserVcsDto(credentials, existingEvcsUserVcs);
+        var evcsCreateUserVCsDtos =
+                mapVcsToEvcsCreateUserVCsDto(
+                        findNewUserVcs(credentials, existingEvcsUserVcs), false);
+
         var existingVcsToUpdate =
-                mapAndUpdateStateOfExistingUserVcs(credentials, existingEvcsUserVcs);
+                mapAndUpdateStateOfExistingUserVcs(
+                        credentials,
+                        existingEvcsUserVcs,
+                        this::mapExistingVcToEvcsCreateUserVCsDto,
+                        false);
+
         var vcToCreateAndUpdate =
-                Stream.concat(newUserVcsToStore.stream(), existingVcsToUpdate.stream()).toList();
+                Stream.concat(evcsCreateUserVCsDtos.stream(), existingVcsToUpdate.stream())
+                        .toList();
         var evcsStoreIdentityDto =
                 new EvcsPostIdentityDto(
                         userId, govukSigninJourneyId, vcToCreateAndUpdate, storedIdentityJwt);
@@ -233,156 +239,50 @@ public class EvcsService {
         return evcsClient.storeUserIdentity(evcsStoreIdentityDto);
     }
 
-    private List<EvcsCreateUserVCsDto> mapNewUsersVcsToEvcsCreateUserVcsDto(
-            List<VerifiableCredential> credentials, List<EvcsGetUserVCDto> existingEvcsUserVcs) {
-        return credentials.stream()
-                .filter(
-                        credential ->
-                                existingEvcsUserVcs.stream()
-                                        .noneMatch(
-                                                evcsVC ->
-                                                        evcsVC.vc()
-                                                                .equals(credential.getVcString())))
-                .map(vc -> new EvcsCreateUserVCsDto(vc.getVcString(), CURRENT, null, ONLINE))
-                .toList();
-    }
-
-    private List<EvcsCreateUserVCsDto> mapAndUpdateStateOfExistingUserVcs(
-            List<VerifiableCredential> credentials, List<EvcsGetUserVCDto> existingEvcsUserVCs) {
+    private <T> List<T> mapAndUpdateStateOfExistingUserVcs(
+            List<VerifiableCredential> credentials,
+            List<EvcsGetUserVCDto> existingEvcsUserVCs,
+            BiFunction<List<EvcsGetUserVCDto>, EvcsVCState, List<T>> mapper,
+            Boolean isPendingIdentity) {
         var existingPendingReturnUserVcsNotInSessionToUpdate =
-                existingEvcsUserVCs.stream()
-                        .filter(vc -> vc.state().equals(PENDING_RETURN))
-                        .filter(
-                                vc ->
-                                        credentials.stream()
-                                                .noneMatch(
-                                                        credential ->
-                                                                credential
-                                                                        .getVcString()
-                                                                        .equals(vc.vc())))
-                        .map(
-                                vc ->
-                                        new EvcsCreateUserVCsDto(
-                                                vc.vc(),
-                                                EvcsVCState.ABANDONED,
-                                                vc.metadata(),
-                                                null))
-                        .toList();
-        var vcsToUpdates = new ArrayList<>(existingPendingReturnUserVcsNotInSessionToUpdate);
+                mapper.apply(
+                        findExistingVcsNotInSessionCredentials(
+                                credentials,
+                                existingEvcsUserVCs,
+                                evcsGetUserVCDto ->
+                                        evcsGetUserVCDto.state().equals(PENDING_RETURN)),
+                        ABANDONED);
 
-        var existingPendingReturnUserVcsInSessionToUpdate =
-                existingEvcsUserVCs.stream()
-                        .filter(vc -> vc.state().equals(PENDING_RETURN))
-                        .filter(
-                                vc ->
-                                        credentials.stream()
-                                                .anyMatch(
-                                                        credential ->
-                                                                credential
-                                                                        .getVcString()
-                                                                        .equals(vc.vc())))
-                        .map(
-                                vc ->
-                                        new EvcsCreateUserVCsDto(
-                                                vc.vc(), EvcsVCState.CURRENT, vc.metadata(), null))
-                        .toList();
-        vcsToUpdates.addAll(existingPendingReturnUserVcsInSessionToUpdate);
+        if (!isPendingIdentity) {
+            var existingPendingReturnUserVcsInSessionToUpdate =
+                    mapper.apply(
+                            findExistingVcsInSessionCredentials(
+                                    credentials,
+                                    existingEvcsUserVCs,
+                                    evcsGetUserVCDto ->
+                                            evcsGetUserVCDto.state().equals(PENDING_RETURN)),
+                            CURRENT);
+            var existingCurrentUserVcsNotInSessionToUpdate =
+                    mapper.apply(
+                            findExistingVcsNotInSessionCredentials(
+                                    credentials,
+                                    existingEvcsUserVCs,
+                                    evcsGetUserVCDto -> evcsGetUserVCDto.state().equals(CURRENT)),
+                            HISTORIC);
 
-        var existingCurrentUserVcsNotInSessionToUpdate =
-                existingEvcsUserVCs.stream()
-                        .filter(vc -> vc.state().equals(CURRENT))
-                        .filter(
-                                vc ->
-                                        credentials.stream()
-                                                .noneMatch(
-                                                        credential ->
-                                                                credential
-                                                                        .getVcString()
-                                                                        .equals(vc.vc())))
-                        .map(
-                                vc ->
-                                        new EvcsCreateUserVCsDto(
-                                                vc.vc(), EvcsVCState.HISTORIC, vc.metadata(), null))
-                        .toList();
-        vcsToUpdates.addAll(existingCurrentUserVcsNotInSessionToUpdate);
+            return Stream.of(
+                            existingPendingReturnUserVcsNotInSessionToUpdate,
+                            existingPendingReturnUserVcsInSessionToUpdate,
+                            existingCurrentUserVcsNotInSessionToUpdate)
+                    .flatMap(Collection::stream)
+                    .toList();
+        }
 
-        return vcsToUpdates;
+        return existingPendingReturnUserVcsNotInSessionToUpdate;
     }
 
     public void invalidateStoredIdentityRecord(String userId) throws EvcsServiceException {
         evcsClient.invalidateStoredIdentityRecord(userId);
-    }
-
-    private void updateExistingUserVCs(
-            String userId,
-            List<VerifiableCredential> credentials,
-            List<EvcsGetUserVCDto> existingEvcsUserVCs,
-            boolean isPendingIdentity)
-            throws EvcsServiceException {
-        var existingPendingReturnUserVcsNotInSessionToUpdate =
-                existingEvcsUserVCs.stream()
-                        .filter(vc -> vc.state().equals(PENDING_RETURN))
-                        .filter(
-                                vc ->
-                                        credentials.stream()
-                                                .noneMatch(
-                                                        credential ->
-                                                                credential
-                                                                        .getVcString()
-                                                                        .equals(vc.vc())))
-                        .map(
-                                vc ->
-                                        new EvcsUpdateUserVCsDto(
-                                                getVcSignature(vc.vc()),
-                                                EvcsVCState.ABANDONED,
-                                                null))
-                        .toList();
-        var vcsToUpdates = new ArrayList<>(existingPendingReturnUserVcsNotInSessionToUpdate);
-
-        if (!isPendingIdentity) {
-            var existingPendingReturnUserVcsInSessionToUpdate =
-                    existingEvcsUserVCs.stream()
-                            .filter(vc -> vc.state().equals(PENDING_RETURN))
-                            .filter(
-                                    vc ->
-                                            credentials.stream()
-                                                    .anyMatch(
-                                                            credential ->
-                                                                    credential
-                                                                            .getVcString()
-                                                                            .equals(vc.vc())))
-                            .map(
-                                    vc ->
-                                            new EvcsUpdateUserVCsDto(
-                                                    getVcSignature(vc.vc()),
-                                                    EvcsVCState.CURRENT,
-                                                    null))
-                            .toList();
-            vcsToUpdates.addAll(existingPendingReturnUserVcsInSessionToUpdate);
-
-            var existingCurrentUserVcsNotInSessionToUpdate =
-                    existingEvcsUserVCs.stream()
-                            .filter(vc -> vc.state().equals(CURRENT))
-                            // identity VCs
-                            .filter(
-                                    vc ->
-                                            credentials.stream()
-                                                    .noneMatch(
-                                                            credential ->
-                                                                    credential
-                                                                            .getVcString()
-                                                                            .equals(vc.vc())))
-                            .map(
-                                    vc ->
-                                            new EvcsUpdateUserVCsDto(
-                                                    getVcSignature(vc.vc()),
-                                                    EvcsVCState.HISTORIC,
-                                                    null))
-                            .toList();
-            vcsToUpdates.addAll(existingCurrentUserVcsNotInSessionToUpdate);
-        }
-
-        if (!vcsToUpdates.isEmpty()) evcsClient.updateUserVCs(userId, vcsToUpdates);
     }
 
     public void markHistoricInEvcs(String userId, List<VerifiableCredential> vcs)
@@ -403,5 +303,85 @@ public class EvcsService {
 
     private static String getVcSignature(String vcString) {
         return vcString.split("\\.")[2];
+    }
+
+    private List<VerifiableCredential> findNewUserVcs(
+            List<VerifiableCredential> sessionCredentials, List<EvcsGetUserVCDto> existingEvcsVCs) {
+        return sessionCredentials.stream()
+                .filter(
+                        credential ->
+                                existingEvcsVCs.stream()
+                                        .noneMatch(
+                                                evcsVc ->
+                                                        evcsVc.vc()
+                                                                .equals(credential.getVcString())))
+                .toList();
+    }
+
+    private List<EvcsCreateUserVCsDto> mapVcsToEvcsCreateUserVCsDto(
+            List<VerifiableCredential> credentials, Boolean isPendingIdentity) {
+        return credentials.stream()
+                .map(
+                        vc ->
+                                new EvcsCreateUserVCsDto(
+                                        vc.getVcString(),
+                                        isPendingIdentity
+                                                ? EvcsVCState.PENDING_RETURN
+                                                : EvcsVCState.CURRENT,
+                                        null,
+                                        EvcsVcProvenance.ONLINE))
+                .toList();
+    }
+
+    private List<EvcsGetUserVCDto> findExistingVcsNotInSessionCredentials(
+            List<VerifiableCredential> credentials,
+            List<EvcsGetUserVCDto> existingEvcsUserVCs,
+            Predicate<EvcsGetUserVCDto> condition) {
+        return existingEvcsUserVCs.stream()
+                .filter(condition)
+                .filter(
+                        existingVc ->
+                                credentials.stream()
+                                        .noneMatch(
+                                                credential ->
+                                                        credential
+                                                                .getVcString()
+                                                                .equals(existingVc.vc())))
+                .toList();
+    }
+
+    private List<EvcsUpdateUserVCsDto> mapExistingVcToEvcsUpdateUserVCsDto(
+            List<EvcsGetUserVCDto> existingVcs, EvcsVCState state) {
+        return existingVcs.stream()
+                .map(
+                        existingVc ->
+                                new EvcsUpdateUserVCsDto(
+                                        getVcSignature(existingVc.vc()), state, null))
+                .toList();
+    }
+
+    private List<EvcsCreateUserVCsDto> mapExistingVcToEvcsCreateUserVCsDto(
+            List<EvcsGetUserVCDto> existingVcs, EvcsVCState state) {
+        return existingVcs.stream()
+                .map(
+                        existingVc ->
+                                new EvcsCreateUserVCsDto(
+                                        existingVc.vc(), state, existingVc.metadata(), null))
+                .toList();
+    }
+
+    private List<EvcsGetUserVCDto> findExistingVcsInSessionCredentials(
+            List<VerifiableCredential> credentials,
+            List<EvcsGetUserVCDto> existingEvcsUserVCs,
+            Predicate<EvcsGetUserVCDto> condition) {
+        return existingEvcsUserVCs.stream()
+                .filter(condition)
+                .filter(
+                        vc ->
+                                credentials.stream()
+                                        .anyMatch(
+                                                credential ->
+                                                        credential.getVcString().equals(vc.vc())))
+                .toList();
     }
 }

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -173,14 +173,16 @@ public class EvcsService {
             throws EvcsServiceException {
 
         var newUserVcs = findNewUserVcs(credentials, existingEvcsUserVCs);
-        var evcsCreateUserVCsDtos = mapVcsToEvcsCreateUserVCsDto(newUserVcs, isPendingIdentity);
+        var evcsCreateUserVCsDtos =
+                mapNewVcsToEvcsCreateUserVCsDto(
+                        newUserVcs, isPendingIdentity ? PENDING_RETURN : CURRENT);
 
         if (!CollectionUtils.isEmpty(existingEvcsUserVCs)) {
             var existingVcsToUpdate =
                     mapAndUpdateStateOfExistingUserVcs(
                             credentials,
                             existingEvcsUserVCs,
-                            this::mapExistingVcToEvcsUpdateUserVCsDto,
+                            this::mapExistingVcsToEvcsUpdateUserVCsDto,
                             isPendingIdentity);
             if (!existingVcsToUpdate.isEmpty()) {
                 evcsClient.updateUserVCs(userId, existingVcsToUpdate);
@@ -219,14 +221,14 @@ public class EvcsService {
                         userId, credentials, strongestAchievedVot, achievedVot);
 
         var evcsCreateUserVCsDtos =
-                mapVcsToEvcsCreateUserVCsDto(
-                        findNewUserVcs(credentials, existingEvcsUserVcs), false);
+                mapNewVcsToEvcsCreateUserVCsDto(
+                        findNewUserVcs(credentials, existingEvcsUserVcs), CURRENT);
 
         var existingVcsToUpdate =
                 mapAndUpdateStateOfExistingUserVcs(
                         credentials,
                         existingEvcsUserVcs,
-                        this::mapExistingVcToEvcsCreateUserVCsDto,
+                        this::mapExistingVcsToEvcsCreateUserVCsDto,
                         false);
 
         var vcToCreateAndUpdate =
@@ -237,6 +239,36 @@ public class EvcsService {
                         userId, govukSigninJourneyId, vcToCreateAndUpdate, storedIdentityJwt);
 
         return evcsClient.storeUserIdentity(evcsStoreIdentityDto);
+    }
+
+    private List<EvcsCreateUserVCsDto> mapNewVcsToEvcsCreateUserVCsDto(
+            List<VerifiableCredential> credentials, EvcsVCState newState) {
+        return credentials.stream()
+                .map(
+                        vc ->
+                                new EvcsCreateUserVCsDto(
+                                        vc.getVcString(), newState, null, EvcsVcProvenance.ONLINE))
+                .toList();
+    }
+
+    private List<EvcsUpdateUserVCsDto> mapExistingVcsToEvcsUpdateUserVCsDto(
+            List<EvcsGetUserVCDto> existingVcs, EvcsVCState newState) {
+        return existingVcs.stream()
+                .map(
+                        existingVc ->
+                                new EvcsUpdateUserVCsDto(
+                                        getVcSignature(existingVc.vc()), newState, null))
+                .toList();
+    }
+
+    private List<EvcsCreateUserVCsDto> mapExistingVcsToEvcsCreateUserVCsDto(
+            List<EvcsGetUserVCDto> existingVcs, EvcsVCState newState) {
+        return existingVcs.stream()
+                .map(
+                        existingVc ->
+                                new EvcsCreateUserVCsDto(
+                                        existingVc.vc(), newState, existingVc.metadata(), null))
+                .toList();
     }
 
     private <T> List<T> mapAndUpdateStateOfExistingUserVcs(
@@ -281,6 +313,51 @@ public class EvcsService {
         return existingPendingReturnUserVcsNotInSessionToUpdate;
     }
 
+    private List<VerifiableCredential> findNewUserVcs(
+            List<VerifiableCredential> sessionCredentials, List<EvcsGetUserVCDto> existingEvcsVCs) {
+        return sessionCredentials.stream()
+                .filter(
+                        credential ->
+                                existingEvcsVCs.stream()
+                                        .noneMatch(
+                                                evcsVc ->
+                                                        evcsVc.vc()
+                                                                .equals(credential.getVcString())))
+                .toList();
+    }
+
+    private List<EvcsGetUserVCDto> findExistingVcsNotInSessionCredentials(
+            List<VerifiableCredential> credentials,
+            List<EvcsGetUserVCDto> existingEvcsUserVCs,
+            Predicate<EvcsGetUserVCDto> condition) {
+        return existingEvcsUserVCs.stream()
+                .filter(condition)
+                .filter(
+                        existingVc ->
+                                credentials.stream()
+                                        .noneMatch(
+                                                credential ->
+                                                        credential
+                                                                .getVcString()
+                                                                .equals(existingVc.vc())))
+                .toList();
+    }
+
+    private List<EvcsGetUserVCDto> findExistingVcsInSessionCredentials(
+            List<VerifiableCredential> credentials,
+            List<EvcsGetUserVCDto> existingEvcsUserVCs,
+            Predicate<EvcsGetUserVCDto> condition) {
+        return existingEvcsUserVCs.stream()
+                .filter(condition)
+                .filter(
+                        vc ->
+                                credentials.stream()
+                                        .anyMatch(
+                                                credential ->
+                                                        credential.getVcString().equals(vc.vc())))
+                .toList();
+    }
+
     public void invalidateStoredIdentityRecord(String userId) throws EvcsServiceException {
         evcsClient.invalidateStoredIdentityRecord(userId);
     }
@@ -303,85 +380,5 @@ public class EvcsService {
 
     private static String getVcSignature(String vcString) {
         return vcString.split("\\.")[2];
-    }
-
-    private List<VerifiableCredential> findNewUserVcs(
-            List<VerifiableCredential> sessionCredentials, List<EvcsGetUserVCDto> existingEvcsVCs) {
-        return sessionCredentials.stream()
-                .filter(
-                        credential ->
-                                existingEvcsVCs.stream()
-                                        .noneMatch(
-                                                evcsVc ->
-                                                        evcsVc.vc()
-                                                                .equals(credential.getVcString())))
-                .toList();
-    }
-
-    private List<EvcsCreateUserVCsDto> mapVcsToEvcsCreateUserVCsDto(
-            List<VerifiableCredential> credentials, Boolean isPendingIdentity) {
-        return credentials.stream()
-                .map(
-                        vc ->
-                                new EvcsCreateUserVCsDto(
-                                        vc.getVcString(),
-                                        isPendingIdentity
-                                                ? EvcsVCState.PENDING_RETURN
-                                                : EvcsVCState.CURRENT,
-                                        null,
-                                        EvcsVcProvenance.ONLINE))
-                .toList();
-    }
-
-    private List<EvcsGetUserVCDto> findExistingVcsNotInSessionCredentials(
-            List<VerifiableCredential> credentials,
-            List<EvcsGetUserVCDto> existingEvcsUserVCs,
-            Predicate<EvcsGetUserVCDto> condition) {
-        return existingEvcsUserVCs.stream()
-                .filter(condition)
-                .filter(
-                        existingVc ->
-                                credentials.stream()
-                                        .noneMatch(
-                                                credential ->
-                                                        credential
-                                                                .getVcString()
-                                                                .equals(existingVc.vc())))
-                .toList();
-    }
-
-    private List<EvcsUpdateUserVCsDto> mapExistingVcToEvcsUpdateUserVCsDto(
-            List<EvcsGetUserVCDto> existingVcs, EvcsVCState state) {
-        return existingVcs.stream()
-                .map(
-                        existingVc ->
-                                new EvcsUpdateUserVCsDto(
-                                        getVcSignature(existingVc.vc()), state, null))
-                .toList();
-    }
-
-    private List<EvcsCreateUserVCsDto> mapExistingVcToEvcsCreateUserVCsDto(
-            List<EvcsGetUserVCDto> existingVcs, EvcsVCState state) {
-        return existingVcs.stream()
-                .map(
-                        existingVc ->
-                                new EvcsCreateUserVCsDto(
-                                        existingVc.vc(), state, existingVc.metadata(), null))
-                .toList();
-    }
-
-    private List<EvcsGetUserVCDto> findExistingVcsInSessionCredentials(
-            List<VerifiableCredential> credentials,
-            List<EvcsGetUserVCDto> existingEvcsUserVCs,
-            Predicate<EvcsGetUserVCDto> condition) {
-        return existingEvcsUserVCs.stream()
-                .filter(condition)
-                .filter(
-                        vc ->
-                                credentials.stream()
-                                        .anyMatch(
-                                                credential ->
-                                                        credential.getVcString().equals(vc.vc())))
-                .toList();
     }
 }

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -268,8 +268,7 @@ public class EvcsService {
             List<VerifiableCredential> credentials,
             List<EvcsGetUserVCDto> existingEvcsUserVcs,
             VotMatchingResult.VotAndProfile strongestAchievedVot,
-            Vot achievedVot,
-            Boolean isPendingIdentity)
+            Vot achievedVot)
             throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
         var storedIdentityJwt =
                 storedIdentityService.getStoredIdentityForEvcs(
@@ -278,8 +277,7 @@ public class EvcsService {
         var newUserVcsToStore =
                 mapNewUsersVcsToEvcsCreateUserVcsDto(credentials, existingEvcsUserVcs);
         var existingVcsToUpdate =
-                mapAndUpdateStateOfExistingUserVcs(
-                        credentials, existingEvcsUserVcs, isPendingIdentity);
+                mapAndUpdateStateOfExistingUserVcs(credentials, existingEvcsUserVcs);
         var vcToCreateAndUpdate =
                 Stream.concat(newUserVcsToStore.stream(), existingVcsToUpdate.stream()).toList();
         var evcsStoreIdentityDto =
@@ -304,9 +302,7 @@ public class EvcsService {
     }
 
     private List<EvcsCreateUserVCsDto> mapAndUpdateStateOfExistingUserVcs(
-            List<VerifiableCredential> credentials,
-            List<EvcsGetUserVCDto> existingEvcsUserVCs,
-            boolean isPendingIdentity) {
+            List<VerifiableCredential> credentials, List<EvcsGetUserVCDto> existingEvcsUserVCs) {
         var existingPendingReturnUserVcsNotInSessionToUpdate =
                 existingEvcsUserVCs.stream()
                         .filter(vc -> vc.state().equals(PENDING_RETURN))
@@ -328,49 +324,41 @@ public class EvcsService {
                         .toList();
         var vcsToUpdates = new ArrayList<>(existingPendingReturnUserVcsNotInSessionToUpdate);
 
-        if (!isPendingIdentity) {
-            var existingPendingReturnUserVcsInSessionToUpdate =
-                    existingEvcsUserVCs.stream()
-                            .filter(vc -> vc.state().equals(PENDING_RETURN))
-                            .filter(
-                                    vc ->
-                                            credentials.stream()
-                                                    .anyMatch(
-                                                            credential ->
-                                                                    credential
-                                                                            .getVcString()
-                                                                            .equals(vc.vc())))
-                            .map(
-                                    vc ->
-                                            new EvcsCreateUserVCsDto(
-                                                    vc.vc(),
-                                                    EvcsVCState.CURRENT,
-                                                    vc.metadata(),
-                                                    null))
-                            .toList();
-            vcsToUpdates.addAll(existingPendingReturnUserVcsInSessionToUpdate);
+        var existingPendingReturnUserVcsInSessionToUpdate =
+                existingEvcsUserVCs.stream()
+                        .filter(vc -> vc.state().equals(PENDING_RETURN))
+                        .filter(
+                                vc ->
+                                        credentials.stream()
+                                                .anyMatch(
+                                                        credential ->
+                                                                credential
+                                                                        .getVcString()
+                                                                        .equals(vc.vc())))
+                        .map(
+                                vc ->
+                                        new EvcsCreateUserVCsDto(
+                                                vc.vc(), EvcsVCState.CURRENT, vc.metadata(), null))
+                        .toList();
+        vcsToUpdates.addAll(existingPendingReturnUserVcsInSessionToUpdate);
 
-            var existingCurrentUserVcsNotInSessionToUpdate =
-                    existingEvcsUserVCs.stream()
-                            .filter(vc -> vc.state().equals(CURRENT))
-                            .filter(
-                                    vc ->
-                                            credentials.stream()
-                                                    .noneMatch(
-                                                            credential ->
-                                                                    credential
-                                                                            .getVcString()
-                                                                            .equals(vc.vc())))
-                            .map(
-                                    vc ->
-                                            new EvcsCreateUserVCsDto(
-                                                    vc.vc(),
-                                                    EvcsVCState.HISTORIC,
-                                                    vc.metadata(),
-                                                    null))
-                            .toList();
-            vcsToUpdates.addAll(existingCurrentUserVcsNotInSessionToUpdate);
-        }
+        var existingCurrentUserVcsNotInSessionToUpdate =
+                existingEvcsUserVCs.stream()
+                        .filter(vc -> vc.state().equals(CURRENT))
+                        .filter(
+                                vc ->
+                                        credentials.stream()
+                                                .noneMatch(
+                                                        credential ->
+                                                                credential
+                                                                        .getVcString()
+                                                                        .equals(vc.vc())))
+                        .map(
+                                vc ->
+                                        new EvcsCreateUserVCsDto(
+                                                vc.vc(), EvcsVCState.HISTORIC, vc.metadata(), null))
+                        .toList();
+        vcsToUpdates.addAll(existingCurrentUserVcsNotInSessionToUpdate);
 
         return vcsToUpdates;
     }

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.ABANDONED;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.CURRENT;
@@ -160,57 +161,59 @@ public class EvcsService {
         return evcsClient.getUserVcs(userId, evcsAccessToken, List.of(states)).vcs();
     }
 
-    public void storePendingIdentityWithPostIdentity(
-            String userId, List<VerifiableCredential> credentials) throws EvcsServiceException {
-        var postIdentityDto = createPendingPostIdentityDto(userId, credentials);
-        evcsClient.storeUserIdentity(postIdentityDto);
-    }
-
-    public HttpResponse<String> storeCompletedIdentityWithPostIdentity(
-            String userId,
-            List<VerifiableCredential> credentials,
-            VotMatchingResult.VotAndProfile strongestAchievedVot,
-            Vot achievedVot)
-            throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
-        var postIdentityDto =
-                createCompletedPostIdentityDto(
-                        userId, credentials, strongestAchievedVot, achievedVot);
-        return evcsClient.storeUserIdentity(postIdentityDto);
-    }
-
-    private EvcsPostIdentityDto createCompletedPostIdentityDto(
-            String userId,
-            List<VerifiableCredential> credentials,
-            VotMatchingResult.VotAndProfile strongestAchievedVot,
-            Vot achievedVot)
-            throws FailedToCreateStoredIdentityForEvcsException {
-        var storedIdentityJwt =
-                storedIdentityService.getStoredIdentityForEvcs(
-                        userId, credentials, strongestAchievedVot, achievedVot);
-
-        return new EvcsPostIdentityDto(
-                userId,
-                credentials.stream()
-                        .map(
-                                vc ->
-                                        new EvcsCreateUserVCsDto(
-                                                vc.getVcString(), CURRENT, null, ONLINE))
-                        .toList(),
-                storedIdentityJwt);
-    }
-
-    private EvcsPostIdentityDto createPendingPostIdentityDto(
-            String userId, List<VerifiableCredential> credentials) {
-        return new EvcsPostIdentityDto(
-                userId,
-                credentials.stream()
-                        .map(
-                                vc ->
-                                        new EvcsCreateUserVCsDto(
-                                                vc.getVcString(), PENDING_RETURN, null, ONLINE))
-                        .toList(),
-                null);
-    }
+    //    public void storePendingIdentityWithPostIdentity(
+    //            String userId, List<VerifiableCredential> credentials) throws EvcsServiceException
+    // {
+    //        var postIdentityDto = createPendingPostIdentityDto(userId, credentials);
+    //        evcsClient.storeUserIdentity(postIdentityDto);
+    //    }
+    //
+    //    public HttpResponse<String> storeCompletedIdentityWithPostIdentity(
+    //            String userId,
+    //            List<VerifiableCredential> credentials,
+    //            VotMatchingResult.VotAndProfile strongestAchievedVot,
+    //            Vot achievedVot)
+    //            throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
+    //        var postIdentityDto =
+    //                createCompletedPostIdentityDto(
+    //                        userId, credentials, strongestAchievedVot, achievedVot);
+    //        return evcsClient.storeUserIdentity(postIdentityDto);
+    //    }
+    //
+    //    private EvcsPostIdentityDto createCompletedPostIdentityDto(
+    //            String userId,
+    //            List<VerifiableCredential> credentials,
+    //            VotMatchingResult.VotAndProfile strongestAchievedVot,
+    //            Vot achievedVot)
+    //            throws FailedToCreateStoredIdentityForEvcsException {
+    //        var storedIdentityJwt =
+    //                storedIdentityService.getStoredIdentityForEvcs(
+    //                        userId, credentials, strongestAchievedVot, achievedVot);
+    //
+    //        return new EvcsPostIdentityDto(
+    //                userId,
+    //                credentials.stream()
+    //                        .map(
+    //                                vc ->
+    //                                        new EvcsCreateUserVCsDto(
+    //                                                vc.getVcString(), CURRENT, null, ONLINE))
+    //                        .toList(),
+    //                storedIdentityJwt);
+    //    }
+    //
+    //    private EvcsPostIdentityDto createPendingPostIdentityDto(
+    //            String userId, List<VerifiableCredential> credentials) {
+    //        return new EvcsPostIdentityDto(
+    //                userId,
+    //                credentials.stream()
+    //                        .map(
+    //                                vc ->
+    //                                        new EvcsCreateUserVCsDto(
+    //                                                vc.getVcString(), PENDING_RETURN, null,
+    // ONLINE))
+    //                        .toList(),
+    //                null);
+    //    }
 
     public void storeCompletedOrPendingIdentityWithPostVcs(
             String userId,
@@ -254,9 +257,122 @@ public class EvcsService {
                 storedIdentityService.getStoredIdentityForEvcs(
                         userId, credentials, strongestAchievedVot, achievedVot);
 
-        var evcsStoreIdentityDto = new EvcsPostIdentityDto(userId, null, storedIdentityJwt);
+        var evcsStoreIdentityDto = new EvcsPostIdentityDto(userId, null, null, storedIdentityJwt);
 
         return evcsClient.storeUserIdentity(evcsStoreIdentityDto);
+    }
+
+    public HttpResponse<String> storeStoredIdentityRecordAndVcs(
+            String userId,
+            String govukSigninJourneyId,
+            List<VerifiableCredential> credentials,
+            List<EvcsGetUserVCDto> existingEvcsUserVcs,
+            VotMatchingResult.VotAndProfile strongestAchievedVot,
+            Vot achievedVot,
+            Boolean isPendingIdentity)
+            throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
+        var storedIdentityJwt =
+                storedIdentityService.getStoredIdentityForEvcs(
+                        userId, credentials, strongestAchievedVot, achievedVot);
+
+        var newUserVcsToStore =
+                mapNewUsersVcsToEvcsCreateUserVcsDto(credentials, existingEvcsUserVcs);
+        var existingVcsToUpdate =
+                mapAndUpdateStateOfExistingUserVcs(
+                        credentials, existingEvcsUserVcs, isPendingIdentity);
+        var vcToCreateAndUpdate =
+                Stream.concat(newUserVcsToStore.stream(), existingVcsToUpdate.stream()).toList();
+        var evcsStoreIdentityDto =
+                new EvcsPostIdentityDto(
+                        userId, govukSigninJourneyId, vcToCreateAndUpdate, storedIdentityJwt);
+
+        return evcsClient.storeUserIdentity(evcsStoreIdentityDto);
+    }
+
+    private List<EvcsCreateUserVCsDto> mapNewUsersVcsToEvcsCreateUserVcsDto(
+            List<VerifiableCredential> credentials, List<EvcsGetUserVCDto> existingEvcsUserVcs) {
+        return credentials.stream()
+                .filter(
+                        credential ->
+                                existingEvcsUserVcs.stream()
+                                        .noneMatch(
+                                                evcsVC ->
+                                                        evcsVC.vc()
+                                                                .equals(credential.getVcString())))
+                .map(vc -> new EvcsCreateUserVCsDto(vc.getVcString(), CURRENT, null, ONLINE))
+                .toList();
+    }
+
+    private List<EvcsCreateUserVCsDto> mapAndUpdateStateOfExistingUserVcs(
+            List<VerifiableCredential> credentials,
+            List<EvcsGetUserVCDto> existingEvcsUserVCs,
+            boolean isPendingIdentity) {
+        var existingPendingReturnUserVcsNotInSessionToUpdate =
+                existingEvcsUserVCs.stream()
+                        .filter(vc -> vc.state().equals(PENDING_RETURN))
+                        .filter(
+                                vc ->
+                                        credentials.stream()
+                                                .noneMatch(
+                                                        credential ->
+                                                                credential
+                                                                        .getVcString()
+                                                                        .equals(vc.vc())))
+                        .map(
+                                vc ->
+                                        new EvcsCreateUserVCsDto(
+                                                vc.vc(),
+                                                EvcsVCState.ABANDONED,
+                                                vc.metadata(),
+                                                null))
+                        .toList();
+        var vcsToUpdates = new ArrayList<>(existingPendingReturnUserVcsNotInSessionToUpdate);
+
+        if (!isPendingIdentity) {
+            var existingPendingReturnUserVcsInSessionToUpdate =
+                    existingEvcsUserVCs.stream()
+                            .filter(vc -> vc.state().equals(PENDING_RETURN))
+                            .filter(
+                                    vc ->
+                                            credentials.stream()
+                                                    .anyMatch(
+                                                            credential ->
+                                                                    credential
+                                                                            .getVcString()
+                                                                            .equals(vc.vc())))
+                            .map(
+                                    vc ->
+                                            new EvcsCreateUserVCsDto(
+                                                    vc.vc(),
+                                                    EvcsVCState.CURRENT,
+                                                    vc.metadata(),
+                                                    null))
+                            .toList();
+            vcsToUpdates.addAll(existingPendingReturnUserVcsInSessionToUpdate);
+
+            var existingCurrentUserVcsNotInSessionToUpdate =
+                    existingEvcsUserVCs.stream()
+                            .filter(vc -> vc.state().equals(CURRENT))
+                            .filter(
+                                    vc ->
+                                            credentials.stream()
+                                                    .noneMatch(
+                                                            credential ->
+                                                                    credential
+                                                                            .getVcString()
+                                                                            .equals(vc.vc())))
+                            .map(
+                                    vc ->
+                                            new EvcsCreateUserVCsDto(
+                                                    vc.vc(),
+                                                    EvcsVCState.HISTORIC,
+                                                    vc.metadata(),
+                                                    null))
+                            .toList();
+            vcsToUpdates.addAll(existingCurrentUserVcsNotInSessionToUpdate);
+        }
+
+        return vcsToUpdates;
     }
 
     public void invalidateStoredIdentityRecord(String userId) throws EvcsServiceException {

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -218,7 +218,7 @@ public class EvcsService {
             List<EvcsGetUserVCDto> existingEvcsUserVCs,
             boolean isPendingIdentity)
             throws EvcsServiceException {
-        List<EvcsCreateUserVCsDto> userVCsToStore =
+        List<EvcsCreateUserVCsDto> newUserVcsToStore =
                 credentials.stream()
                         .filter(
                                 credential ->
@@ -239,7 +239,9 @@ public class EvcsService {
                         .toList();
         if (!CollectionUtils.isEmpty(existingEvcsUserVCs))
             updateExistingUserVCs(userId, credentials, existingEvcsUserVCs, isPendingIdentity);
-        if (!userVCsToStore.isEmpty()) evcsClient.storeUserVCs(userId, userVCsToStore);
+        if (!newUserVcsToStore.isEmpty()) {
+            evcsClient.storeUserVCs(userId, newUserVcsToStore);
+        }
     }
 
     public HttpResponse<String> storeStoredIdentityRecord(

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
@@ -74,6 +74,7 @@ class EvcsClientTest {
             "L2BGccX59Ea9PMJ3ipu9t7r99ykD2Tlh1KYpdjdg"; // pragma: allowlist secret
     private static final String TEST_EVCS_ACCESS_TOKEN = "TEST_EVCS_ACCESS_TOKEN";
     private static final String TEST_USER_ID = "urn:uuid:9bd7f130-4238-4532-83cd-01cb29584834";
+    private static final String TEST_GOVUK_SIGNIN_JOURNEY_ID = "TEST_GOVUK_SIGNIN_JOURNEY_ID";
     private static final Map<String, Object> TEST_METADATA =
             Map.of(
                     "reason", "testing",
@@ -113,6 +114,13 @@ class EvcsClientTest {
                     TEST_USER_ID,
                     null,
                     null,
+                    new EvcsStoredIdentityDto("storedIdentityJwt", Vot.P2));
+
+    private static final EvcsPostIdentityDto EVCS_POST_IDENTITY_DTO_SI_AND_VCS =
+            new EvcsPostIdentityDto(
+                    TEST_USER_ID,
+                    TEST_GOVUK_SIGNIN_JOURNEY_ID,
+                    EVCS_CREATE_USER_VCS_DTO,
                     new EvcsStoredIdentityDto("storedIdentityJwt", Vot.P2));
     private static final List<EvcsVCState> VC_STATES_FOR_QUERY = List.of(CURRENT, PENDING_RETURN);
 
@@ -607,6 +615,41 @@ class EvcsClientTest {
             assertEquals("storedIdentityJwt", evcsPostIdentityDto.si().jwt());
             assertEquals(Vot.P2, evcsPostIdentityDto.si().vot());
             assertEquals(TEST_USER_ID, evcsPostIdentityDto.userId());
+        }
+    }
+
+    @Test
+    void storeUserIdentityShouldSuccessfullySendRequestWithVCsAndGovukSigninJourneyId()
+            throws Exception {
+        // Arrange
+        when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.ACCEPTED);
+        // Act
+        try (MockedStatic<HttpRequest.BodyPublishers> mockedBodyPublishers =
+                mockStatic(HttpRequest.BodyPublishers.class, CALLS_REAL_METHODS)) {
+            evcsClient.storeUserIdentity(EVCS_POST_IDENTITY_DTO_SI_AND_VCS);
+
+            // Assert
+            verify(mockHttpClient).send(httpRequestCaptor.capture(), any());
+            HttpRequest httpRequest = httpRequestCaptor.getValue();
+            assertEquals("POST", httpRequest.method());
+            assertTrue(httpRequest.bodyPublisher().isPresent());
+            assertFalse(httpRequest.headers().map().containsKey(AUTHORIZATION));
+            assertTrue(httpRequest.headers().map().containsKey(X_API_KEY_HEADER));
+            assertEquals("/v1/identity", httpRequest.uri().getPath());
+
+            mockedBodyPublishers.verify(
+                    () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
+            var evcsPostIdentityDto =
+                    OBJECT_MAPPER.readValue(
+                            stringCaptor.getAllValues().get(0),
+                            new TypeReference<EvcsPostIdentityDto>() {});
+            assertEquals("storedIdentityJwt", evcsPostIdentityDto.si().jwt());
+            assertEquals(Vot.P2, evcsPostIdentityDto.si().vot());
+            assertEquals(TEST_USER_ID, evcsPostIdentityDto.userId());
+            assertEquals(EVCS_CREATE_USER_VCS_DTO, evcsPostIdentityDto.vcs());
+            assertEquals(
+                    TEST_GOVUK_SIGNIN_JOURNEY_ID, evcsPostIdentityDto.govuk_signin_journey_id());
         }
     }
 

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
@@ -110,7 +110,10 @@ class EvcsClientTest {
                             "VC_Signature2", EvcsVCState.ABANDONED, TEST_METADATA));
     private static final EvcsPostIdentityDto EVCS_POST_IDENTITY_DTO_SI_ONLY =
             new EvcsPostIdentityDto(
-                    TEST_USER_ID, null, new EvcsStoredIdentityDto("storedIdentityJwt", Vot.P2));
+                    TEST_USER_ID,
+                    null,
+                    null,
+                    new EvcsStoredIdentityDto("storedIdentityJwt", Vot.P2));
     private static final List<EvcsVCState> VC_STATES_FOR_QUERY = List.of(CURRENT, PENDING_RETURN);
 
     @Mock private ConfigService mockConfigService;

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
@@ -514,7 +514,7 @@ class ContractTest {
     void testPostIdentityReturns202(MockServer mockServer) throws EvcsServiceException {
         // Arrange
         var evcsPostIdentityDto =
-                new EvcsPostIdentityDto(TEST_USER_ID, null, EVCS_STORED_IDENTITY_DTO);
+                new EvcsPostIdentityDto(TEST_USER_ID, null, null, EVCS_STORED_IDENTITY_DTO);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act
@@ -595,7 +595,8 @@ class ContractTest {
     @PactTestFor(pactMethod = "nullUserIdPostIdentityReturns400")
     void testNullUserIdPostIdentityReturns400(MockServer mockServer) {
         // Arrange
-        var evcsPostIdentityDto = new EvcsPostIdentityDto(null, null, EVCS_STORED_IDENTITY_DTO);
+        var evcsPostIdentityDto =
+                new EvcsPostIdentityDto(null, null, null, EVCS_STORED_IDENTITY_DTO);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act & Assert
@@ -644,7 +645,7 @@ class ContractTest {
     @PactTestFor(pactMethod = "emptyUserIdPostIdentityReturns400")
     void testEmptyUserIdPostIdentityReturns400(MockServer mockServer) {
         // Arrange
-        var evcsPostIdentityDto = new EvcsPostIdentityDto("", null, EVCS_STORED_IDENTITY_DTO);
+        var evcsPostIdentityDto = new EvcsPostIdentityDto("", null, null, EVCS_STORED_IDENTITY_DTO);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act & Assert
@@ -688,7 +689,7 @@ class ContractTest {
     @PactTestFor(pactMethod = "nullSiPostIdentityReturns400")
     void testNullSiPostIdentityReturns400(MockServer mockServer) {
         // Arrange
-        var evcsPostIdentityDto = new EvcsPostIdentityDto(TEST_USER_ID, null, null);
+        var evcsPostIdentityDto = new EvcsPostIdentityDto(TEST_USER_ID, null, null, null);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act & Assert
@@ -738,7 +739,7 @@ class ContractTest {
     void testInvalidSiPostIdentityReturns400(MockServer mockServer) {
         // Arrange
         var evcsPostIdentityDto =
-                new EvcsPostIdentityDto(TEST_USER_ID, null, EVCS_INVALID_STORED_IDENTITY_DTO);
+                new EvcsPostIdentityDto(TEST_USER_ID, null, null, EVCS_INVALID_STORED_IDENTITY_DTO);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act & Assert
@@ -791,7 +792,7 @@ class ContractTest {
                 .when(mockConfigService.getSecret(ConfigurationVariable.EVCS_API_KEY))
                 .thenReturn(EVCS_INVALID_API_KEY);
         var evcsPostIdentityDto =
-                new EvcsPostIdentityDto(TEST_USER_ID, null, EVCS_STORED_IDENTITY_DTO);
+                new EvcsPostIdentityDto(TEST_USER_ID, null, null, EVCS_STORED_IDENTITY_DTO);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act & Assert

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -307,60 +307,64 @@ class EvcsServiceTest {
 
     @Nested
     class StoreIdentityWithPostIdentityMethod {
-        @Test
-        void shouldStorePendingIdentityWithPostIdentityMethod() throws Exception {
-            // Arrange
-            var testVcs = List.of(VC_ADDRESS_TEST);
+        //        @Test
+        //        void shouldStorePendingIdentityWithPostIdentityMethod() throws Exception {
+        //            // Arrange
+        //            var testVcs = List.of(VC_ADDRESS_TEST);
+        //
+        //            // Act
+        //            evcsService.storePendingIdentityWithPostIdentity(TEST_USER_ID, testVcs);
+        //
+        //            // Assert
+        //            verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
+        //
+        //            assertEquals(
+        //                    clientOAuthSessionItem.getUserId(),
+        //                    evcsPostIdentityDtoCaptor.getValue().userId());
+        //            assertEquals(
+        //                    VC_ADDRESS_TEST.getVcString(),
+        //                    evcsPostIdentityDtoCaptor.getValue().vcs().get(0).vc());
+        //            assertEquals(PENDING_RETURN,
+        // evcsPostIdentityDtoCaptor.getValue().vcs().get(0).state());
+        //            assertEquals(ONLINE,
+        // evcsPostIdentityDtoCaptor.getValue().vcs().get(0).provenance());
+        //
+        //            verify(mockEvcsClient, never()).updateUserVCs(any(), any());
+        //            verify(mockEvcsClient, never()).storeUserVCs(any(), any());
+        //        }
 
-            // Act
-            evcsService.storePendingIdentityWithPostIdentity(TEST_USER_ID, testVcs);
-
-            // Assert
-            verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
-
-            assertEquals(
-                    clientOAuthSessionItem.getUserId(),
-                    evcsPostIdentityDtoCaptor.getValue().userId());
-            assertEquals(
-                    VC_ADDRESS_TEST.getVcString(),
-                    evcsPostIdentityDtoCaptor.getValue().vcs().get(0).vc());
-            assertEquals(PENDING_RETURN, evcsPostIdentityDtoCaptor.getValue().vcs().get(0).state());
-            assertEquals(ONLINE, evcsPostIdentityDtoCaptor.getValue().vcs().get(0).provenance());
-
-            verify(mockEvcsClient, never()).updateUserVCs(any(), any());
-            verify(mockEvcsClient, never()).storeUserVCs(any(), any());
-        }
-
-        @Test
-        void shouldStoreCompletedIdentityWithPostIdentityMethod() throws Exception {
-            // Arrange
-            var testVcs = List.of(VC_ADDRESS_TEST);
-            var testSiJwt = "test.si.jwt";
-            when(mockStoredIdentityService.getStoredIdentityForEvcs(
-                            TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT))
-                    .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
-
-            // Act
-            evcsService.storeCompletedIdentityWithPostIdentity(
-                    TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT);
-
-            // Assert
-            verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
-
-            assertEquals(
-                    clientOAuthSessionItem.getUserId(),
-                    evcsPostIdentityDtoCaptor.getValue().userId());
-            assertEquals(
-                    VC_ADDRESS_TEST.getVcString(),
-                    evcsPostIdentityDtoCaptor.getValue().vcs().get(0).vc());
-            assertEquals(CURRENT, evcsPostIdentityDtoCaptor.getValue().vcs().get(0).state());
-            assertEquals(ONLINE, evcsPostIdentityDtoCaptor.getValue().vcs().get(0).provenance());
-            assertEquals(testSiJwt, evcsPostIdentityDtoCaptor.getValue().si().jwt());
-            assertEquals(P1, evcsPostIdentityDtoCaptor.getValue().si().vot());
-
-            verify(mockEvcsClient, never()).updateUserVCs(any(), any());
-            verify(mockEvcsClient, never()).storeUserVCs(any(), any());
-        }
+        //        @Test
+        //        void shouldStoreCompletedIdentityWithPostIdentityMethod() throws Exception {
+        //            // Arrange
+        //            var testVcs = List.of(VC_ADDRESS_TEST);
+        //            var testSiJwt = "test.si.jwt";
+        //            when(mockStoredIdentityService.getStoredIdentityForEvcs(
+        //                            TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT))
+        //                    .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
+        //
+        //            // Act
+        //            evcsService.storeCompletedIdentityWithPostIdentity(
+        //                    TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT);
+        //
+        //            // Assert
+        //            verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
+        //
+        //            assertEquals(
+        //                    clientOAuthSessionItem.getUserId(),
+        //                    evcsPostIdentityDtoCaptor.getValue().userId());
+        //            assertEquals(
+        //                    VC_ADDRESS_TEST.getVcString(),
+        //                    evcsPostIdentityDtoCaptor.getValue().vcs().get(0).vc());
+        //            assertEquals(CURRENT,
+        // evcsPostIdentityDtoCaptor.getValue().vcs().get(0).state());
+        //            assertEquals(ONLINE,
+        // evcsPostIdentityDtoCaptor.getValue().vcs().get(0).provenance());
+        //            assertEquals(testSiJwt, evcsPostIdentityDtoCaptor.getValue().si().jwt());
+        //            assertEquals(P1, evcsPostIdentityDtoCaptor.getValue().si().vot());
+        //
+        //            verify(mockEvcsClient, never()).updateUserVCs(any(), any());
+        //            verify(mockEvcsClient, never()).storeUserVCs(any(), any());
+        //        }
     }
 
     @Test

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.core.library.evcs.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +23,6 @@ import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
 import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
-import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
 import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
 
@@ -108,7 +106,6 @@ class EvcsServiceTest {
     private static final VotMatchingResult.VotAndProfile STRONGEST_MATCHED_VOT =
             new VotMatchingResult.VotAndProfile(P1, Optional.of(L1A));
     private static final Vot ACHIEVED_VOT = P1;
-    private static ClientOAuthSessionItem clientOAuthSessionItem;
 
     @Captor ArgumentCaptor<List<EvcsCreateUserVCsDto>> evcsCreateUserVCsDtosCaptor;
     @Captor ArgumentCaptor<List<EvcsUpdateUserVCsDto>> evcsUpdateUserVCsDtosCaptor;
@@ -119,11 +116,6 @@ class EvcsServiceTest {
     @Mock ConfigService mockConfigService;
     @Mock StoredIdentityService mockStoredIdentityService;
     @InjectMocks EvcsService evcsService;
-
-    @BeforeEach
-    void setUp() {
-        clientOAuthSessionItem = ClientOAuthSessionItem.builder().userId(TEST_USER_ID).build();
-    }
 
     @Nested
     class StoreIdentityWithPost {

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.ipv.core.library.evcs.dto.EvcsStoredIdentityDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
+import uk.gov.di.ipv.core.library.evcs.exception.FailedToCreateStoredIdentityForEvcsException;
 import uk.gov.di.ipv.core.library.exceptions.CredentialParseException;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.service.ConfigService;
@@ -42,7 +43,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.enums.Vot.P1;
+import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.ABANDONED;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.CURRENT;
+import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.HISTORIC;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.PENDING_RETURN;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVcProvenance.OFFLINE;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVcProvenance.ONLINE;
@@ -75,6 +78,7 @@ class EvcsServiceTest {
     private static final List<VerifiableCredential> VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS =
             List.of(VC_DRIVING_PERMIT_TEST, VC_ADDRESS_TEST, VC_F2F);
     private static final String TEST_USER_ID = "a-user-id";
+    private static final String TEST_GOVUK_SIGNIN_JOURNEY_ID = "test-govuk-signin-journey-id";
 
     private static final String TEST_EVCS_ACCESS_TOKEN = "TEST_EVCS_ACCESS_TOKEN";
     private static final List<EvcsGetUserVCDto> EVCS_GET_USER_VC_DTO =
@@ -303,68 +307,6 @@ class EvcsServiceTest {
                             .count()));
             mockOrderVerifier.verify(mockEvcsClient, times(0)).storeUserVCs(any(), any());
         }
-    }
-
-    @Nested
-    class StoreIdentityWithPostIdentityMethod {
-        //        @Test
-        //        void shouldStorePendingIdentityWithPostIdentityMethod() throws Exception {
-        //            // Arrange
-        //            var testVcs = List.of(VC_ADDRESS_TEST);
-        //
-        //            // Act
-        //            evcsService.storePendingIdentityWithPostIdentity(TEST_USER_ID, testVcs);
-        //
-        //            // Assert
-        //            verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
-        //
-        //            assertEquals(
-        //                    clientOAuthSessionItem.getUserId(),
-        //                    evcsPostIdentityDtoCaptor.getValue().userId());
-        //            assertEquals(
-        //                    VC_ADDRESS_TEST.getVcString(),
-        //                    evcsPostIdentityDtoCaptor.getValue().vcs().get(0).vc());
-        //            assertEquals(PENDING_RETURN,
-        // evcsPostIdentityDtoCaptor.getValue().vcs().get(0).state());
-        //            assertEquals(ONLINE,
-        // evcsPostIdentityDtoCaptor.getValue().vcs().get(0).provenance());
-        //
-        //            verify(mockEvcsClient, never()).updateUserVCs(any(), any());
-        //            verify(mockEvcsClient, never()).storeUserVCs(any(), any());
-        //        }
-
-        //        @Test
-        //        void shouldStoreCompletedIdentityWithPostIdentityMethod() throws Exception {
-        //            // Arrange
-        //            var testVcs = List.of(VC_ADDRESS_TEST);
-        //            var testSiJwt = "test.si.jwt";
-        //            when(mockStoredIdentityService.getStoredIdentityForEvcs(
-        //                            TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT))
-        //                    .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
-        //
-        //            // Act
-        //            evcsService.storeCompletedIdentityWithPostIdentity(
-        //                    TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT);
-        //
-        //            // Assert
-        //            verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
-        //
-        //            assertEquals(
-        //                    clientOAuthSessionItem.getUserId(),
-        //                    evcsPostIdentityDtoCaptor.getValue().userId());
-        //            assertEquals(
-        //                    VC_ADDRESS_TEST.getVcString(),
-        //                    evcsPostIdentityDtoCaptor.getValue().vcs().get(0).vc());
-        //            assertEquals(CURRENT,
-        // evcsPostIdentityDtoCaptor.getValue().vcs().get(0).state());
-        //            assertEquals(ONLINE,
-        // evcsPostIdentityDtoCaptor.getValue().vcs().get(0).provenance());
-        //            assertEquals(testSiJwt, evcsPostIdentityDtoCaptor.getValue().si().jwt());
-        //            assertEquals(P1, evcsPostIdentityDtoCaptor.getValue().si().vot());
-        //
-        //            verify(mockEvcsClient, never()).updateUserVCs(any(), any());
-        //            verify(mockEvcsClient, never()).storeUserVCs(any(), any());
-        //        }
     }
 
     @Test
@@ -610,6 +552,87 @@ class EvcsServiceTest {
 
         verify(mockEvcsClient, never()).updateUserVCs(any(), any());
         verify(mockEvcsClient, never()).storeUserVCs(any(), any());
+    }
+
+    private List<EvcsCreateUserVCsDto> extractVcsFromDto(
+            EvcsVCState evcsVCState, EvcsPostIdentityDto evcsPostIdentityDto) {
+        return evcsPostIdentityDto.vcs().stream()
+                .filter(vc -> vc.state().equals(evcsVCState))
+                .toList();
+    }
+
+    @Test
+    void shouldStoreStoredIdentityRecordAndVcs()
+            throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
+        // Arrange
+        var testSiJwt = "test.si.jwt";
+        var credentials = List.of(VC_ADDRESS_TEST);
+
+        when(mockStoredIdentityService.getStoredIdentityForEvcs(
+                        TEST_USER_ID, credentials, STRONGEST_MATCHED_VOT, ACHIEVED_VOT))
+                .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
+
+        // Act
+        evcsService.storeStoredIdentityRecordAndVcs(
+                TEST_USER_ID,
+                TEST_GOVUK_SIGNIN_JOURNEY_ID,
+                credentials,
+                EVCS_GET_USER_VC_DTO,
+                STRONGEST_MATCHED_VOT,
+                ACHIEVED_VOT);
+
+        // Assert
+        verify(mockEvcsClient, times(1)).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
+
+        assertEquals(testSiJwt, evcsPostIdentityDtoCaptor.getValue().si().jwt());
+        assertEquals(P1, evcsPostIdentityDtoCaptor.getValue().si().vot());
+        assertEquals(4, evcsPostIdentityDtoCaptor.getValue().vcs().size());
+
+        var extractVcsFromDto = evcsPostIdentityDtoCaptor.getValue();
+        var abandonedVcs = extractVcsFromDto(ABANDONED, extractVcsFromDto).size();
+        var historicVcs = extractVcsFromDto(HISTORIC, extractVcsFromDto).size();
+        var currentVcs = extractVcsFromDto(CURRENT, extractVcsFromDto).size();
+
+        assertEquals(1, abandonedVcs);
+        assertEquals(2, historicVcs);
+        assertEquals(1, currentVcs);
+    }
+
+    @Test
+    void shouldStoreStoredIdentityRecordAndPendingReturnVcsExistingInEvcs()
+            throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
+        // Arrange
+        var testSiJwt = "test.si.jwt";
+        var credentials = List.of(VC_ADDRESS_TEST);
+
+        var existingGetUserVcDto =
+                List.of(
+                        new EvcsGetUserVCDto(
+                                VC_ADDRESS_TEST.getVcString(),
+                                PENDING_RETURN,
+                                Map.of("reason", "testing")));
+
+        when(mockStoredIdentityService.getStoredIdentityForEvcs(
+                        TEST_USER_ID, credentials, STRONGEST_MATCHED_VOT, ACHIEVED_VOT))
+                .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
+
+        // Act
+        evcsService.storeStoredIdentityRecordAndVcs(
+                TEST_USER_ID,
+                TEST_GOVUK_SIGNIN_JOURNEY_ID,
+                credentials,
+                existingGetUserVcDto,
+                STRONGEST_MATCHED_VOT,
+                ACHIEVED_VOT);
+
+        // Assert
+        verify(mockEvcsClient, times(1)).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
+        var extractVcsFromDto = evcsPostIdentityDtoCaptor.getValue();
+
+        assertEquals(testSiJwt, extractVcsFromDto.si().jwt());
+        assertEquals(P1, extractVcsFromDto.si().vot());
+        assertEquals(1, extractVcsFromDto.vcs().size());
+        assertEquals(CURRENT, extractVcsFromDto.vcs().getFirst().state());
     }
 
     @Test

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -358,7 +358,7 @@ core:
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: true
     sisVerificationEnabled: true
-    evcsApiUpdatesEnabled: false
+    evcsApiUpdatesEnabled: true
 
   features:
     evcsApiUpdates:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -358,7 +358,7 @@ core:
     kidJarHeaderEnabled: true
     drivingLicenceAuthCheck: true
     sisVerificationEnabled: true
-    evcsApiUpdatesEnabled: true
+    evcsApiUpdatesEnabled: false
 
   features:
     evcsApiUpdates:


### PR DESCRIPTION
## Proposed changes
### What changed

- Added logic to store the SI object and VCs in a single request to the EVCS POST /identity endpoint according to the API changes. The updated endpoint is fail-closed and redirects the user to an error page if the request fails.
Hidden behind the EVS_API_UPDATES feature flag.

### Why did it change

Currently, we use the POST /identity endpoint for storing Stored Identity objects. The T&R team have updated this endpoint so that:

- the request body takes a [list of VCs](https://github.com/govuk-one-login/ipv-identity-reuse-storage/blob/7b551a6d0a0c3735988af5cc63045aa459324ca5/src/specs/api.yaml#L831-L832) for storage
- the request body also takes a [govuk_signin_journey_id](https://github.com/govuk-one-login/ipv-identity-reuse-storage/blob/7b551a6d0a0c3735988af5cc63045aa459324ca5/src/specs/api.yaml#L779-L786)
- an existing SI will be overridden by the si in the request
- VCs which do not already exist in EVCS will be created.
- VCs which already exist in EVCS will have their state and metadata updated. 
- VCs not referenced in the request will not be updated. To change the state or metadata of a stored VC the caller must include it in the request and EVCS will not automatically change the state of Verifiable Credentials.

With this addition, we can store both the user’s Stored Identity (SI) and their VCs in a single API call.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8459](https://govukverify.atlassian.net/browse/PYIC-8459)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-8459]: https://govukverify.atlassian.net/browse/PYIC-8459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ