### PR TITLE
PYIC-9048: Add temp routing for banners during scheduled Experian outage (26th April 2026)

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -238,6 +238,12 @@ states:
           - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: PYI_ESCAPE_NO_PHOTO_ID
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+      postOfficeTriageBanner:
+        targetState: PYI_POST_OFFICE
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -253,6 +259,12 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+      postOfficeTriageBanner:
+        targetState: PYI_POST_OFFICE
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT


### PR DESCRIPTION
_**NOT TO BE MERGED UNTIL READY TO GO LIVE WTH BANNER**_

## Proposed changes
### What changed

- Add temp routing for banners during scheduled Experian outage (26th April 2026)

### Why did it change

- Experian will be undertaking another scheduled maintenance on Sunday, 26 April 2026 to make changes to their IIQ,

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9048](https://govukverify.atlassian.net/browse/PYIC-9048)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9048]: https://govukverify.atlassian.net/browse/PYIC-9048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ