### PR TITLE
Revert "PYIC-9048: Add temp routing for banners during scheduled Experian outage (26th April 2026)"

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -238,12 +238,6 @@ states:
           - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: PYI_ESCAPE_NO_PHOTO_ID
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
-      postOfficeTriageBanner:
-        targetState: PYI_POST_OFFICE
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -259,12 +253,6 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
-      # Temporary routing
-      appTriageBanner:
-        targetState: STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
-      postOfficeTriageBanner:
-        targetState: PYI_POST_OFFICE
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-back#3904