### PR TITLE
PYIC-9008: Remove reference to storedIdentityService

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -109,7 +109,6 @@ Feature: Audit Events
       | CRI     | scenario               |
       | address | kenneth-current        |
       | fraud   | kenneth-score-2        |
-    And I activate the 'storedIdentityService' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'page-ipv-reuse' page response
     When I submit a 'next' event

--- a/api-tests/features/stored-identity/m1c-journeys.feature
+++ b/api-tests/features/stored-identity/m1c-journeys.feature
@@ -1,7 +1,5 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Stored Identity - M1C Outcomes
-  Background:
-    Given I activate the 'storedIdentityService' feature set
 
   Rule: New Identities - UK Address
     Background:

--- a/api-tests/features/stored-identity/p1-journeys.feature
+++ b/api-tests/features/stored-identity/p1-journeys.feature
@@ -1,7 +1,6 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Stored Identity - P1 journeys
   Background: Enabled stored identity service flag and start p1 journey
-    Given I activate the 'storedIdentityService' feature sets
     When I start a new 'low-confidence' journey
     Then I get a 'page-ipv-identity-document-start' page response
 

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -1,7 +1,5 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Stored Identity - P2 journeys
-  Background: Enabled stored identity service flag and start p1 journey
-    Given I activate the 'storedIdentityService' feature sets
 
   Scenario: Successful stored identity storage - P2 app international journey - medium-confidence journey
     When I start a new 'medium-confidence' journey
@@ -158,8 +156,7 @@ Feature: Stored Identity - P2 journeys
       Then I get a 'prove-identity-no-photo-id' page response
       When I submit an 'next' event
       Then I get a 'claimedIdentity' CRI response
-      When I activate the 'storedIdentityService' feature set
-      And I submit 'kenneth-current' details with attributes to the CRI stub
+      When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
       Then I get a 'bav' CRI response


### PR DESCRIPTION
## Proposed changes
### What changed

Remove storedIdentityService use from API tests

### Why did it change

Usage of the flag has already been removed

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9008](https://govukverify.atlassian.net/browse/PYIC-9008)


[PYIC-9008]: https://govukverify.atlassian.net/browse/PYIC-9008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ