### PR TITLE
PYIC-8459: Add temporary routes for notification banner. Experian outage 10th May 2026.

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -238,6 +238,12 @@ states:
           - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: PYI_ESCAPE_NO_PHOTO_ID
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+      appTriageBanner2:
+        targetState: PYI_POST_OFFICE
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -253,6 +259,12 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+      appTriageBanner2:
+          targetState: PYI_POST_OFFICE
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT


### PR DESCRIPTION
We are set notification banners with link for Experian outage on 10th May 2026. New routes redirect user to device sniffing page or post office journey.

## Proposed changes
### What changed

- Added temporary routes for notification banner links.
- Redirect user to device sniffing page
- Redirect user to post office journey

### Why did it change

Experian will be undertaking another scheduled maintenance on Sunday, 10 May 2026 to make changes resulting in a 100% service outage for Experian KBVs between 18:30 and 22:30.

Notification banner : A notification banner will be displayed informing users that, during this period, identity verification will be limited to the app and F2F. The banner is scheduled to appear when the outage is ongoing.

The only way users will be able to prove their identity during this period are :
- using the GOV.UK one login app
- using F2F

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9110](https://govukverify.atlassian.net/browse/PYIC-9110)

## Checklists

- [x] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9110]: https://govukverify.atlassian.net/browse/PYIC-9110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ