### PR TITLE
PYIC-8711: Routing to avoid a dead end for COI/RFC users

### DIFF
--- a/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
+++ b/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
@@ -1,0 +1,380 @@
+@Build @QualityGateIntegrationTest @QualityGateRegressionTest
+Feature: Update details higher strength
+  Rule: Repeat Fraud Check
+    Background:
+      Given the subject already has the following credentials
+        | CRI     | scenario               |
+        | dcmaw   | kenneth-passport-valid |
+        | address | kenneth-current        |
+      And the subject already has the following expired credentials
+        | CRI   | scenario        |
+        | fraud | kenneth-score-2 |
+      And I have an existing stored identity record with a 'P3' vot
+      And I activate the 'coi6mfcDeadEndRouting' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
+
+    Scenario: Successful 6MFC identity recovery via App for Name and Address change
+      When I submit a 'family-name-and-address' event
+      Then I get a 'page-update-name' page response and pageContext
+        | Context     | Value            |
+        | journeyType | repeatFraudCheck |
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value             |
+        | journeyType          | repeatFraudCheck  |  
+      When I submit an 'passport' event  
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-changed-given-name-passport-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response and pageContext
+        | Context   | Value |
+        | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'address' CRI response
+      When I submit 'kenneth-changed' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response and pageContext
+        | Context     | Value |
+        | journeyType | coi   | 
+
+    Scenario: Successful 6MFC identity recovery via App for Name change only
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response and pageContext
+        | Context     | Value            |
+        | journeyType | repeatFraudCheck |
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value             |
+        | journeyType          | repeatFraudCheck  |  
+      When I submit an 'passport' event  
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-changed-given-name-passport-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response and pageContext
+        | Context   | Value |
+        | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response and pageContext
+        | Context     | Value |
+        | journeyType | coi   | 
+
+    Scenario: User abandons 6MFC App recovery
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response and pageContext
+        | Context     | Value            |
+        | journeyType | repeatFraudCheck |
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value            |
+        | journeyType          | repeatFraudCheck |   
+      When I submit an 'passport' event  
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces an 'access_denied' error response
+      And I pass on the DCMAW callback
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'pyi-no-match' page response and pageContext
+        | Context | Value            |
+        | reason  | repeatFraudCheck |
+
+  Rule: Update details
+    Background:
+      Given the subject already has the following credentials
+        | CRI     | scenario               |
+        | dcmaw   | kenneth-passport-valid |
+        | address | kenneth-current        |
+        | fraud   | kenneth-score-2        |
+      And I have an existing stored identity record with a 'P3' vot
+      And I activate the 'coi6mfcDeadEndRouting' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-reuse' page response
+      When I submit a 'update-details' event
+      Then I get a 'update-details' page response
+
+    Scenario: Successful COI identity recovery via App after name update
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value         |
+        | journeyType          | updateDetails |    
+      When I submit an 'passport' event  
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-changed-given-name-passport-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response and pageContext
+        | Context   | Value |
+        | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response and pageContext
+        | Context     | Value |
+        | journeyType | coi   | 
+
+    Scenario: COI recovery fails at final Fraud check
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value         |
+        | journeyType          | updateDetails |  
+      When I submit an 'passport' event  
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-changed-given-name-passport-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response and pageContext
+        | Context   | Value |
+        | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'pyi-no-match' page response and pageContext
+        | Context | Value         |
+        | reason  | updateDetails |
+
+    Scenario: User fails twice with app
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value         |
+        | journeyType          | updateDetails |   
+      When I submit an 'passport' event  
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'pyi-no-match' page response and pageContext
+        | Context | Value         |
+        | reason  | updateDetails |
+
+    Scenario: User chooses not to use the app after initial failure
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value         |
+        | journeyType          | updateDetails |    
+      When I submit an 'passport' event  
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When I submit a 'preferNoApp' event
+      Then I get an 'update-details-failed' page response

--- a/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
+++ b/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
@@ -39,7 +39,7 @@ Feature: Update details higher strength
       When I submit the returned journey event
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value             |
-        | journeyType          | repeatFraudCheck  |  
+        | journeyType          | repeatFraudCheck  |
       When I submit an 'passport' event  
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -57,9 +57,7 @@ Feature: Update details higher strength
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
-      Then I get a 'page-dcmaw-success' page response and pageContext
-        | Context   | Value |
-        | noAddress | true  |
+      Then I get a 'page-dcmaw-success' page response
       When I submit a 'next' event
       Then I get a 'address' CRI response
       When I submit 'kenneth-changed' details to the CRI stub
@@ -96,7 +94,7 @@ Feature: Update details higher strength
       When I submit the returned journey event
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value             |
-        | journeyType          | repeatFraudCheck  |  
+        | journeyType          | repeatFraudCheck  |
       When I submit an 'passport' event  
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -151,7 +149,7 @@ Feature: Update details higher strength
       When I submit the returned journey event
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value            |
-        | journeyType          | repeatFraudCheck |   
+        | journeyType          | repeatFraudCheck |
       When I submit an 'passport' event  
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -173,6 +171,41 @@ Feature: Update details higher strength
       Then I get a 'pyi-no-match' page response and pageContext
         | Context | Value            |
         | reason  | repeatFraudCheck |
+    
+    Scenario: 6MFC identity recovery via App for Name change only profile unmet
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response and pageContext
+        | Context     | Value            |
+        | journeyType | repeatFraudCheck |
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+      And I pass on the DCMAW callback
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response and pageContext
+        | Context   | Value |
+        | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-1-history-0' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value            |
+        | journeyType          | repeatFraudCheck |
 
   Rule: Update details
     Background:
@@ -211,7 +244,7 @@ Feature: Update details higher strength
       When I submit the returned journey event
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value         |
-        | journeyType          | updateDetails |    
+        | journeyType          | updateDetails |
       When I submit an 'passport' event  
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -264,7 +297,7 @@ Feature: Update details higher strength
       When I submit the returned journey event
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value         |
-        | journeyType          | updateDetails |  
+        | journeyType          | updateDetails |
       When I submit an 'passport' event  
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -317,7 +350,7 @@ Feature: Update details higher strength
       When I submit the returned journey event
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value         |
-        | journeyType          | updateDetails |   
+        | journeyType          | updateDetails |
       When I submit an 'passport' event  
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -362,7 +395,7 @@ Feature: Update details higher strength
       When I submit the returned journey event
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value         |
-        | journeyType          | updateDetails |    
+        | journeyType          | updateDetails |
       When I submit an 'passport' event  
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event

--- a/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
+++ b/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
@@ -190,11 +190,13 @@ Feature: Update details higher strength
         | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
       And I pass on the DCMAW callback
       When I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
       Then I get a 'page-dcmaw-success' page response and pageContext
         | Context   | Value |
         | noAddress | true  |
@@ -202,10 +204,39 @@ Feature: Update details higher strength
       Then I get a 'fraud' CRI response
       When I submit 'kenneth-score-1-history-0' details with attributes to the CRI stub
         | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
+        | evidence_requested | {"identityFraudScore": 2} |
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value            |
         | journeyType          | repeatFraudCheck |
+       When I submit an 'passport' event  
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-changed-given-name-passport-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response and pageContext
+        | Context   | Value |
+        | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response and pageContext
+        | Context     | Value |
+        | journeyType | coi   | 
+
 
   Rule: Update details
     Background:

--- a/journey-map/src/constants.ts
+++ b/journey-map/src/constants.ts
@@ -5,6 +5,7 @@ export const JOURNEY_TYPES: Record<string, string> = {
   REUSE_EXISTING_IDENTITY: "Reuse existing identity",
   UPDATE_NAME: "Update name",
   UPDATE_ADDRESS: "Update address",
+  UPDATE_DETAILS_HIGHER_STRENGTH: "Update details with higher srength",
   INELIGIBLE: "Ineligible journey",
   FAILED: "Failed journey",
   TECHNICAL_ERROR: "Technical error",

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -74,15 +74,21 @@ states:
       next:
         targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_NINO
 
-  FAILED_RFC:
-    events:
-      next:
-        targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_REPEAT_FRAUD_CHECK
-
-  FAILED_COI:
+  FAILED_UPDATE_DETAILS_HIGHER_STRENGTH:
     events:
       next:
         targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_UPDATE_DETAILS
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_END
+        auditContext:
+          successful: false
+        checkJourneyContext:
+          rfc:
+            targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_REPEAT_FRAUD_CHECK
+            auditEvents:
+              - IPV_USER_DETAILS_UPDATE_END
+            auditContext:
+              successful: false
 
   FAILED_NO_TICF:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -74,6 +74,16 @@ states:
       next:
         targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_NINO
 
+  FAILED_RFC:
+    events:
+      next:
+        targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_REPEAT_FRAUD_CHECK
+
+  FAILED_COI:
+    events:
+      next:
+        targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_UPDATE_DETAILS
+
   FAILED_NO_TICF:
     events:
       next:
@@ -224,6 +234,42 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR_NO_TICF
 
+  PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_REPEAT_FRAUD_CHECK:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_REPEAT_FRAUD_CHECK
+      account-intervention:
+        targetJourney: FAILED
+        targetState: FAILED_ACCOUNT_INTERVENTION
+      fail-with-ci:
+        targetState: NO_MATCH_PAGE_REPEAT_FRAUD_CHECK
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
+  PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_UPDATE_DETAILS:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: NO_MATCH_PAGE_UPDATE_DETAILS
+      account-intervention:
+        targetJourney: FAILED
+        targetState: FAILED_ACCOUNT_INTERVENTION
+      fail-with-ci:
+        targetState: NO_MATCH_PAGE_UPDATE_DETAILS
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
   COULD_NOT_CONFIRM_DETAILS_PAGE_VALID_ID:
     response:
       type: page
@@ -336,6 +382,26 @@ states:
       pageId: pyi-no-match
       pageContext:
         reason: nino
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  NO_MATCH_PAGE_REPEAT_FRAUD_CHECK:
+    response:
+      type: page
+      pageId: pyi-no-match
+      pageContext:
+        reason: repeatFraudCheck
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  NO_MATCH_PAGE_UPDATE_DETAILS:
+    response:
+      type: page
+      pageId: pyi-no-match
+      pageContext:
+        reason: updateDetails
     events:
       next:
         targetState: RETURN_TO_RP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -111,7 +111,7 @@ nestedJourneyStates:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
-        exitEventToEmit: anotherWay
+        exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
@@ -144,7 +144,7 @@ nestedJourneyStates:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
-        exitEventToEmit: anotherWay
+        exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
@@ -197,7 +197,7 @@ nestedJourneyStates:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
-        exitEventToEmit: anotherWay
+        exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
@@ -230,7 +230,7 @@ nestedJourneyStates:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
-        exitEventToEmit: anotherWay
+        exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
@@ -487,7 +487,7 @@ nestedJourneyStates:
       failedDlAuthCheckInvalidDl:
         exitEventToEmit: failedDlAuthCheckInvalidDl
       failWithNoCiFromApp:
-        exitEventToEmit: anotherWay
+        exitEventToEmit: failWithNoCiFromApp
       failWithCiFromApp:
         exitEventToEmit: failWithCiFromApp
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -176,6 +176,15 @@ states:
       failWithCiFromApp:
         targetJourney: FAILED
         targetState: FAILED
+      failWithNoCiFromApp:
+        targetState: MULTIPLE_DOC_CHECK_PAGE
+        checkMitigation:
+          enhanced-verification:
+            targetState: MITIGATION_01_PYI_POST_OFFICE
+            checkIfDisabled:
+              f2f:
+                targetJourney: INELIGIBLE
+                targetState: INELIGIBLE
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
@@ -587,6 +596,12 @@ states:
       failWithCiFromApp:
         targetJourney: FAILED
         targetState: FAILED
+      failWithNoCiFromApp:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -173,6 +173,16 @@ states:
       failWithCiFromApp:
         targetJourney: FAILED
         targetState: FAILED
+      failWithNoCiFromApp:
+        targetState: MULTIPLE_DOC_CHECK_PAGE
+        journeyContextToUnset: appOnly
+        checkMitigation:
+          enhanced-verification:
+            targetState: MITIGATION_01_PYI_POST_OFFICE
+            checkIfDisabled:
+              f2f:
+                targetJourney: INELIGIBLE
+                targetState: INELIGIBLE
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
         journeyContextToUnset: appOnly
@@ -639,6 +649,12 @@ states:
       failWithCiFromApp:
         targetJourney: FAILED
         targetState: FAILED
+      failWithNoCiFromApp:
+        targetState: PYI_POST_OFFICE
+        checkIfDisabled:
+          f2f:
+            targetJourney: INELIGIBLE
+            targetState: INELIGIBLE
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
@@ -754,6 +770,8 @@ states:
       failWithCiFromApp:
         targetJourney: FAILED
         targetState: FAILED
+      failWithNoCiFromApp:
+        targetState: STRATEGIC_APP_NON_UK_NO_APP_PAGE
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -55,12 +55,11 @@ states:
     response:
       type: page
       pageId: page-dcmaw-success
-      pageContext:
-        noAddress: true
     events:
       next:
         targetState: ADDRESS_AND_FRAUD
         targetEntryEvent: internationalUser
+        journeyContextToUnset: nameAndAddress
 
   FRAUD_CHECK_NAMES_ONLY:
     response:
@@ -72,18 +71,10 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
 
   ADDRESS_AND_FRAUD:
     nestedJourney: ADDRESS_AND_FRAUD
@@ -93,13 +84,13 @@ states:
       fraud-fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
 
-  # Remove any DCMAW Async VC from previous attempts
+  # Remove all VCs from previous attempts
   RESET_SESSION_BEFORE_NEW_IDENTITY:
     response:
       type: process
       lambda: reset-session-identity
       lambdaInput:
-        resetType: PENDING_DCMAW_ASYNC_ALL
+        resetType: ALL
     events:
       next:
         targetState: STRATEGIC_APP_IDENTIFY_DEVICE
@@ -123,25 +114,13 @@ states:
         targetState: FAILED_ACCOUNT_INTERVENTION
       coi-check-failed:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       profile-unmet:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
@@ -177,7 +156,8 @@ states:
       dadAndroid:
         targetState: DAD_ANDROID_START_SESSION
       noDevice:
-        targetState: NEED_TO_REPROVE_NO_DEVICE
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
 
   # Mobile pages
   MOBILE_IPHONE_START_SESSION:
@@ -211,14 +191,10 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_RFC
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -254,14 +230,10 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_RFC
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -300,24 +272,16 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_RFC
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED
@@ -330,14 +294,10 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_RFC
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
 
   DAD_ANDROID_START_SESSION:
     response:
@@ -372,24 +332,16 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_RFC
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED
@@ -402,14 +354,10 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_RFC
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
 
   # Handle app result
   STRATEGIC_APP_HANDLE_RESULT:
@@ -422,11 +370,7 @@ states:
             targetState: POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       incompleteDlAuthCheckInvalidDlv2:
         targetJourney: UPDATE_NAME
         targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_ONLY
@@ -436,60 +380,13 @@ states:
             targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_WITH_ADDRESS
       failedDlAuthCheckInvalidDl:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       failWithCiFromApp:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       failWithNoCiFromApp:
         targetJourney: FAILED
-        targetState: FAILED_COI
-        checkJourneyContext:
-          rfc:
-            targetJourney: FAILED
-            targetState: FAILED_RFC
-
-  NEED_TO_REPROVE_NO_DEVICE:
-    response:
-      type: page
-      pageId: need-prove-identity-again-no-app
-    events:
-      delete:
-        targetState: DELETE_LOGIN
-      returnToRp:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
-
-  DELETE_LOGIN:
-    response:
-      type: page
-      pageId: delete-handover
-      pageContext:
-        journeyType: reprove
-
-  PROCESS_INCOMPLETE_IDENTITY:
-    response:
-      type: process
-      lambda: process-candidate-identity
-      lambdaInput:
-        identityType: INCOMPLETE
-    events:
-      next:
-        targetState: RETURN_TO_RP
-      account-intervention:
-        targetJourney: FAILED
-        targetState: FAILED_ACCOUNT_INTERVENTION
-      fail-with-ci:
-        targetState: RETURN_TO_RP
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
 
   # Parent states (needed for STRATEGIC_APP_HANDLE_RESULT)
   CRI_STATE:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -1,0 +1,523 @@
+name: Update Name Higher Strength
+
+description: >-
+  A journey for users to retry with higher srength doc
+
+states:
+
+  # Entry points
+  START_HIGHER_STRENGTH:
+    events:
+      next:
+        targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS
+        checkJourneyContext:
+          rfc:
+            targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK
+
+  # Journey States
+  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK:
+    response:
+      type: page
+      pageId: need-more-information-confirm-change-details
+      pageContext:
+        journeyType: repeatFraudCheck
+    events:
+      passport:
+        targetState: RESET_SESSION_BEFORE_NEW_IDENTITY
+      returnToRp:
+        targetJourney: FAILED
+        targetState: FAILED_SKIP_MESSAGE
+
+  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS:
+    response:
+      type: page
+      pageId: need-more-information-confirm-change-details
+      pageContext:
+        journeyType: updateDetails
+    events:
+      passport:
+        targetState: RESET_SESSION_BEFORE_NEW_IDENTITY
+      returnToRp:
+        targetJourney: FAILED
+        targetState: FAILED_SKIP_MESSAGE
+
+  POST_APP_DOC_CHECK_NAMES_ONLY:
+    response:
+      type: page
+      pageId: page-dcmaw-success
+      pageContext:
+        noAddress: true
+    events:
+      next:
+        targetState: FRAUD_CHECK_NAMES_ONLY
+    
+  POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS:
+    response:
+      type: page
+      pageId: page-dcmaw-success
+      pageContext:
+        noAddress: true
+    events:
+      next:
+        targetState: ADDRESS_AND_FRAUD
+        targetEntryEvent: internationalUser
+
+  FRAUD_CHECK_NAMES_ONLY:
+    response:
+      type: cri
+      criId: fraud
+    parent: CRI_STATE
+    events:
+      next:
+        targetState: PROCESS_UPDATE_IDENTITY
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+
+  ADDRESS_AND_FRAUD:
+    nestedJourney: ADDRESS_AND_FRAUD
+    exitEvents:
+      next:
+        targetState: PROCESS_UPDATE_IDENTITY
+      fraud-fail-with-no-ci:
+        targetState: PROCESS_UPDATE_IDENTITY
+
+  # Remove any DCMAW Async VC from previous attempts
+  RESET_SESSION_BEFORE_NEW_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: PENDING_DCMAW_ASYNC_ALL
+    events:
+      next:
+        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
+        targetEntryEvent: identify-device
+
+  PROCESS_UPDATE_IDENTITY:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: UPDATE
+    events:
+      next:
+        targetState: IPV_SUCCESS_PAGE
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_END
+        auditContext:
+          successful: true
+      account-intervention:
+        targetJourney: FAILED
+        targetState: FAILED_ACCOUNT_INTERVENTION
+      coi-check-failed:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      profile-unmet:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  IPV_SUCCESS_PAGE:
+    response:
+      type: page
+      pageId: page-ipv-success
+      pageContext:
+        journeyType: coi
+    events:
+      next:
+        targetState: RETURN_TO_RP
+
+  RETURN_TO_RP:
+    response:
+      type: process
+      lambda: build-client-oauth-response
+
+  # Device detection
+  STRATEGIC_APP_IDENTIFY_DEVICE:
+    nestedJourney: STRATEGIC_APP_IDENTIFY_DEVICE
+    exitEvents:
+      mamIphone:
+        targetState: MOBILE_IPHONE_START_SESSION
+      mamAndroid:
+        targetState: MOBILE_ANDROID_START_SESSION
+      dadIphone:
+        targetState: DAD_IPHONE_START_SESSION
+      dadAndroid:
+        targetState: DAD_ANDROID_START_SESSION
+      noDevice:
+        targetState: NEED_TO_REPROVE_NO_DEVICE
+
+  # Mobile pages
+  MOBILE_IPHONE_START_SESSION:
+    response:
+      type: process
+      lambda: call-dcmaw-async-cri
+      lambdaInput:
+        mobileAppJourneyType: mam
+    events:
+      next:
+        targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
+        journeyContextToSet: mamIphone
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE:
+    response:
+      type: page
+      pageId: pyi-triage-mobile-download-app
+      pageContext:
+        smartphone: iphone
+        isAppOnly: true
+    events:
+      next:
+        targetState: STRATEGIC_APP_HANDLE_RESULT
+        targetEntryEvent: check-mobile-app-result
+      preferNoApp:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      anotherWay:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  MOBILE_ANDROID_START_SESSION:
+    response:
+      type: process
+      lambda: call-dcmaw-async-cri
+      lambdaInput:
+        mobileAppJourneyType: mam
+    events:
+      next:
+        targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
+        journeyContextToSet: mamAndroid
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE:
+    response:
+      type: page
+      pageId: pyi-triage-mobile-download-app
+      pageContext:
+        smartphone: android
+        isAppOnly: true
+    events:
+      next:
+        targetState: STRATEGIC_APP_HANDLE_RESULT
+        targetEntryEvent: check-mobile-app-result
+      preferNoApp:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      anotherWay:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  # Desktop pages
+  DAD_IPHONE_START_SESSION:
+    response:
+      type: process
+      lambda: call-dcmaw-async-cri
+      lambdaInput:
+        mobileAppJourneyType: dad
+    events:
+      next:
+        targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
+        journeyContextToSet: dadIphone
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE:
+    response:
+      type: page
+      pageId: pyi-triage-desktop-download-app
+      pageContext:
+        smartphone: iphone
+        isAppOnly: true
+    events:
+      next:
+        targetState: POST_APP_DOC_CHECK_NAMES_ONLY
+        checkJourneyContext:
+          nameAndAddress:
+            targetState: POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS
+      abandon:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+      dl-auth-source-check:
+        targetState: STRATEGIC_APP_HANDLE_RESULT
+        targetEntryEvent: dl-auth-source-check
+      preferNoApp:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      anotherWay:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+
+  DAD_ANDROID_START_SESSION:
+    response:
+      type: process
+      lambda: call-dcmaw-async-cri
+      lambdaInput:
+        mobileAppJourneyType: dad
+    events:
+      next:
+        targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
+        journeyContextToSet: dadAndroid
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE:
+    response:
+      type: page
+      pageId: pyi-triage-desktop-download-app
+      pageContext:
+        smartphone: android
+        isAppOnly: true
+    events:
+      next:
+        targetState: POST_APP_DOC_CHECK_NAMES_ONLY
+        checkJourneyContext:
+          nameAndAddress:
+            targetState: POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS
+      abandon:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+      dl-auth-source-check:
+        targetState: STRATEGIC_APP_HANDLE_RESULT
+        targetEntryEvent: dl-auth-source-check
+      preferNoApp:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      anotherWay:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+
+  # Handle app result
+  STRATEGIC_APP_HANDLE_RESULT:
+    nestedJourney: STRATEGIC_APP_HANDLE_RESULT
+    exitEvents:
+      next:
+        targetState: POST_APP_DOC_CHECK_NAMES_ONLY
+        checkJourneyContext:
+          nameAndAddress:
+            targetState: POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS
+      anotherWay:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      incompleteDlAuthCheckInvalidDlv2:
+        targetJourney: UPDATE_NAME
+        targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_ONLY
+        checkJourneyContext:
+          nameAndAddress:
+            targetJourney: UPDATE_NAME
+            targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_WITH_ADDRESS
+      failedDlAuthCheckInvalidDl:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      failWithCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+      failWithNoCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED_COI
+        checkJourneyContext:
+          rfc:
+            targetJourney: FAILED
+            targetState: FAILED_RFC
+
+  NEED_TO_REPROVE_NO_DEVICE:
+    response:
+      type: page
+      pageId: need-prove-identity-again-no-app
+    events:
+      delete:
+        targetState: DELETE_LOGIN
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+
+  DELETE_LOGIN:
+    response:
+      type: page
+      pageId: delete-handover
+      pageContext:
+        journeyType: reprove
+
+  PROCESS_INCOMPLETE_IDENTITY:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      account-intervention:
+        targetJourney: FAILED
+        targetState: FAILED_ACCOUNT_INTERVENTION
+      fail-with-ci:
+        targetState: RETURN_TO_RP
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  # Parent states (needed for STRATEGIC_APP_HANDLE_RESULT)
+  CRI_STATE:
+    events:
+      not-found:
+        targetJourney: FAILED
+        targetState: FAILED
+      fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      access-denied:
+        targetJourney: FAILED
+        targetState: FAILED
+      invalid-request:
+        targetJourney: FAILED
+        targetState: FAILED
+      temporarily-unavailable:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+      fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      vcs-not-correlated:
+        targetJourney: FAILED
+        targetState: FAILED
+      dl-auth-source-check:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -90,7 +90,7 @@ states:
       type: process
       lambda: reset-session-identity
       lambdaInput:
-        resetType: ALL
+        resetType: ALL_INC_DCMAW_ASYNC_PENDING
     events:
       next:
         targetState: STRATEGIC_APP_IDENTIFY_DEVICE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -106,7 +106,14 @@ states:
       failWithCiFromApp:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
+      failWithNoCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
         journeyContextToUnset: appOnly
+        checkFeatureFlag:
+          coi6mfcDeadEndRoutingEnabled:
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
       returnToRp:
         targetState: RETURN_TO_RP
         journeyContextToUnset: appOnly
@@ -145,6 +152,10 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
+        checkFeatureFlag:
+          coi6mfcDeadEndRoutingEnabled:
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
@@ -236,6 +247,15 @@ states:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
         journeyContextToUnset: appOnly
+      failWithNoCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS
+        journeyContextToUnset: appOnly
+        checkFeatureFlag:
+          coi6mfcDeadEndRoutingEnabled:
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
+            journeyContextToSet: nameAndAddress
       returnToRp:
         targetState: RETURN_TO_RP
         journeyContextToUnset: appOnly
@@ -299,9 +319,13 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fraud-fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
+        checkFeatureFlag:
+          coi6mfcDeadEndRoutingEnabled:
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
+            journeyContextToSet: nameAndAddress
 
   # SHARED STATES
-
   PROCESS_UPDATE_IDENTITY:
     response:
       type: process

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -271,6 +271,7 @@ states:
         targetState: STRATEGIC_APP_TRIAGE_NAMES_WITH_ADDRESS
         targetEntryEvent: appTriage
         journeyContextToSet: appOnly
+        journeyContextToUnset: nameAndAddress
       returnToRp:
         targetState: RETURN_TO_RP
 
@@ -351,6 +352,10 @@ states:
       profile-unmet:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+        checkFeatureFlag:
+          coi6mfcDeadEndRoutingEnabled:
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF

--- a/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
+++ b/lambdas/reset-session-identity/src/main/java/uk/gov/di/ipv/core/resetsessionidentity/ResetSessionIdentityHandler.java
@@ -40,6 +40,7 @@ import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
+import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.ALL_INC_DCMAW_ASYNC_PENDING;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_DCMAW_ASYNC_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.SessionCredentialsResetType.REINSTATE;
@@ -160,7 +161,8 @@ public class ResetSessionIdentityHandler
                                         input.getDeviceInformation())));
             }
 
-            if (sessionCredentialsResetType.equals(PENDING_DCMAW_ASYNC_ALL)) {
+            if (sessionCredentialsResetType.equals(PENDING_DCMAW_ASYNC_ALL)
+                    || sessionCredentialsResetType.equals(ALL_INC_DCMAW_ASYNC_PENDING)) {
                 doResetForPendingVc(clientOAuthSessionItem, DCMAW_ASYNC);
             }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/domain/IpvJourneyTypes.java
@@ -33,6 +33,7 @@ public enum IpvJourneyTypes {
     // Continuity of Identity journeys
     UPDATE_ADDRESS("update-address"),
     UPDATE_NAME("update-name"),
+    UPDATE_DETAILS_HIGHER_STRENGTH("update-details-higher-strength"),
 
     // MFA reset journey
     REVERIFICATION("reverification");

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/SessionCredentialsResetType.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.core.library.enums;
 
 public enum SessionCredentialsResetType {
     ALL,
+    ALL_INC_DCMAW_ASYNC_PENDING, // PYIC-8711: Investigate if we can use PENDING_DCMAW_ASYNC_ALL
     DCMAW,
     DCMAW_ASYNC,
     NAME_ONLY_CHANGE,

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -356,6 +356,7 @@ core:
     sisVerificationEnabled: true
     testFeatureFlag: false
     evcsApiUpdatesEnabled: false
+    coi6mfcDeadEndRoutingEnabled: false
   features:
     testFeature:
       self:
@@ -366,6 +367,9 @@ core:
     disableTestFeatureFlag:
       featureFlags:
         testFeatureFlag: false
+    coi6mfcDeadEndRouting:
+      featureFlags:
+        coi6mfcDeadEndRoutingEnabled: true
     evcsApiUpdates:
       featureFlags:
         evcsApiUpdatesEnabled: true

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -106,7 +106,8 @@ public class SessionCredentialsService {
             var sessionCredentialItems = dataStore.getItems(ipvSessionId);
             var vcsToDelete =
                     switch (resetType) {
-                        case ALL, PENDING_F2F_ALL, REINSTATE -> sessionCredentialItems;
+                        case ALL, ALL_INC_DCMAW_ASYNC_PENDING, PENDING_F2F_ALL, REINSTATE ->
+                                sessionCredentialItems;
                         case ADDRESS_ONLY_CHANGE ->
                                 sessionCredentialItems.stream()
                                         .filter(

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -360,8 +360,12 @@ core:
     sisVerificationEnabled: true
     evcsApiUpdatesEnabled: false
     mitigations9020Enabled: false
+    coi6mfcDeadEndRoutingEnabled: false
 
   features:
+    coi6mfcDeadEndRouting:
+      featureFlags:
+        coi6mfcDeadEndRoutingEnabled: true
     mitigations9020:
       featureFlags:
         mitigations9020Enabled: true


### PR DESCRIPTION
## Proposed changes
### What changed

- Add new journeyMap update-details-higher-strength. This follows same pattern as intervention-reprove-identity. Due to specific scenarios such as the link on page firing the preferNoApp event we need to dupliate the strategicAppTriage steps manually. 
 
- Scenarios covered:
  - COI / 6MFC / user route due to GPG45 evaluation failures
  - COI / 6MFC / User drop-off in DCMAW eligibility screens/ ineligible for app
  - COI / 6MFC / User chooses “Confirm your identity another way” in the app - abandoned event
  - COI / 6MFC / System error with option to exit
  - COI / 6MFC / Fail app twice
  - COI / 6MFC / Fail final fraud

### Why did it change

- In One Login, users are required to maintain a level of confidence in their identity to access services. Its possible that during COI journey while updating their details , some users may lose their medium confidence status.

- Currently, these users can encounter a dead end — either being shown a failure page or being forced to return to the relying party without a valid route to recover their status.

- To avoid this, we should provide users in both journeys with a clear option to use a valid passport via the GOV.UK One login app to re-establish their medium confidence level.


### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8711](https://govukverify.atlassian.net/browse/PYIC-8711)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-8711]: https://govukverify.atlassian.net/browse/PYIC-8711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ