### PR TITLE
PYIC-9087: Add new routes for non uk users.

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -181,7 +181,7 @@ nestedJourneyStates:
       useApp:
         targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
 
-  DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP:
+  DESKTOP_IPHONE_DOWNLOAD_PAGE_NEED_APP:
     response:
       type: page
       pageId: need-app
@@ -277,7 +277,7 @@ nestedJourneyStates:
       useApp:
         targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
 
-  DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP:
+  DESKTOP_ANDROID_DOWNLOAD_PAGE_NEED_APP:
     response:
       type: page
       pageId: need-app
@@ -495,7 +495,7 @@ nestedJourneyStates:
       useApp:
         targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
 
-  DAD_SELECT_SMARTPHONE_NON_UK_NEED_APP:
+  DAD_SELECT_SMARTPHONE_NEED_APP:
     response:
       type: page
       pageId: need-app
@@ -506,7 +506,7 @@ nestedJourneyStates:
         targetState: STRATEGIC_APP_IDENTIFY_DEVICE
         targetEntryEvent: dad-select-smartphone
 
-  MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP:
+  MOBILE_IPHONE_DOWNLOAD_PAGE_NEED_APP:
     response:
       type: page
       pageId: need-app
@@ -516,7 +516,7 @@ nestedJourneyStates:
       useApp:
         targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
 
-  MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP:
+  MOBILE_ANDROID_DOWNLOAD_PAGE_NEED_APP:
     response:
       type: page
       pageId: need-app

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -181,6 +181,16 @@ nestedJourneyStates:
       useApp:
         targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
 
+  DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP:
+    response:
+      type: page
+      pageId: need-app
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
+      useApp:
+        targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
+
   DESKTOP_ANDROID_DOWNLOAD_PAGE:
     response:
       type: page
@@ -261,6 +271,16 @@ nestedJourneyStates:
     response:
       type: page
       pageId: non-uk-no-app-options
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
+      useApp:
+        targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
+
+  DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP:
+    response:
+      type: page
+      pageId: need-app
     events:
       returnToRp:
         exitEventToEmit: returnToRp
@@ -469,6 +489,37 @@ nestedJourneyStates:
     response:
       type: page
       pageId: non-uk-no-app-options
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
+      useApp:
+        targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
+
+  DAD_SELECT_SMARTPHONE_NON_UK_NEED_APP:
+    response:
+      type: page
+      pageId: need-app
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
+      useApp:
+        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
+        targetEntryEvent: dad-select-smartphone
+
+  MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP:
+    response:
+      type: page
+      pageId: need-app
+    events:
+      returnToRp:
+        exitEventToEmit: returnToRp
+      useApp:
+        targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
+
+  MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP:
+    response:
+      type: page
+      pageId: need-app
     events:
       returnToRp:
         exitEventToEmit: returnToRp

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -755,7 +755,7 @@ states:
         auditEvents:
           - IPV_INTERNATIONAL_ADDRESS_START
       abandon:
-        targetState: NON_UK_NO_PASSPORT
+        targetState: NON_UK_NEED_BIOMETRIC_PASSPORT
 
   NON_UK_NEED_BIOMETRIC_PASSPORT:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -743,6 +743,31 @@ states:
         targetState: STRATEGIC_APP_TRIAGE_INTERNATIONAL_ADDRESS
         targetEntryEvent: appTriage
 
+  NON_UK_PASSPORT_BIOMETRIC_CHIP:
+    response:
+      type: page
+      pageId: passport-biometric-chip
+    events:
+      next:
+        targetState: STRATEGIC_APP_TRIAGE_INTERNATIONAL_ADDRESS
+        targetEntryEvent: appTriage
+        journeyContextToSet: appOnly
+        auditEvents:
+          - IPV_INTERNATIONAL_ADDRESS_START
+      abandon:
+        targetState: NON_UK_NO_PASSPORT
+
+  NON_UK_NEED_BIOMETRIC_PASSPORT:
+    response:
+      type: page
+      pageId: need-biometric-passport
+    events:
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+      useApp:
+        targetState: STRATEGIC_APP_TRIAGE_INTERNATIONAL_ADDRESS
+        targetEntryEvent: appTriage
+
   POST_APP_DOC_CHECK_INTERNATIONAL_SUCCESS_PAGE:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -743,7 +743,7 @@ states:
         targetState: STRATEGIC_APP_TRIAGE_INTERNATIONAL_ADDRESS
         targetEntryEvent: appTriage
 
-  NON_UK_PASSPORT_BIOMETRIC_CHIP:
+  PASSPORT_BIOMETRIC_CHIP:
     response:
       type: page
       pageId: passport-biometric-chip
@@ -755,9 +755,9 @@ states:
         auditEvents:
           - IPV_INTERNATIONAL_ADDRESS_START
       abandon:
-        targetState: NON_UK_NEED_BIOMETRIC_PASSPORT
+        targetState: NEED_BIOMETRIC_PASSPORT
 
-  NON_UK_NEED_BIOMETRIC_PASSPORT:
+  NEED_BIOMETRIC_PASSPORT:
     response:
       type: page
       pageId: need-biometric-passport


### PR DESCRIPTION
⚠️ MERGE THOSE PRs IN ORDER ⚠️ 

- [Add new pages](https://github.com/govuk-one-login/ipv-core-back/pull/3945)
- [Add new routes](https://github.com/govuk-one-login/ipv-core-back/pull/3945)
- [Pin journey engine to new routes/pages](https://github.com/govuk-one-login/ipv-core-back/pull/3951)
- [Remove unused(renamed) routes](https://github.com/govuk-one-login/ipv-core-back/pull/3952)
- [Remove unused(renamed) pages](https://github.com/govuk-one-login/ipv-core-front/pull/2814)

## Proposed changes
### What changed

Added new routes for non uk users to renamed pages:
- /non-uk-passport → /passport-biometric-chip
- /non-uk-no-passport ->/need-biometric-passport
- /non-uk-no-app-options → /need-app

### Why did it change

To support page renaming without disrupting in-flight journeys, we need to keep both the old and routes available simultaneously while coordinating the change with the core-front.

### Context

Two existing pages designed for international users are due to be adopted and made dynamic for CI mitigation mid-journey drop outs. As a result the names of these URLs require updating to ensure the URL remains relevant to the use case.

The pages affected are:
- /non-uk-passport → /passport-biometric-chip
- /non-uk-no-passport ->/need-biometric-passport
- /non-uk-no-app-options → /need-app

⚠️ Need to consider staging out release so we don’t break any in flight journeys ⚠️ 


### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9087](https://govukverify.atlassian.net/browse/PYIC-9087)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9087]: https://govukverify.atlassian.net/browse/PYIC-9087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ