### PR TITLE
PYIC-9087: Pin live journeys to new (renamed) events.

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -471,7 +471,7 @@ Feature: Audit Events
     And I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     When I submit a 'international' event
-    Then I get a 'non-uk-passport' page response
+    Then I get a 'passport-biometric-chip' page response
     When I submit a 'next' event
     Then I get a 'identify-device' page response
     And audit events for 'international-address-journey' are recorded [local only]

--- a/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
+++ b/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
@@ -238,7 +238,7 @@ Feature: P2 Journeys with DL authoritative source check
       And I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event

--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -12,7 +12,7 @@ Feature: P2 International Address
 
     Scenario: International address user is taken back to smartphone triage after selecting neither initially then trying again
       When I submit a 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -22,7 +22,7 @@ Feature: P2 International Address
         | Context    | Value |
         | deviceType | dad   |
       When I submit a 'neither' event
-      Then I get a 'non-uk-no-app-options' page response
+      Then I get a 'need-app' page response
       When I submit a 'useApp' event
       Then I get a 'pyi-triage-select-smartphone' page response and pageContext
         | Context    | Value |
@@ -30,7 +30,7 @@ Feature: P2 International Address
 
     Scenario: International address user decides to return to RP from DCMAW exit page
       When I submit a 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -40,14 +40,14 @@ Feature: P2 International Address
         | Context    | Value |
         | deviceType | dad   |
       When I submit a 'neither' event
-      Then I get a 'non-uk-no-app-options' page response
+      Then I get a 'need-app' page response
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
 
     Scenario: Successful P2 international identity via DCMAW using passport
       When I submit an 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -87,7 +87,7 @@ Feature: P2 International Address
 
     Scenario: User fails V2 app with CI - MAM
       When I submit an 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -117,7 +117,7 @@ Feature: P2 International Address
 
     Scenario: User fails V2 app with CI - DAD
       When I submit an 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -144,9 +144,9 @@ Feature: P2 International Address
 
     Scenario: User looks for alternative methods to prove identity without using the app
       When I submit an 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit an 'abandon' event
-      Then I get a 'non-uk-no-passport' page response
+      Then I get a 'need-biometric-passport' page response
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -155,15 +155,15 @@ Feature: P2 International Address
 
     Scenario: International user abandons due to no biometric passport then returns
       When I submit an 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'abandon' event
-      Then I get a 'non-uk-no-passport' page response
+      Then I get a 'need-biometric-passport' page response
       When I submit a 'useApp' event
       Then I get an 'identify-device' page response
 
     Scenario: International user wants to prove identity another way from download page
       When I submit an 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -178,7 +178,7 @@ Feature: P2 International Address
         | smartphone | iphone |
         | isAppOnly  | true   |
       When I submit a 'preferNoApp' event
-      Then I get a 'non-uk-no-app-options' page response
+      Then I get a 'need-app' page response
       # Change their mind and go back
       When I submit a 'useApp' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
@@ -187,7 +187,7 @@ Feature: P2 International Address
         | isAppOnly  | true   |
       # Decide to abandon again
       When I submit a 'preferNoApp' event
-      Then I get a 'non-uk-no-app-options' page response
+      Then I get a 'need-app' page response
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -201,7 +201,7 @@ Feature: P2 International Address
 
     Scenario: Successful P2 received via DCMAW
       When I submit an 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event

--- a/api-tests/features/stored-identity/m1c-journeys.feature
+++ b/api-tests/features/stored-identity/m1c-journeys.feature
@@ -72,7 +72,7 @@ Feature: Stored Identity - M1C Outcomes
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'international' event
-      Then I get a 'non-uk-passport' page response
+      Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -5,7 +5,7 @@ Feature: Stored Identity - P2 journeys
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
     And I submit an 'international' event
-    Then I get a 'non-uk-passport' page response
+    Then I get a 'passport-biometric-chip' page response
     When I submit a 'next' event
     Then I get an 'identify-device' page response
     When I submit an 'appTriage' event

--- a/api-tests/features/strategic-app-retry-routing.feature
+++ b/api-tests/features/strategic-app-retry-routing.feature
@@ -82,7 +82,7 @@ Feature: Strategic App Retry Journeys
 
   Scenario Outline: Trying again with a mobile device app only goes directly to the correct download page
     When I submit a 'international' event
-    Then I get a 'non-uk-passport' page response
+    Then I get a 'passport-biometric-chip' page response
     When I submit a 'next' event
     Then I get an 'identify-device' page response
     When I submit an 'appTriage' event
@@ -121,7 +121,7 @@ Feature: Strategic App Retry Journeys
 
   Scenario Outline: Trying again with a desktop device app only goes directly to the correct download page
     When I submit a 'international' event
-    Then I get a 'non-uk-passport' page response
+    Then I get a 'passport-biometric-chip' page response
     When I submit a 'next' event
     Then I get an 'identify-device' page response
     When I submit an 'appTriage' event

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -64,7 +64,7 @@ nestedJourneyStates:
         targetState: DAD_SELECT_SMARTPHONE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DAD_SELECT_SMARTPHONE_NON_UK_NO_APP_OPTIONS
+            targetState: DAD_SELECT_SMARTPHONE_NON_UK_NEED_APP
 
   DAD_SELECT_SMARTPHONE_EXIT_BUFFER:
     response:
@@ -124,7 +124,7 @@ nestedJourneyStates:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -157,7 +157,7 @@ nestedJourneyStates:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -220,7 +220,7 @@ nestedJourneyStates:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -253,7 +253,7 @@ nestedJourneyStates:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -353,7 +353,7 @@ nestedJourneyStates:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
       error:
@@ -375,7 +375,7 @@ nestedJourneyStates:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
       error:
@@ -425,7 +425,7 @@ nestedJourneyStates:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
       error:
@@ -447,7 +447,7 @@ nestedJourneyStates:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS
+            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
       error:
@@ -579,4 +579,4 @@ nestedJourneyStates:
         targetState: DAD_SELECT_SMARTPHONE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DAD_SELECT_SMARTPHONE_NON_UK_NO_APP_OPTIONS
+            targetState: DAD_SELECT_SMARTPHONE_NON_UK_NEED_APP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -64,7 +64,7 @@ nestedJourneyStates:
         targetState: DAD_SELECT_SMARTPHONE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DAD_SELECT_SMARTPHONE_NON_UK_NEED_APP
+            targetState: DAD_SELECT_SMARTPHONE_NEED_APP
 
   DAD_SELECT_SMARTPHONE_EXIT_BUFFER:
     response:
@@ -124,7 +124,7 @@ nestedJourneyStates:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP
+            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -157,7 +157,7 @@ nestedJourneyStates:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP
+            targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -220,7 +220,7 @@ nestedJourneyStates:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP
+            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -253,7 +253,7 @@ nestedJourneyStates:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP
+            targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
 
@@ -353,7 +353,7 @@ nestedJourneyStates:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP
+            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
       error:
@@ -375,7 +375,7 @@ nestedJourneyStates:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NEED_APP
+            targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
       error:
@@ -425,7 +425,7 @@ nestedJourneyStates:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP
+            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
       error:
@@ -447,7 +447,7 @@ nestedJourneyStates:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NEED_APP
+            targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NEED_APP
       anotherWay:
         exitEventToEmit: anotherWay
       error:
@@ -579,4 +579,4 @@ nestedJourneyStates:
         targetState: DAD_SELECT_SMARTPHONE_EXIT_BUFFER
         checkJourneyContext:
           internationalAddress:
-            targetState: DAD_SELECT_SMARTPHONE_NON_UK_NEED_APP
+            targetState: DAD_SELECT_SMARTPHONE_NEED_APP

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -719,7 +719,7 @@ states:
         targetState: IDENTITY_START_PAGE
         journeyContextToUnset: internationalAddress
       international:
-        targetState: NON_UK_PASSPORT
+        targetState: PASSPORT_BIOMETRIC_CHIP
         journeyContextToSet: internationalAddress
 
   NON_UK_PASSPORT:


### PR DESCRIPTION
⚠️ MERGE THOSE PRs IN ORDER ⚠️ 

- [Add new pages](https://github.com/govuk-one-login/ipv-core-back/pull/3945)
- [Add new routes](https://github.com/govuk-one-login/ipv-core-back/pull/3945)
- [Pin journey engine to new routes/pages](https://github.com/govuk-one-login/ipv-core-back/pull/3951)
- [Remove unused(renamed) routes](https://github.com/govuk-one-login/ipv-core-back/pull/3952)
- [Remove unused(renamed) pages](https://github.com/govuk-one-login/ipv-core-front/pull/2814)

## Proposed changes
### What changed

- Wired new events to be used by live journeys. (see code changes)
- Update all api tests to expect new page names.

### Why did it change

- Those routes was previously created and corresponding pages was duplicated in core-front (with renamed values),
to pin new journeys to new pages while keeping existing, not yet renamed pages, to avoid breaking in-flight journeys.

### Context

Two existing pages designed for international users are due to be adopted and made dynamic for CI mitigation mid-journey drop outs. As a result the names of these URLs require updating to ensure the URL remains relevant to the use case.

The pages affected are:
- /non-uk-passport → /passport-biometric-chip
- /non-uk-no-passport ->/need-biometric-passport
- /non-uk-no-app-options → /need-app

⚠️ Need to consider staging out release so we don’t break any in flight journeys ⚠️ 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9087](https://govukverify.atlassian.net/browse/PYIC-9087)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9087]: https://govukverify.atlassian.net/browse/PYIC-9087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ