### PR TITLE
PYIC-9087: Remove unused (renamed) events.

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -171,16 +171,6 @@ nestedJourneyStates:
       back:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE
 
-  DESKTOP_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
-    response:
-      type: page
-      pageId: non-uk-no-app-options
-    events:
-      returnToRp:
-        exitEventToEmit: returnToRp
-      useApp:
-        targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
-
   DESKTOP_IPHONE_DOWNLOAD_PAGE_NEED_APP:
     response:
       type: page
@@ -266,16 +256,6 @@ nestedJourneyStates:
         exitEventToEmit: anotherWay
       back:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE
-
-  DESKTOP_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
-    response:
-      type: page
-      pageId: non-uk-no-app-options
-    events:
-      returnToRp:
-        exitEventToEmit: returnToRp
-      useApp:
-        targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
 
   DESKTOP_ANDROID_DOWNLOAD_PAGE_NEED_APP:
     response:
@@ -463,37 +443,6 @@ nestedJourneyStates:
         exitEventToEmit: anotherWay
       back:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE
-
-  DAD_SELECT_SMARTPHONE_NON_UK_NO_APP_OPTIONS:
-    response:
-      type: page
-      pageId: non-uk-no-app-options
-    events:
-      returnToRp:
-        exitEventToEmit: returnToRp
-      useApp:
-        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
-        targetEntryEvent: dad-select-smartphone
-
-  MOBILE_IPHONE_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
-    response:
-      type: page
-      pageId: non-uk-no-app-options
-    events:
-      returnToRp:
-        exitEventToEmit: returnToRp
-      useApp:
-        targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
-
-  MOBILE_ANDROID_DOWNLOAD_PAGE_NON_UK_NO_APP_OPTIONS:
-    response:
-      type: page
-      pageId: non-uk-no-app-options
-    events:
-      returnToRp:
-        exitEventToEmit: returnToRp
-      useApp:
-        targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
 
   DAD_SELECT_SMARTPHONE_NEED_APP:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -722,31 +722,6 @@ states:
         targetState: PASSPORT_BIOMETRIC_CHIP
         journeyContextToSet: internationalAddress
 
-  NON_UK_PASSPORT:
-    response:
-      type: page
-      pageId: non-uk-passport
-    events:
-      next:
-        targetState: STRATEGIC_APP_TRIAGE_INTERNATIONAL_ADDRESS
-        targetEntryEvent: appTriage
-        journeyContextToSet: appOnly
-        auditEvents:
-          - IPV_INTERNATIONAL_ADDRESS_START
-      abandon:
-        targetState: NON_UK_NO_PASSPORT
-
-  NON_UK_NO_PASSPORT:
-    response:
-      type: page
-      pageId: non-uk-no-passport
-    events:
-      returnToRp:
-        targetState: PROCESS_INCOMPLETE_IDENTITY
-      useApp:
-        targetState: STRATEGIC_APP_TRIAGE_INTERNATIONAL_ADDRESS
-        targetEntryEvent: appTriage
-
   PASSPORT_BIOMETRIC_CHIP:
     response:
       type: page


### PR DESCRIPTION
⚠️ MERGE THOSE PRs IN ORDER ⚠️ 

- [Add new pages](https://github.com/govuk-one-login/ipv-core-back/pull/3945)
- [Add new routes](https://github.com/govuk-one-login/ipv-core-back/pull/3945)
- [Pin journey engine to new routes/pages](https://github.com/govuk-one-login/ipv-core-back/pull/3951)
- [Remove unused(renamed) routes](https://github.com/govuk-one-login/ipv-core-back/pull/3952)
- [Remove unused(renamed) pages](https://github.com/govuk-one-login/ipv-core-front/pull/2814)

## Proposed changes
### What changed

- Removed unused (renamed) events. (See code changes)

### Why did it change

- Corresponding pages are renamed and used by new routes.

### Context

Two existing pages designed for international users are due to be adopted and made dynamic for CI mitigation mid-journey drop outs. As a result the names of these URLs require updating to ensure the URL remains relevant to the use case.

The pages affected are:
- /non-uk-passport → /passport-biometric-chip
- /non-uk-no-passport ->/need-biometric-passport
- /non-uk-no-app-options → /need-app

⚠️ Need to consider staging out release so we don’t break any in flight journeys ⚠️ 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9087](https://govukverify.atlassian.net/browse/PYIC-9087)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9087]: https://govukverify.atlassian.net/browse/PYIC-9087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ