### PR TITLE
[IPS-2341] Change CODEOWNERS from ID-SRE to REX

### DIFF
--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -56,7 +56,7 @@ Three OpenAPI specs define core-back's API surface:
 - link-workflows.yaml — workflow linking
 
 PR template (/.github/pull_request_template.md) uses Jira PYIC-XXXX ticket references and includes checklists for documentation, tests, PII exposure, and canary deployment considerations.
-CODEOWNERS: `@govuk-one-login/core-team` and `@govuk-one-login/identity-sre`.
+CODEOWNERS: `@govuk-one-login/core-team` and `@govuk-one-login/reliability-engineering-x`.
 Dependabot is configured for Gradle, npm (api-tests and journey-map), and GitHub Actions dependencies.
 
 # API Tests

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/core-team @govuk-one-login/identity-sre
+* @govuk-one-login/core-team @govuk-one-login/reliability-engineering-x


### PR DESCRIPTION
## Proposed changes

Changing CODEOWNERS from IDSRE to REX

### What changed

CODEOWNERS were changed from @govuk-one-login/identity-sre to @govuk-one-login/reliability-engineering-x

### Why did it change

Identity SRE have become a cross cutting SRE team under a new name, this changes the ownership from the old team to the new team

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [IPS-2341](https://govukverify.atlassian.net/browse/IPS-2341)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[IPS-2341]: https://govukverify.atlassian.net/browse/IPS-2341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ