### PR TITLE
PYIC-9022: Add expired passport/brp app and f2f routes API tests.

### DIFF
--- a/api-tests/data/cri-stub-requests/dcmawAsync/kenneth-brp-expired/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/dcmawAsync/kenneth-brp-expired/credentialSubject.json
@@ -1,0 +1,29 @@
+{
+  "residencePermit": [
+    {
+      "documentType": "IR",
+      "icaoIssuerCode": "GBR",
+      "documentNumber": "ZR8016200",
+      "expiryDate": "2024-02-02"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/dcmawAsync/kenneth-brp-expired/evidence.json
+++ b/api-tests/data/cri-stub-requests/dcmawAsync/kenneth-brp-expired/evidence.json
@@ -1,0 +1,19 @@
+{
+  "type": "IdentityCheck",
+  "txn": "RB000117420948",
+  "strengthScore": 4,
+  "validityScore": 0,
+  "activityHistoryScore": 1,
+  "failedCheckDetails": [
+    {
+      "checkMethod": "vcrypt",
+      "identityCheckPolicy": "published",
+      "activityFrom": "2019-01-01"
+    },
+    {
+      "checkMethod": "bvr",
+      "biometricVerificationProcessLevel": 3
+    }
+  ],
+  "ci": ["ALWAYS-REQUIRED"]
+}

--- a/api-tests/data/cri-stub-requests/f2f/kenneth-passport-expired/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/f2f/kenneth-passport-expired/credentialSubject.json
@@ -1,0 +1,28 @@
+{
+  "passport": [
+    {
+      "expiryDate": "2024-01-01",
+      "icaoIssuerCode": "GBR",
+      "documentNumber": "321654987"
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "Kenneth"
+        },
+        {
+          "type": "FamilyName",
+          "value": "Decerqueira"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/f2f/kenneth-passport-expired/evidence.json
+++ b/api-tests/data/cri-stub-requests/f2f/kenneth-passport-expired/evidence.json
@@ -1,0 +1,14 @@
+{
+  "type": "IdentityCheck",
+  "txn": "RB000117420948",
+  "validityScore": 0,
+  "strengthScore": 3,
+  "activityHistoryScore": 0,
+  "ci": ["ALWAYS-REQUIRED"],
+  "failedCheckDetails": [
+    {
+      "identityCheckPolicy": "published",
+      "checkMethod": "data"
+    }
+  ]
+}

--- a/api-tests/features/account-intervention/reprove-identity.feature
+++ b/api-tests/features/account-intervention/reprove-identity.feature
@@ -405,7 +405,7 @@ Feature: Reprove Identity Journey
         | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
@@ -482,7 +482,7 @@ Feature: Reprove Identity Journey
         | Context    | Value   |
         | smartphone | iphone  |
         | isAppOnly  | true    |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response

--- a/api-tests/features/app-cross-browser/p1-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p1-cross-browser.feature
@@ -241,7 +241,7 @@ Feature: P1 V2 App Cross Browser Scenario
       Then I get a 'pyi-post-office' page response
 
     Scenario: Separate session DCMAW enhanced verification mitigation - breaching CI received from DCMAW
-      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a 'BREACHING' CI
       And I pass on the DCMAW callback in a separate session
       Then I get a 'problem-different-browser' page response
       # This simulates the user clicking continue on the problem-different-browser

--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
@@ -108,7 +108,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | false  |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC with a 'BREACHING' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
@@ -171,7 +171,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       And I have a stored identity record with a 'P3' max vot
 
     Scenario: Separate session DCMAW enhanced verification mitigation - breaching CI received from DCMAW
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC with a 'BREACHING' CI
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
       When I poll for async DCMAW credential receipt

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
@@ -226,7 +226,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | false  |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
@@ -256,7 +256,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | false  |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response

--- a/api-tests/features/dl-auth-source-checks/p1-enhanced-verification-mitigation.feature
+++ b/api-tests/features/dl-auth-source-checks/p1-enhanced-verification-mitigation.feature
@@ -236,7 +236,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       Then I get a 'pyi-post-office' page response
 
     Scenario: Separate session DCMAW enhanced verification mitigation - breaching CI received from DCMAW
-      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a 'BREACHING' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response

--- a/api-tests/features/p1-app-journey.feature
+++ b/api-tests/features/p1-app-journey.feature
@@ -81,7 +81,7 @@ Feature: P1 app journey
       | Context    | Value  |
       | smartphone | iphone |
       | isAppOnly  | false  |
-    When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+    When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
       # And the user returns from the app to core-front
     And I pass on the DCMAW callback
     Then I get an 'check-mobile-app-result' page response

--- a/api-tests/features/p1-app-journey.feature
+++ b/api-tests/features/p1-app-journey.feature
@@ -90,6 +90,52 @@ Feature: P1 app journey
     When I submit the returned journey event
     Then I get an 'pyi-no-match' page response
 
+  Scenario: MAM journey - passport fails with ci (score 1) and goes to alternative document check
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | mam   |
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+      | Context    | Value  |
+      | smartphone | iphone |
+      | isAppOnly  | false  |
+    When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'ALWAYS-REQUIRED' CI
+      # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get an 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'page-multiple-doc-check' page response and pageContext
+      | Context   | Value |
+      | allowNino | true  |
+    When I submit a 'drivingLicence' event
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'experianKbv' CRI response
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a 'P1' identity
+    And I have a stored identity record with a 'P1' max vot
+
   Scenario: MAM journey no compatible smartphone continues to other methods
     When I submit an 'appTriage' event
     Then I get a 'pyi-triage-select-device' page response
@@ -181,3 +227,48 @@ Feature: P1 app journey
     Then I get a 'page-multiple-doc-check' page response and pageContext
       | Context   | Value |
       | allowNino | true  |
+
+  Scenario: DAD journey - BRP fails with ci (score 1) and goes to alternative document check
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | mam   |
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+      | Context    | Value  |
+      | smartphone | iphone |
+      | isAppOnly  | false  |
+    When the async DCMAW CRI produces a 'kenneth-brp-expired' VC
+    And I pass on the DCMAW callback
+    Then I get an 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'page-multiple-doc-check' page response and pageContext
+      | Context   | Value |
+      | allowNino | true  |
+    When I submit a 'drivingLicence' event
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'experianKbv' CRI response
+    When I submit 'kenneth-score-1' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a 'P1' identity
+    And I have a stored identity record with a 'P1' max vot

--- a/api-tests/features/p1-f2f-journey.feature
+++ b/api-tests/features/p1-f2f-journey.feature
@@ -113,3 +113,14 @@ Feature: P1 F2F journey
       When I use the OAuth response to get my identity
       Then I am issued a 'P1' identity
       And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Failed F2F journey using passport with CI (score 1) - allow user to start again
+      When I submit 'kenneth-passport-expired' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey - Inform user on unsuccessful check and allow to start journey again
+      When I start new 'medium-confidence' journeys until I get a 'pyi-f2f-technical' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -329,6 +329,50 @@ Feature: P2 App journey
       When I submit the returned journey event
       Then I get an 'pyi-no-match' page response
 
+    Scenario: MAM journey - passport fails with ci (score 1) and goes to alternative document check
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'ALWAYS-REQUIRED' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'page-multiple-doc-check' page response
+      When I submit a 'drivingLicence' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
     Scenario: DAD journey credential fails with with no ci and continues to other methods
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
@@ -346,6 +390,47 @@ Feature: P2 App journey
       Then the poll returns a '201'
       When I submit the returned journey event
       Then I get an 'page-multiple-doc-check' page response
+
+    Scenario: DAD journey - BRP fails with with ci (score 1) goes to alternative document check
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-brp-expired' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'page-multiple-doc-check' page response
+      When I submit a 'drivingLicence' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
     Scenario: DAD journey no compatible smartphone
       When I submit an 'appTriage' event

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -261,7 +261,7 @@ Feature: P2 App journey
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | false  |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
@@ -323,7 +323,7 @@ Feature: P2 App journey
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | false  |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -67,6 +67,34 @@ Feature: P2 F2F journey
         | medium-confidence      | passport | kenneth-passport-valid       |
         | medium-confidence      | DL       | kenneth-driving-permit-valid |
 
+    Scenario: Failed F2F journey using passport with CI (score 1) - allow user to start again
+      # Initial journey
+      Given I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-passport-expired' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey - Inform user on unsuccessful check and allow to start journey again
+      When I start new 'medium-confidence' journeys until I get a 'pyi-f2f-technical' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+
     Scenario Outline: Successful P2 identity via F2F using <doc> - no valid device to go through app
       # Initial journey
       And I start a new 'medium-confidence' journey

--- a/api-tests/features/p2-international-journey.feature
+++ b/api-tests/features/p2-international-journey.feature
@@ -101,7 +101,7 @@ Feature: P2 International Address
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | true   |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
@@ -131,7 +131,7 @@ Feature: P2 International Address
         | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -165,7 +165,7 @@ Feature: Repeat fraud check failures
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | true   |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
@@ -192,7 +192,7 @@ Feature: Repeat fraud check failures
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | true   |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
@@ -216,7 +216,7 @@ Feature: Repeat fraud check failures
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | true   |
-      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a 'BREACHING' CI
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -157,7 +157,7 @@ Feature: Identity reuse update details failures
                 | Context    | Value   |
                 | smartphone | android |
                 | isAppOnly  | true    |
-            When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+            When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
             # And the user returns from the app to core-front
             And I pass on the DCMAW callback
             Then I get a 'check-mobile-app-result' page response
@@ -184,7 +184,7 @@ Feature: Identity reuse update details failures
                 | Context    | Value  |
                 | smartphone | iphone |
                 | isAppOnly  | true   |
-            When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+            When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
             And I poll for async DCMAW credential receipt
             Then the poll returns a '201'
             When I submit the returned journey event
@@ -208,7 +208,7 @@ Feature: Identity reuse update details failures
                 | Context    | Value  |
                 | smartphone | iphone |
                 | isAppOnly  | true   |
-            When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a CI
+            When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC with a 'BREACHING' CI
             And I poll for async DCMAW credential receipt
             Then the poll returns a '201'
             When I submit the returned journey event

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -51,7 +51,7 @@ Feature: TICF failed/error journeys
         | Context    | Value  |
         | smartphone | iphone |
         | isAppOnly  | false  |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
     # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -552,20 +552,27 @@ When(
 );
 
 When(
-  /^the async DCMAW CRI produces an? '([\w-]+)' '([\w-]+)' '([\w-]+)' VC( with a CI)?$/,
+  /^the async DCMAW CRI produces an? '([\w-]+)' '([\w-]+)' '([\w-]+)' VC(?: with a '([\w-]+)' CI)?$/,
   async function (
     this: World,
     testUser: string,
     documentType: string,
     evidenceType: string,
-    hasCi: " with a CI" | undefined,
+    ciType:
+      | "NON-BREACHING"
+      | "BREACHING"
+      | "BREACHING-P1-ONLY"
+      | "NEEDS-ENHANCED-VERIFICATION"
+      | "NEEDS-ALTERNATE-DOC"
+      | "ALWAYS-REQUIRED"
+      | undefined,
   ): Promise<void> {
     this.oauthState = await enqueueVcFromDetails(
       this.userId,
       testUser,
       documentType,
       evidenceType,
-      hasCi && ["BREACHING"],
+      ciType ? [ciType] : undefined,
     );
   },
 );


### PR DESCRIPTION
## Proposed changes
### What changed

Added API Tests for:
-  expired passport/brp documents in APP journey resulting in redirection to web journey
- expired passport document in F2F journey allowing returning user to start new journey

### Why did it change

A CI is applied to a user’s VC when a piece of evidence has expired (chipped documents only).

As part of CI Mitigations, it has been agreed that IPV Core and SPOT will amend the score making it a flag but not a blocking indicator for users. These users will not be issued with an identity, but given the opportunity to prove their identity using a different document instead of being blocked indefinitely.

As this change affects chipped docs only, CI will be applied for expired chipped passports in F2F or for expired BRPs or chipped passports in App.

### Issue tracking
- [PYIC-9022](https://govukverify.atlassian.net/browse/PYIC-9022)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9022]: https://govukverify.atlassian.net/browse/PYIC-9022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ