### PR TITLE
OJ-3391: fix - remove "exp" key from Orange CRIs VC

### DIFF
--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
@@ -569,7 +569,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_EXPERIAN_SIGNATURE =
-            "Jy6iSQcjSYDsopf1AIPuscR_uwJTVdQaU3EcbFyZLukrFQ04fQWDFwUF2wzief2YL4v8_x2SVuMO7sqnn3m9MA"; // pragma: allowlist secret
+            "S64rhfYI527Tm17GflXVoerzu_3RO1hraph_Xsm5fna8h8RkMCSgdhTaYllvld7S-L37srFCrLsS_px8rqhVZw"; // pragma: allowlist secret
 
     private static final String VALID_VC_ADDRESS_BODY =
             """
@@ -605,7 +605,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_ADDRESS_SIGNATURE =
-            "gHKt0bP-EDzMapHW5DfMJ93e31-WFltzYQxONTYlgN2okm5yRjkgjqsIyC1LFeeV6PtgctcW6FzrU_oqFS3GQA"; // pragma: allowlist secret
+            "gyDkSMo7Uad7mQSCVGKqbIu0t5DtbH-LFtzqFmAOQzyt97SbKic8lz-VGmLJk0Fp-6M4dcsOWuHlIFaohPXT-g"; // pragma: allowlist secret
 
     private static final String VALID_VC_CHANGED_ADDRESS_BODY =
             """
@@ -648,7 +648,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_CHANGED_ADDRESS_SIGNATURE =
-            "2GkXxAwDnFVYbQMhsh3w-F4ffSlMVavviDIddMge_CjnQbWERBkhu-CCy6F9kGE1B8ZFrAlFAqDJQaT5PkbPbw"; // pragma: allowlist secret
+            "Fa3iM-6-Rpz7bns-Xl92yb6iDcnt_N1j2pMmS8qjW0WTuqf_g3aZrQlbhXFJnuRCEdSwAmSEPwQFHaCVUBiY7A"; // pragma: allowlist secret
 
     private static final String VALID_VC_INTERNATIONAL_ADDRESS_BODY =
             """
@@ -688,5 +688,5 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_INTERNATIONAL_ADDRESS_SIGNATURE =
-            "cr_bBHq1GD0dyl2L4ryF3fVD9-yLbS78wcRqFZaPB_FGAV9ANGjJHoRSGXoDNn0cib9tVeQDFYgeIZkm3iz46Q"; // pragma: allowlist secret
+            "EejAGSdJxLKdn00LnU8sXOELnYuMdPy7NLJaLFpE-IC3bOwgGLMmhUD3P0jB9mTiHJd9I9GFdS9Nrgdwgq7WzQ"; // pragma: allowlist secret
 }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
@@ -539,7 +539,6 @@ class CredentialTests {
               "iss": "dummyAddressComponentId",
               "sub": "test-subject",
               "nbf": 4070908800,
-              "exp": 4070909400,
               "vc": {
                 "type": [
                   "VerifiableCredential",
@@ -578,7 +577,6 @@ class CredentialTests {
               "iss": "dummyAddressComponentId",
               "sub": "test-subject",
               "nbf": 4070908800,
-              "exp": 4070909400,
               "vc": {
                 "type": [
                   "VerifiableCredential",
@@ -615,7 +613,6 @@ class CredentialTests {
               "iss": "dummyAddressComponentId",
               "sub": "test-subject",
               "nbf": 4070908800,
-              "exp": 4070909400,
               "vc": {
                 "type": [
                   "VerifiableCredential",
@@ -659,7 +656,6 @@ class CredentialTests {
               "iss": "dummyAddressComponentId",
               "sub": "test-subject",
               "nbf": 4070908800,
-              "exp": 4070909400,
               "vc": {
                 "type": [
                   "VerifiableCredential",

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/addressCri/CredentialTests.java
@@ -569,7 +569,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_EXPERIAN_SIGNATURE =
-            "S64rhfYI527Tm17GflXVoerzu_3RO1hraph_Xsm5fna8h8RkMCSgdhTaYllvld7S-L37srFCrLsS_px8rqhVZw"; // pragma: allowlist secret
+            "8czA2bqTpfh6Gk-pdwrJv14Kgk4-uVKxRErYVgdix9-j2HPqjNj1zLVu0miE3T91ezq8Ly4kcq4WhBeQlURq_w"; // pragma: allowlist secret
 
     private static final String VALID_VC_ADDRESS_BODY =
             """
@@ -605,7 +605,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_ADDRESS_SIGNATURE =
-            "gyDkSMo7Uad7mQSCVGKqbIu0t5DtbH-LFtzqFmAOQzyt97SbKic8lz-VGmLJk0Fp-6M4dcsOWuHlIFaohPXT-g"; // pragma: allowlist secret
+            "RS3IMX4Vmzpr33jVuBi0tX-eG7WDQKjauSEjsMXbQVG9YibiLDZ_FCdJffd-XMbaSA5Qcg8XNHXwdNflJzb4FQ"; // pragma: allowlist secret
 
     private static final String VALID_VC_CHANGED_ADDRESS_BODY =
             """
@@ -648,7 +648,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_CHANGED_ADDRESS_SIGNATURE =
-            "Fa3iM-6-Rpz7bns-Xl92yb6iDcnt_N1j2pMmS8qjW0WTuqf_g3aZrQlbhXFJnuRCEdSwAmSEPwQFHaCVUBiY7A"; // pragma: allowlist secret
+            "aTEl9GodHJ3VGNRABT_S5eymTXBlwXB7u6NwLJSx4j-tKkjuXOiNTlLxmrrmU6D-8NAqYE11n22g_4ARmA46-A"; // pragma: allowlist secret
 
     private static final String VALID_VC_INTERNATIONAL_ADDRESS_BODY =
             """
@@ -688,5 +688,5 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_INTERNATIONAL_ADDRESS_SIGNATURE =
-            "EejAGSdJxLKdn00LnU8sXOELnYuMdPy7NLJaLFpE-IC3bOwgGLMmhUD3P0jB9mTiHJd9I9GFdS9Nrgdwgq7WzQ"; // pragma: allowlist secret
+            "Pr7z7A-0olLZrZLx03OU2BqY-8ZXAPEb1stuz0Cu5zqjfeLsvBhtLgRaMhvzoL2V_lao2l4j8m7i7w5Heo_vyA"; // pragma: allowlist secret
 }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
@@ -596,7 +596,6 @@ class CredentialTests {
                "iss": "dummyExperianKbvComponentId",
                "sub": "test-subject",
                "nbf": 4070908800,
-               "exp": 4070909400,
                "vc": {
                  "@context": [
                    "https://www.w3.org/2018/credentials/v1",
@@ -684,7 +683,6 @@ class CredentialTests {
               "iss": "dummyExperianKbvComponentId",
               "sub": "test-subject",
               "nbf": 4070908800,
-              "exp": 4070909400,
               "vc": {
                 "@context": [
                   "https://www.w3.org/2018/credentials/v1",
@@ -755,7 +753,6 @@ class CredentialTests {
               "iss": "dummyExperianKbvComponentId",
               "sub": "test-subject",
               "nbf": 4070908800,
-              "exp": 4070909400,
               "vc": {
                 "@context": [
                   "https://www.w3.org/2018/credentials/v1",

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
@@ -675,7 +675,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_SIGNATURE =
-            "34505Qywo0EAF4qD0j-Jqncg67hKzH6ix0eHyJpCWLICID13yi-9WVEMbsn3CfyGt2et_A_kjIsYMtqMtjq8_g"; // pragma: allowlist secret
+            "Krq-lfEOsIDXWmtOMprkXagMOiLWEioGLYQBJhvNpr4k2yS1UqkdCyL5cqJ1ILZaZ3B6hxMBPe34Q_5PhQFTfA"; // pragma: allowlist secret
 
     private static final String VALID_THIN_FILE_VC_BODY =
             """
@@ -745,7 +745,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_THIN_FILE_VC_SIGNATURE =
-            "ZCVsXX_RLWrxt_l2ZCwa9QLpyiPMx91mNPDnkyIwiYM4r0TaD5xItuAfq2IKb_6bF5LVm6-cwCzhZ0HYdrey8g"; // pragma: allowlist secret
+            "XvQeyw342xQVyoUQCvqiSgsl-w31ByJjvzZtiCou6ibk6V9gurnMViSh-6nlBKqWIsL1LTlULXW-smgGOPBqOw"; // pragma: allowlist secret
 
     private static final String FAILED_VC_BODY =
             """
@@ -839,5 +839,5 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_VC_SIGNATURE =
-            "Agb8PP9IYHV9pwm0gRyPRcWsK3o3STicbbFbuEm1nyGya-I_9nvBipO7eSEe0HYbEjIW_PmB0cY8k55ovUDH-Q"; // pragma: allowlist secret
+            "xg4gIkQeZCJVZHfNWJ7pKcI4Wo1G2vBlt5Med1LNCzkidD2wnrsAYWtZZ6_Z2jqMLl2PSTw15Sc8jl2bQ0LPJA"; // pragma: allowlist secret
 }

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/experianKbvCri/CredentialTests.java
@@ -675,7 +675,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_VC_SIGNATURE =
-            "cHYsPI1M8wa6JOwU70yVZv8E7Bb6ev1QV20Nomm6e3QPKzyKo2rxuy8Gsk3r9fErXy8hv1N0L-LuZn7pLTSQSQ"; // pragma: allowlist secret
+            "34505Qywo0EAF4qD0j-Jqncg67hKzH6ix0eHyJpCWLICID13yi-9WVEMbsn3CfyGt2et_A_kjIsYMtqMtjq8_g"; // pragma: allowlist secret
 
     private static final String VALID_THIN_FILE_VC_BODY =
             """
@@ -745,7 +745,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_THIN_FILE_VC_SIGNATURE =
-            "gjiDQ5rzrzFjrVqvOE2ayqnbaQlDQpa7VHRBh-cGhar5Ty4pEkcTYr6LLChT5NoGPkSE9PlT9G4SuSEkako6gw"; // pragma: allowlist secret
+            "ZCVsXX_RLWrxt_l2ZCwa9QLpyiPMx91mNPDnkyIwiYM4r0TaD5xItuAfq2IKb_6bF5LVm6-cwCzhZ0HYdrey8g"; // pragma: allowlist secret
 
     private static final String FAILED_VC_BODY =
             """
@@ -839,5 +839,5 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_VC_SIGNATURE =
-            "m3xuM0mpZ3lTHhDk9hOLa79hyLr1x9fcCavK7RCD_OOGo04QvZFyxtV6OoUPnANU-WxEr3iMv7ZNBLPEcQb90g"; // pragma: allowlist secret
+            "Agb8PP9IYHV9pwm0gRyPRcWsK3o3STicbbFbuEm1nyGya-I_9nvBipO7eSEe0HYbEjIW_PmB0cY8k55ovUDH-Q"; // pragma: allowlist secret
 }


### PR DESCRIPTION

## Proposed changes
### What changed

- Removed "exp" key from Address and KBV pact test VCs as its no longer being used within Orange to align with OL standards and to prevent pact test failures.

### Why did it change

- Since "exp" is no longer being used in the VC based on this [decision](https://github.com/govuk-one-login/architecture/blob/main/adr/0076-vc-lifetime.md) removed the references within Orange CRIs VC (Address & KBV)

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [OJ-3391](https://govukverify.atlassian.net/browse/OJ-3391)

## Checklists

- [ ] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[OJ-3672]: https://govukverify.atlassian.net/browse/OJ-3672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OJ-3391]: https://govukverify.atlassian.net/browse/OJ-3391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ