### PR TITLE
PYIC-9037: Enable reproveViaAppOnlyEnabled feature flag.

### DIFF
--- a/api-tests/features/account-intervention/fail-open.feature
+++ b/api-tests/features/account-intervention/fail-open.feature
@@ -88,8 +88,7 @@ Feature: Fail open scenarios
       | final reprove identity | ERROR               | AIS_FORCED_USER_IDENTITY_VERIFY |
 
   Scenario: Reprove identity journey with AIS failure succeeds
-    Given I activate the 'reproveViaAppOnly' feature set
-    And the subject already has the following credentials
+    Given the subject already has the following credentials
       | CRI     | scenario                     |
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |

--- a/api-tests/features/account-intervention/journey-ending-interventions.feature
+++ b/api-tests/features/account-intervention/journey-ending-interventions.feature
@@ -129,8 +129,7 @@ Feature: Journey ending interventions
       | Password reset and reprove identity | 06                     |
 
   Scenario Outline: <intervention> intervention during reprove identity journey
-    Given I activate the 'reproveViaAppOnly' feature set
-    And the subject already has the following credentials
+    Given the subject already has the following credentials
       | CRI     | scenario                     |
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |

--- a/api-tests/features/account-intervention/reprove-identity.feature
+++ b/api-tests/features/account-intervention/reprove-identity.feature
@@ -8,6 +8,7 @@ Feature: Reprove Identity Journey
         | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
+      And I activate the 'disableReproveViaAppOnly' feature set
       And The AIS stub will return an '<ais_response>' result
       When I start a new 'medium-confidence' journey
       Then I get a 'reprove-identity-start' page response
@@ -59,6 +60,7 @@ Feature: Reprove Identity Journey
         | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
+      And I activate the 'disableReproveViaAppOnly' feature set
       And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
       When I start a new 'medium-confidence' journey
       Then I get a 'reprove-identity-start' page response
@@ -92,6 +94,7 @@ Feature: Reprove Identity Journey
       And I have a stored identity record with a 'P2' max vot
 
     Scenario: User needs to reprove their identity with F2F pending with AIS
+      Given I activate the 'disableReproveViaAppOnly' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
@@ -127,6 +130,7 @@ Feature: Reprove Identity Journey
         | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |
         | fraud   | kenneth-score-2              |
+      And I activate the 'disableReproveViaAppOnly' feature set
       And The AIS stub will return an 'AIS_FORCED_USER_IDENTITY_VERIFY' result
       When I start a new 'medium-confidence' journey with reprove identity
       Then I get a 'reprove-identity-start' page response
@@ -177,9 +181,6 @@ Feature: Reprove Identity Journey
       And I don't have a stored identity in EVCS
 
   Rule: App only reprove journey
-    Background:
-      Given I activate the 'reproveViaAppOnly' feature set
-
     Scenario: Happy path user reproves identity on desktop android
       Given the subject already has the following credentials
         | CRI     | scenario                     |
@@ -498,8 +499,7 @@ Feature: Reprove Identity Journey
 
   Rule: App only reprove journey authoritative source check fails
     Background:
-      Given I activate the 'reproveViaAppOnly' feature set
-      And the subject already has the following credentials
+      Given the subject already has the following credentials
         | CRI     | scenario                     |
         | dcmaw   | kenneth-driving-permit-valid |
         | address | kenneth-current              |

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -227,8 +227,7 @@ Feature: Audit Events
 
   @QualityGateRegressionTest
   Scenario: Reprove identity journey with AIS
-    Given I activate the 'reproveViaAppOnly' feature set
-    And the subject already has the following credentials
+    Given the subject already has the following credentials
       | CRI     | scenario                     |
       | dcmaw   | kenneth-driving-permit-valid |
       | address | kenneth-current              |

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -351,7 +351,7 @@ core:
       apiBaseUrl: "https://queue.stubs.account.gov.uk"
   featureFlags:
     repeatFraudCheckEnabled: true
-    reproveViaAppOnlyEnabled: false
+    reproveViaAppOnlyEnabled: true
     parseVcClasses: true
     sqsAsync: true
     kidJarHeaderEnabled: true
@@ -374,9 +374,9 @@ core:
     evcsApiUpdates:
         featureFlags:
           evcsApiUpdatesEnabled: true
-    reproveViaAppOnly:
+    disableReproveViaAppOnly:
       featureFlags:
-        reproveViaAppOnlyEnabled: true
+        reproveViaAppOnlyEnabled: false
     zeroHourFraudVcExpiry:
       self:
         fraudCheckExpiryPeriodDays: 0


### PR DESCRIPTION
## Proposed changes
### What changed

- Enabled reproveViaAppOnlyEnabled feature flag in local running environment
- Added disableReproveViaAppOnly feature set
- Adjusted API tests

### Why did it change

To enable feature flag in api tests as we approaching release. Additionally, the disableReproveViaAppOnly feature set allows production testing to continue until the feature is also enabled there.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9037](https://govukverify.atlassian.net/browse/PYIC-9037)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9037]: https://govukverify.atlassian.net/browse/PYIC-9037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ