### PR TITLE
PYIC-9130: Removing expired DLs dynamic variation

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -518,9 +518,7 @@ Feature: Audit Events
     When I start a new 'reverification' journey
     Then I get a 'you-can-change-security-code-method' page response
     When I submit a 'next' event
-    Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+    Then I get a 'page-ipv-identity-document-start' page response
     When I submit an 'appTriage' event
     Then I get a 'dcmaw' CRI response
     When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub

--- a/api-tests/features/mfa-reset-journey.feature
+++ b/api-tests/features/mfa-reset-journey.feature
@@ -14,9 +14,7 @@ Feature: MFA reset journey
 
     Scenario: Successful MFA reset journey
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -28,9 +26,7 @@ Feature: MFA reset journey
 
     Scenario: Successful MFA reset journey - with DL auth source check
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -46,9 +42,7 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey with breaching CI - user can still reuse existing identity
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-with-breaching-ci' details to the CRI stub
@@ -62,9 +56,7 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - DCMAW error
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error
@@ -80,9 +72,7 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - failed verification score
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-verification-zero' details to the CRI stub
@@ -92,9 +82,7 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - non-matching identity
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'alice-passport-valid' details to the CRI stub
@@ -104,9 +92,7 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - failed DL auth source check
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -120,9 +106,7 @@ Feature: MFA reset journey
 
     Scenario: Failed MFA reset journey - incorrect DL details from DL auth source check - prove identity another way
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -142,9 +126,7 @@ Feature: MFA reset journey
 
     Scenario: Incorrect DL details from DL auth source check - allowed retry through the app
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -173,9 +155,7 @@ Feature: MFA reset journey
 
     Scenario: Successful MFA reset journey still using v1 app
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -203,9 +183,7 @@ Feature: MFA reset journey
       When I start a new 'reverification' journey
       Then I get a 'you-can-change-security-code-method' page response
       When I submit a 'next' event
-      Then I get a 'page-ipv-identity-document-start' page response and pageContext
-        | Context       | Value |
-        | allowMfaReset | true  |
+      Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'dcmaw' CRI response
       When The AIS stub will return an 'AIS_ACCOUNT_BLOCKED' result

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -11,7 +11,6 @@ public class PageContextValidator extends AbstractPageContextValidator {
                             "need-more-information-confirm-change-details", Set.of("journeyType")),
                     Map.entry("no-photo-id-security-questions-find-another-way", Set.of("reason")),
                     Map.entry("page-dcmaw-success", Set.of("noAddress")),
-                    Map.entry("page-ipv-identity-document-start", Set.of("allowMfaReset")),
                     Map.entry("page-ipv-success", Set.of("journeyType")),
                     Map.entry("page-multiple-doc-check", Set.of("allowNino")),
                     Map.entry("page-update-name", Set.of("journeyType")),

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -77,8 +77,6 @@ states:
     response:
       type: page
       pageId: page-ipv-identity-document-start
-      pageContext:
-        allowMfaReset: true
     events:
       appTriage:
         targetState: APP_DOC_CHECK


### PR DESCRIPTION
## Proposed changes
### What changed

- Removing expired DLs dynamic variation

### Why did it change

- As part of the expired DL initiative for mobile, the go-live was split between V1 of the OL app and V2 of the OL app. V2 of the app was put live and consequently IPV Core introduced variant screens to show different text to a user based on whether they were on a V1 app journey (MFA reset journey) or a V2 app journey. 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9130](https://govukverify.atlassian.net/browse/PYIC-9130)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9130]: https://govukverify.atlassian.net/browse/PYIC-9130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ