### PR TITLE
PYIC-9083: Avoid a dead end for COI users - enable feature flag to lower environments

### DIFF
--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -40,6 +40,7 @@ Feature: Repeat fraud check failures
       When I start a new 'medium-confidence' journey
       Then I get a 'confirm-your-details' page response
 
+    @amrit
     Scenario: Applicable authoritative source failed check evidence too weak
       When I submit a 'update-name' event
       Then I get an 'identify-device' page response
@@ -70,10 +71,38 @@ Feature: Repeat fraud check failures
       When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'sorry-could-not-confirm-details' page response and pageContext
-        | Context                 | Value |
-        | isExistingIdentityValid | false |
-      When I submit a 'returnToRp' event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value             |
+        | journeyType          | repeatFraudCheck  |
+      When I submit an 'passport' event  
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-changed-given-name-passport-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response and pageContext
+        | Context   | Value |
+        | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'pyi-no-match' page response and pageContext
+        | Context | Value         |
+        | reason  | updateDetails |  
+      When I submit a 'next' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I am issued a 'P0' identity

--- a/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
+++ b/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
@@ -10,7 +10,6 @@ Feature: Update details higher strength
         | CRI   | scenario        |
         | fraud | kenneth-score-2 |
       And I have an existing stored identity record with a 'P3' vot
-      And I activate the 'coi6mfcDeadEndRouting' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'confirm-your-details' page response
 
@@ -246,7 +245,6 @@ Feature: Update details higher strength
         | address | kenneth-current        |
         | fraud   | kenneth-score-2        |
       And I have an existing stored identity record with a 'P3' vot
-      And I activate the 'coi6mfcDeadEndRouting' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-reuse' page response
       When I submit a 'update-details' event

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -355,7 +355,7 @@ core:
     sisVerificationEnabled: true
     testFeatureFlag: false
     evcsApiUpdatesEnabled: false
-    coi6mfcDeadEndRoutingEnabled: false
+    coi6mfcDeadEndRoutingEnabled: true
   features:
     testFeature:
       self:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -359,7 +359,7 @@ core:
     sisVerificationEnabled: true
     evcsApiUpdatesEnabled: false
     mitigations9020Enabled: false
-    coi6mfcDeadEndRoutingEnabled: false
+    coi6mfcDeadEndRoutingEnabled: true
 
   features:
     coi6mfcDeadEndRouting:


### PR DESCRIPTION
## Proposed changes
### What changed

- Enable the featureFlag
- Update tests

### Why did it change

-

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9083](https://govukverify.atlassian.net/browse/PYIC-9083)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9083]: https://govukverify.atlassian.net/browse/PYIC-9083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ