### PR TITLE
PYIC-9037: Bump mermaid to 11.15.

### DIFF
--- a/journey-map/package-lock.json
+++ b/journey-map/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "dotenv": "17.4.1",
         "express": "5.2.0",
-        "mermaid": "^11.15.0",
+        "mermaid": "11.15.0",
         "svg-pan-zoom": "3.6.2",
         "yaml": "2.9.0"
       },
@@ -2691,9 +2691,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
-      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
       "license": "MIT",
       "workspaces": [
         "docs",

--- a/journey-map/package.json
+++ b/journey-map/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "dotenv": "17.4.1",
     "express": "5.2.0",
-    "mermaid": "11.14.0",
+    "mermaid": "11.15.0",
     "svg-pan-zoom": "3.6.2",
     "yaml": "2.9.0"
   },


### PR DESCRIPTION
Previously fixed via audit-fix which make package.json and package-lock.json out of sync which cause failing to run "npm ci" in actions.

## Proposed changes
### What changed

- Bumped mermaid to 11.15

### Why did it change

- previously mermaid was updated to 11.15 via audit-fix which changed packag-lock.json file and make out of sync with package.json
This cause fail to run "npm ci" command in workflow. 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9135](https://govukverify.atlassian.net/browse/PYIC-9135)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9135]: https://govukverify.atlassian.net/browse/PYIC-9135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ