### PR TITLE
PYIC-9135: Bump pact lib to 4.7.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ awsSdk = "2.44.4"
 jackson = "2.21.2"
 log4j = "2.26.0"
 mockito = "5.21.0"
-pact = "4.7.0"
+pact = "4.7.1"
 powertools = "2.10.0"
 
 [libraries]


### PR DESCRIPTION
## Proposed changes
### What changed

- Upgraded pact library 4.7.0 to 4.7.1

### Why did it change

- To hopefully resolve some vulnerabilities caused by indirect dependency via pact library 4.7.0

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9135](https://govukverify.atlassian.net/browse/PYIC-9135)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9135]: https://govukverify.atlassian.net/browse/PYIC-9135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ