### PR TITLE
PYIC-9135: Remove deprecated dependency notation.

### DIFF
--- a/lambdas/reset-session-identity/build.gradle
+++ b/lambdas/reset-session-identity/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	testImplementation libs.hamcrest,
 			libs.junitJupiter,
 			libs.mockitoJunit,
-			project(":libs:common-services").sourceSets.test.output,
+			project(path: ":libs:common-services", configuration: "tests"),
 			project(path: ':libs:test-helpers')
 
 	mockitoAgent(libs.mockitoCore) {

--- a/libs/ais-service/build.gradle
+++ b/libs/ais-service/build.gradle
@@ -72,13 +72,15 @@ jacocoTestReport {
 }
 
 configurations {
-	tests.extendsFrom(testImplementation)
+	tests {
+		extendsFrom testImplementation
+	}
 }
 
-tasks.register('jarTest', Jar) {
+tasks.register('testJar', Jar) {
 	from sourceSets.test.output
-	archiveClassifier.set('tests')
+	archiveClassifier.set('test')
 }
 artifacts {
-	tests jarTest
+	tests tasks.named('testJar')
 }

--- a/libs/common-services/build.gradle
+++ b/libs/common-services/build.gradle
@@ -82,13 +82,16 @@ jacocoTestReport {
 }
 
 configurations {
-	tests.extendsFrom(testImplementation)
+	tests {
+		extendsFrom testImplementation
+	}
 }
 
-tasks.register('jarTest', Jar) {
+tasks.register('testJar', Jar) {
 	from sourceSets.test.output
-	archiveClassifier.set('tests')
+	archiveClassifier.set('test')
 }
+
 artifacts {
-	tests jarTest
+	tests tasks.named('testJar')
 }

--- a/libs/cri-response-service/build.gradle
+++ b/libs/cri-response-service/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
-			project(":libs:common-services").sourceSets.test.output
+			project(path: ":libs:common-services", configuration: "tests")
 
 	mockitoAgent(libs.mockitoCore) {
 		transitive = false

--- a/libs/verifiable-credentials/build.gradle
+++ b/libs/verifiable-credentials/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 	testImplementation libs.junitJupiter,
 			libs.mockitoJunit,
-			project(":libs:common-services").sourceSets.test.output,
+			project(path: ":libs:common-services", configuration: "tests"),
 			project(path: ':libs:test-helpers')
 
 	mockitoAgent(libs.mockitoCore) {


### PR DESCRIPTION
## Proposed changes
### What changed

- removed deprecated dependency notation (.sourceSets.test.output)

### Why did it change

- to unblock gradle upgrade to 9.5.1
- also marked by IDE as unrecognised dependency notation (No candidates found for method call project(":libs:common-services").sourceSets.)

Dependabot PR:
https://github.com/govuk-one-login/ipv-core-back/pull/3956

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9135](https://govukverify.atlassian.net/browse/PYIC-9135)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9135]: https://govukverify.atlassian.net/browse/PYIC-9135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ