### PR TITLE
PYIC-9095: Tidy up repeatFraudCheckEnabled feature flag

### DIFF
--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -77,7 +77,6 @@ import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_NOT_FOUND;
 import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.INTERVENTION_REPROVE_VIA_APP_ONLY;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.REPEAT_FRAUD_CHECK;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SIS_VERIFICATION;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
@@ -695,9 +694,8 @@ public class CheckExistingIdentityHandler
                         .toList();
         var fixedClock = Clock.fixed(Instant.now(), DateAndTimeHelper.LONDON_TIMEZONE);
 
-        if (configService.enabled(REPEAT_FRAUD_CHECK)
-                && VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
-                        fraudVcs, configService, fixedClock)) {
+        if (VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                fraudVcs, configService, fixedClock)) {
             LOGGER.info(
                     LogHelper.buildLogMessage(
                             "All Fraud VCs are expired or from unavailable source"));

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -224,6 +224,7 @@ class CheckExistingIdentityHandlerTest {
     @Captor private ArgumentCaptor<AuditEvent> auditEventArgumentCaptor;
     private JourneyRequest event;
     private ClientOAuthSessionItem clientOAuthSessionItem;
+    private MockedStatic<VcHelper> mockVcHelper;
 
     @BeforeEach
     void setUpEach() {
@@ -263,10 +264,15 @@ class CheckExistingIdentityHandlerTest {
                         .build();
 
         when(configService.getComponentId()).thenReturn("https://core-component.example");
+
+        mockVcHelper = mockStatic(VcHelper.class, CALLS_REAL_METHODS);
     }
 
     @AfterEach
     void checkAuditEventWait() {
+        if (mockVcHelper != null) {
+            mockVcHelper.close();
+        }
         InOrder auditInOrder = inOrder(auditService);
         auditInOrder.verify(auditService).awaitAuditEvents();
         auditInOrder.verifyNoMoreInteractions();
@@ -964,6 +970,12 @@ class CheckExistingIdentityHandlerTest {
                     .thenReturn(clientOAuthSessionItem);
             when(mockAisService.fetchAisState(TEST_USER_ID))
                     .thenReturn(createNoInterventionAisState());
+            mockVcHelper
+                    .when(
+                            () ->
+                                    VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                                            any(), any(), any()))
+                    .thenReturn(false);
         }
 
         @Test
@@ -1002,22 +1014,12 @@ class CheckExistingIdentityHandlerTest {
                             true))
                     .thenReturn(buildMatchResultFor(P2, matchedProfile));
 
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
-                                                any(), any(), any()))
-                        .thenReturn(false);
+            var journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
 
-                var journeyResponse =
-                        toResponseClass(
-                                checkExistingIdentityHandler.handleRequest(event, context),
-                                JourneyResponse.class);
-
-                assertEquals(JOURNEY_REUSE, journeyResponse);
-            }
+            assertEquals(JOURNEY_REUSE, journeyResponse);
 
             verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
             assertEquals(
@@ -1058,22 +1060,12 @@ class CheckExistingIdentityHandlerTest {
                             true))
                     .thenThrow(new RuntimeException("boom"));
 
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
-                                                any(), any(), any()))
-                        .thenReturn(false);
+            var journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
 
-                var journeyResponse =
-                        toResponseClass(
-                                checkExistingIdentityHandler.handleRequest(event, context),
-                                JourneyResponse.class);
-
-                assertEquals(JOURNEY_REUSE, journeyResponse);
-            }
+            assertEquals(JOURNEY_REUSE, journeyResponse);
 
             verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
             assertEquals(
@@ -1107,22 +1099,12 @@ class CheckExistingIdentityHandlerTest {
                     .thenReturn(buildMatchResultFor(P2, M1A));
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
 
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
-                                                any(), any(), any()))
-                        .thenReturn(false);
+            var journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
 
-                var journeyResponse =
-                        toResponseClass(
-                                checkExistingIdentityHandler.handleRequest(event, context),
-                                JourneyResponse.class);
-
-                assertEquals(JOURNEY_REUSE_WITH_STORE, journeyResponse);
-            }
+            assertEquals(JOURNEY_REUSE_WITH_STORE, journeyResponse);
         }
 
         @Test
@@ -1138,29 +1120,18 @@ class CheckExistingIdentityHandlerTest {
                     .when(mockSessionCredentialService)
                     .persistCredentials(any(), any(), anyBoolean());
 
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
-                                                any(), any(), any()))
-                        .thenReturn(false);
+            var journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyErrorResponse.class);
 
-                var journeyResponse =
-                        toResponseClass(
-                                checkExistingIdentityHandler.handleRequest(event, context),
-                                JourneyErrorResponse.class);
-
-                assertEquals(JOURNEY_ERROR_PATH, journeyResponse.getJourney());
-                assertEquals(HTTPResponse.SC_SERVER_ERROR, journeyResponse.getStatusCode());
-                assertEquals(
-                        ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getCode(),
-                        journeyResponse.getCode());
-                assertEquals(
-                        ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getMessage(),
-                        journeyResponse.getMessage());
-            }
+            assertEquals(JOURNEY_ERROR_PATH, journeyResponse.getJourney());
+            assertEquals(HTTPResponse.SC_SERVER_ERROR, journeyResponse.getStatusCode());
+            assertEquals(
+                    ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getCode(), journeyResponse.getCode());
+            assertEquals(
+                    ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getMessage(),
+                    journeyResponse.getMessage());
         }
 
         @Test
@@ -1186,32 +1157,19 @@ class CheckExistingIdentityHandlerTest {
                                     Gpg45Scores.builder().build()));
             when(configService.getDcmawExpiredDlValidityPeriodDays()).thenReturn(180);
 
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.isExpiredDrivingPermitVc(
-                                                any(), eq(configService), any()))
-                        .thenReturn(true);
+            mockVcHelper
+                    .when(() -> VcHelper.isExpiredDrivingPermitVc(any(), eq(configService), any()))
+                    .thenReturn(true);
 
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
-                                                any(), any(), any()))
-                        .thenReturn(false);
+            // Act
+            var result = checkExistingIdentityHandler.handleRequest(event, context);
 
-                // Act
-                var result = checkExistingIdentityHandler.handleRequest(event, context);
+            // Assert
+            var journeyResponse = toResponseClass(result, JourneyResponse.class);
 
-                // Assert
-                var journeyResponse = toResponseClass(result, JourneyResponse.class);
-
-                assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM, journeyResponse);
-                verify(mockEvcsService, times(1))
-                        .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
-            }
+            assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM, journeyResponse);
+            verify(mockEvcsService, times(1))
+                    .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
 
             verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
             var auditEvent = auditEventArgumentCaptor.getValue();
@@ -1247,32 +1205,19 @@ class CheckExistingIdentityHandlerTest {
             when(configService.getDcmawExpiredDlValidityPeriodDays()).thenReturn(180);
             when(configService.enabled(EVCS_API_UPDATES)).thenReturn(true);
 
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.isExpiredDrivingPermitVc(
-                                                any(), eq(configService), any()))
-                        .thenReturn(true);
+            mockVcHelper
+                    .when(() -> VcHelper.isExpiredDrivingPermitVc(any(), eq(configService), any()))
+                    .thenReturn(true);
 
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
-                                                any(), any(), any()))
-                        .thenReturn(false);
+            // Act
+            var result = checkExistingIdentityHandler.handleRequest(event, context);
 
-                // Act
-                var result = checkExistingIdentityHandler.handleRequest(event, context);
+            // Assert
+            var journeyResponse = toResponseClass(result, JourneyResponse.class);
 
-                // Assert
-                var journeyResponse = toResponseClass(result, JourneyResponse.class);
-
-                assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM, journeyResponse);
-                verify(mockEvcsService, times(1))
-                        .markHistoricInEvcsV2(TEST_USER_ID, TEST_JOURNEY_ID, testCredentialBundle);
-            }
+            assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM, journeyResponse);
+            verify(mockEvcsService, times(1))
+                    .markHistoricInEvcsV2(TEST_USER_ID, TEST_JOURNEY_ID, testCredentialBundle);
 
             verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
             var auditEvent = auditEventArgumentCaptor.getValue();
@@ -1300,31 +1245,19 @@ class CheckExistingIdentityHandlerTest {
             when(mockVotMatcher.findStrongestMatches(
                             List.of(P2), testCredentialBundle, List.of(), true))
                     .thenReturn(buildMatchResultFor(P2, M1A));
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.isExpiredDrivingPermitVc(
-                                                any(), eq(configService), any()))
-                        .thenReturn(false);
 
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
-                                                any(), any(), any()))
-                        .thenReturn(false);
+            mockVcHelper
+                    .when(() -> VcHelper.isExpiredDrivingPermitVc(any(), eq(configService), any()))
+                    .thenReturn(false);
 
-                var journeyResponse =
-                        toResponseClass(
-                                checkExistingIdentityHandler.handleRequest(event, context),
-                                JourneyResponse.class);
+            var journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
 
-                assertEquals(JOURNEY_REUSE, journeyResponse);
-                verify(mockEvcsService, times(0))
-                        .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
-            }
+            assertEquals(JOURNEY_REUSE, journeyResponse);
+            verify(mockEvcsService, times(0))
+                    .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
         }
 
         @Test
@@ -1337,17 +1270,7 @@ class CheckExistingIdentityHandlerTest {
             when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                     .thenReturn(emptyAsyncCriStatus);
 
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
-                                                any(), any(), any()))
-                        .thenReturn(false);
-
-                checkExistingIdentityHandler.handleRequest(event, context);
-            }
+            checkExistingIdentityHandler.handleRequest(event, context);
 
             verify(mockEvcsService, times(0))
                     .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
@@ -1833,36 +1756,30 @@ class CheckExistingIdentityHandlerTest {
                     .thenReturn(buildMatchResultFor(P2, M1B));
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
             when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(1);
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.isExpiredDrivingPermitVc(
-                                                any(), eq(configService), any()))
-                        .thenReturn(false);
 
-                var journeyResponse =
-                        toResponseClass(
-                                checkExistingIdentityHandler.handleRequest(event, context),
-                                JourneyResponse.class);
-                assertEquals(JOURNEY_REPEAT_FRAUD_CHECK, journeyResponse);
+            mockVcHelper
+                    .when(() -> VcHelper.isExpiredDrivingPermitVc(any(), eq(configService), any()))
+                    .thenReturn(false);
 
-                var expectedStoredVc = vcs.stream().filter(vc -> vc != fraudVc).toList();
-                verify(mockSessionCredentialService)
-                        .persistCredentials(
-                                expectedStoredVc, ipvSessionItem.getIpvSessionId(), false);
+            var journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+            assertEquals(JOURNEY_REPEAT_FRAUD_CHECK, journeyResponse);
 
-                assertEquals(Vot.P0, ipvSessionItem.getVot());
-                verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
-                var auditEvent = auditEventArgumentCaptor.getValue();
-                var extension = (AuditExtensionExpiredFraudVcFound) auditEvent.getExtensions();
-                assertEquals(AuditEventTypes.IPV_EXPIRED_FRAUD_VC_FOUND, auditEvent.getEventName());
-                assertEquals(
-                        1658829758000L, // 26/07/2022 timestamp in ms
-                        extension.vcIssueDate());
-                assertEquals(86400000L, extension.vcExpiryPeriodMs()); // 1 day in ms
-            }
+            var expectedStoredVc = vcs.stream().filter(vc -> vc != fraudVc).toList();
+            verify(mockSessionCredentialService)
+                    .persistCredentials(expectedStoredVc, ipvSessionItem.getIpvSessionId(), false);
+
+            assertEquals(Vot.P0, ipvSessionItem.getVot());
+            verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
+            var auditEvent = auditEventArgumentCaptor.getValue();
+            var extension = (AuditExtensionExpiredFraudVcFound) auditEvent.getExtensions();
+            assertEquals(AuditEventTypes.IPV_EXPIRED_FRAUD_VC_FOUND, auditEvent.getEventName());
+            assertEquals(
+                    1658829758000L, // 26/07/2022 timestamp in ms
+                    extension.vcIssueDate());
+            assertEquals(86400000L, extension.vcExpiryPeriodMs()); // 1 day in ms
         }
 
         @Test
@@ -1875,31 +1792,25 @@ class CheckExistingIdentityHandlerTest {
                     .thenReturn(buildMatchResultFor(P2, M1B));
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
             when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(100000000);
-            try (MockedStatic<VcHelper> mockVcHelper =
-                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
-                mockVcHelper
-                        .when(
-                                () ->
-                                        VcHelper.isExpiredDrivingPermitVc(
-                                                any(), eq(configService), any()))
-                        .thenReturn(false);
 
-                var journeyResponse =
-                        toResponseClass(
-                                checkExistingIdentityHandler.handleRequest(event, context),
-                                JourneyResponse.class);
-                assertNotEquals(JOURNEY_REPEAT_FRAUD_CHECK, journeyResponse);
+            mockVcHelper
+                    .when(() -> VcHelper.isExpiredDrivingPermitVc(any(), eq(configService), any()))
+                    .thenReturn(false);
 
-                verify(mockSessionCredentialService)
-                        .persistCredentials(
-                                VCS_FROM_STORE, ipvSessionItem.getIpvSessionId(), false);
+            var journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+            assertNotEquals(JOURNEY_REPEAT_FRAUD_CHECK, journeyResponse);
 
-                var inOrder = inOrder(ipvSessionItem, ipvSessionService);
-                inOrder.verify(ipvSessionItem).setVot(P2);
-                inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
-                inOrder.verify(ipvSessionItem, never()).setVot(any());
-                assertEquals(P2, ipvSessionItem.getVot());
-            }
+            verify(mockSessionCredentialService)
+                    .persistCredentials(VCS_FROM_STORE, ipvSessionItem.getIpvSessionId(), false);
+
+            var inOrder = inOrder(ipvSessionItem, ipvSessionService);
+            inOrder.verify(ipvSessionItem).setVot(P2);
+            inOrder.verify(ipvSessionService).updateIpvSession(ipvSessionItem);
+            inOrder.verify(ipvSessionItem, never()).setVot(any());
+            assertEquals(P2, ipvSessionItem.getVot());
         }
     }
 

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -110,7 +110,6 @@ import static uk.gov.di.ipv.core.library.ais.TestData.createResetPasswordAisStat
 import static uk.gov.di.ipv.core.library.ais.TestData.createSuspendedIdentityAisState;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.INTERVENTION_REPROVE_VIA_APP_ONLY;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.REPEAT_FRAUD_CHECK;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SIS_VERIFICATION;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
@@ -1003,12 +1002,22 @@ class CheckExistingIdentityHandlerTest {
                             true))
                     .thenReturn(buildMatchResultFor(P2, matchedProfile));
 
-            var journeyResponse =
-                    toResponseClass(
-                            checkExistingIdentityHandler.handleRequest(event, context),
-                            JourneyResponse.class);
+            try (MockedStatic<VcHelper> mockVcHelper =
+                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
+                mockVcHelper
+                        .when(
+                                () ->
+                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                                                any(), any(), any()))
+                        .thenReturn(false);
 
-            assertEquals(JOURNEY_REUSE, journeyResponse);
+                var journeyResponse =
+                        toResponseClass(
+                                checkExistingIdentityHandler.handleRequest(event, context),
+                                JourneyResponse.class);
+
+                assertEquals(JOURNEY_REUSE, journeyResponse);
+            }
 
             verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
             assertEquals(
@@ -1049,12 +1058,23 @@ class CheckExistingIdentityHandlerTest {
                             true))
                     .thenThrow(new RuntimeException("boom"));
 
-            var journeyResponse =
-                    toResponseClass(
-                            checkExistingIdentityHandler.handleRequest(event, context),
-                            JourneyResponse.class);
+            try (MockedStatic<VcHelper> mockVcHelper =
+                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
+                mockVcHelper
+                        .when(
+                                () ->
+                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                                                any(), any(), any()))
+                        .thenReturn(false);
 
-            assertEquals(JOURNEY_REUSE, journeyResponse);
+                var journeyResponse =
+                        toResponseClass(
+                                checkExistingIdentityHandler.handleRequest(event, context),
+                                JourneyResponse.class);
+
+                assertEquals(JOURNEY_REUSE, journeyResponse);
+            }
+
             verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
             assertEquals(
                     AuditEventTypes.IPV_IDENTITY_REUSE_COMPLETE,
@@ -1087,12 +1107,22 @@ class CheckExistingIdentityHandlerTest {
                     .thenReturn(buildMatchResultFor(P2, M1A));
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
 
-            var journeyResponse =
-                    toResponseClass(
-                            checkExistingIdentityHandler.handleRequest(event, context),
-                            JourneyResponse.class);
+            try (MockedStatic<VcHelper> mockVcHelper =
+                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
+                mockVcHelper
+                        .when(
+                                () ->
+                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                                                any(), any(), any()))
+                        .thenReturn(false);
 
-            assertEquals(JOURNEY_REUSE_WITH_STORE, journeyResponse);
+                var journeyResponse =
+                        toResponseClass(
+                                checkExistingIdentityHandler.handleRequest(event, context),
+                                JourneyResponse.class);
+
+                assertEquals(JOURNEY_REUSE_WITH_STORE, journeyResponse);
+            }
         }
 
         @Test
@@ -1108,19 +1138,29 @@ class CheckExistingIdentityHandlerTest {
                     .when(mockSessionCredentialService)
                     .persistCredentials(any(), any(), anyBoolean());
 
-            var journeyResponse =
-                    toResponseClass(
-                            checkExistingIdentityHandler.handleRequest(event, context),
-                            JourneyErrorResponse.class);
+            try (MockedStatic<VcHelper> mockVcHelper =
+                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
+                mockVcHelper
+                        .when(
+                                () ->
+                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                                                any(), any(), any()))
+                        .thenReturn(false);
 
-            assertEquals(JOURNEY_ERROR_PATH, journeyResponse.getJourney());
+                var journeyResponse =
+                        toResponseClass(
+                                checkExistingIdentityHandler.handleRequest(event, context),
+                                JourneyErrorResponse.class);
 
-            assertEquals(HTTPResponse.SC_SERVER_ERROR, journeyResponse.getStatusCode());
-            assertEquals(
-                    ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getCode(), journeyResponse.getCode());
-            assertEquals(
-                    ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getMessage(),
-                    journeyResponse.getMessage());
+                assertEquals(JOURNEY_ERROR_PATH, journeyResponse.getJourney());
+                assertEquals(HTTPResponse.SC_SERVER_ERROR, journeyResponse.getStatusCode());
+                assertEquals(
+                        ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getCode(),
+                        journeyResponse.getCode());
+                assertEquals(
+                        ErrorResponse.FAILED_TO_SAVE_CREDENTIAL.getMessage(),
+                        journeyResponse.getMessage());
+            }
         }
 
         @Test
@@ -1154,6 +1194,13 @@ class CheckExistingIdentityHandlerTest {
                                         VcHelper.isExpiredDrivingPermitVc(
                                                 any(), eq(configService), any()))
                         .thenReturn(true);
+
+                mockVcHelper
+                        .when(
+                                () ->
+                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                                                any(), any(), any()))
+                        .thenReturn(false);
 
                 // Act
                 var result = checkExistingIdentityHandler.handleRequest(event, context);
@@ -1209,6 +1256,13 @@ class CheckExistingIdentityHandlerTest {
                                                 any(), eq(configService), any()))
                         .thenReturn(true);
 
+                mockVcHelper
+                        .when(
+                                () ->
+                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                                                any(), any(), any()))
+                        .thenReturn(false);
+
                 // Act
                 var result = checkExistingIdentityHandler.handleRequest(event, context);
 
@@ -1255,6 +1309,13 @@ class CheckExistingIdentityHandlerTest {
                                                 any(), eq(configService), any()))
                         .thenReturn(false);
 
+                mockVcHelper
+                        .when(
+                                () ->
+                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                                                any(), any(), any()))
+                        .thenReturn(false);
+
                 var journeyResponse =
                         toResponseClass(
                                 checkExistingIdentityHandler.handleRequest(event, context),
@@ -1276,7 +1337,17 @@ class CheckExistingIdentityHandlerTest {
             when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
                     .thenReturn(emptyAsyncCriStatus);
 
-            checkExistingIdentityHandler.handleRequest(event, context);
+            try (MockedStatic<VcHelper> mockVcHelper =
+                    mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
+                mockVcHelper
+                        .when(
+                                () ->
+                                        VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource(
+                                                any(), any(), any()))
+                        .thenReturn(false);
+
+                checkExistingIdentityHandler.handleRequest(event, context);
+            }
 
             verify(mockEvcsService, times(0))
                     .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
@@ -1745,8 +1816,7 @@ class CheckExistingIdentityHandlerTest {
         }
 
         @Test
-        void shouldReturnJourneyRepeatFraudCheckResponseIfExpiredFraudAndFlagIsTrue()
-                throws Exception {
+        void shouldReturnJourneyRepeatFraudCheckResponseIfExpiredFraud() throws Exception {
             var fraudVc = vcExperianFraudM1aExpired();
             var vcs =
                     List.of(
@@ -1762,7 +1832,6 @@ class CheckExistingIdentityHandlerTest {
             when(mockVotMatcher.findStrongestMatches(List.of(P2), vcs, List.of(), true))
                     .thenReturn(buildMatchResultFor(P2, M1B));
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-            when(configService.enabled(REPEAT_FRAUD_CHECK)).thenReturn(true);
             when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(1);
             try (MockedStatic<VcHelper> mockVcHelper =
                     mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {
@@ -1797,8 +1866,7 @@ class CheckExistingIdentityHandlerTest {
         }
 
         @Test
-        void shouldNotReturnJourneyRepeatFraudCheckResponseIfNotExpiredFraudAndFlagIsTrue()
-                throws Exception {
+        void shouldNotReturnJourneyRepeatFraudCheckResponseIfNotExpiredFraud() throws Exception {
             when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
                             TEST_USER_ID, EVCS_TEST_TOKEN, false, CURRENT, PENDING_RETURN))
                     .thenReturn(Map.of(CURRENT, VCS_FROM_STORE));
@@ -1806,7 +1874,6 @@ class CheckExistingIdentityHandlerTest {
             when(mockVotMatcher.findStrongestMatches(List.of(P2), VCS_FROM_STORE, List.of(), true))
                     .thenReturn(buildMatchResultFor(P2, M1B));
             when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-            when(configService.enabled(REPEAT_FRAUD_CHECK)).thenReturn(true);
             when(configService.getFraudCheckExpiryPeriodDays()).thenReturn(100000000);
             try (MockedStatic<VcHelper> mockVcHelper =
                     mockStatic(VcHelper.class, CALLS_REAL_METHODS)) {

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.core.library.config;
 
 public enum CoreFeatureFlag implements FeatureFlag {
     UNUSED_PLACEHOLDER("unusedPlaceHolder"),
-    REPEAT_FRAUD_CHECK("repeatFraudCheckEnabled"),
     SQS_ASYNC("sqsAsync"),
     DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
     SIS_VERIFICATION("sisVerificationEnabled"),

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -291,11 +291,6 @@ class AppConfigServiceTest {
     }
 
     @Test
-    void enabledTrueIfFeatureFlagEnabled() {
-        assertTrue(configService.enabled("repeatFraudCheckEnabled"));
-    }
-
-    @Test
     void enabledFalseIfFeatureFlagNotEnabled() {
         assertFalse(configService.enabled("testFeatureFlag"));
     }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -291,6 +291,11 @@ class AppConfigServiceTest {
     }
 
     @Test
+    void enabledTrueIfFeatureFlagEnabled() {
+        assertTrue(configService.enabled("parseVcClasses"));
+    }
+
+    @Test
     void enabledFalseIfFeatureFlagNotEnabled() {
         assertFalse(configService.enabled("testFeatureFlag"));
     }

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -346,7 +346,6 @@ core:
     asyncQueue:
       apiBaseUrl: "https://queue.stubs.account.gov.uk"
   featureFlags:
-    repeatFraudCheckEnabled: true
     reproveViaAppOnlyEnabled: false
     parseVcClasses: true
     sqsAsync: true

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -350,7 +350,6 @@ core:
     asyncQueue:
       apiBaseUrl: "https://queue.stubs.account.gov.uk"
   featureFlags:
-    repeatFraudCheckEnabled: true
     reproveViaAppOnlyEnabled: true
     parseVcClasses: true
     sqsAsync: true


### PR DESCRIPTION
## Proposed changes
### What changed

- Updated the CheckExistingIdentityHandlerTest suite to align with the decommissioning of the REPEAT_FRAUD_CHECK feature flag. 
Because the fraud check expiration logic is now permanent and executes on every request, standard identity reuse tests were incorrectly routing to the repeat fraud check path due to missing/empty mock fraud data. 

- Added MockedStatic<VcHelper> blocks to the failing standard reuse tests.
- Stubbed VcHelper.allFraudVcsAreExpiredOrFromUnavailableSource to return false for reuse scenarios, forcing the code to bypass the fraud check rerouting and cleanly hit the expected identity reuse assertions.

### Why did it change

- The repeat fraud check feature has long been live and there are no plans to turn it off, in fact it will be built into SIS when Phase 3 goes live. We no longer need it behind a feature flag in core-back.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9095](https://govukverify.atlassian.net/browse/PYIC-9095)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9095]: https://govukverify.atlassian.net/browse/PYIC-9095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ