### PR TITLE
PYIC-9149: Fix COI/6MFC dead end routing M1C profile matching

### DIFF
--- a/api-tests/features/m1c-journeys.feature
+++ b/api-tests/features/m1c-journeys.feature
@@ -397,10 +397,10 @@ Feature: M1C Unavailable Journeys
       When I submit 'kenneth-changed-family-name-unavailable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'sorry-could-not-confirm-details' page response and pageContext
-        | Context                 | Value |
-        | isExistingIdentityValid | true  |
-      When I submit a 'returnToRp' event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value          |
+        | journeyType          | updateDetails  |
+      When I submit a 'continueToService' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I am issued a 'P2' identity

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -70,9 +70,9 @@ Feature: Repeat fraud check failures
       When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'sorry-could-not-confirm-details' page response and pageContext
-        | Context                 | Value |
-        | isExistingIdentityValid | false |
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value            |
+        | journeyType          | repeatFraudCheck |
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -109,9 +109,9 @@ Feature: Repeat fraud check failures
       When I submit 'kenneth-unavailable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'sorry-could-not-confirm-details' page response and pageContext
-        | Context                 | Value |
-        | isExistingIdentityValid | false |
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value            |
+        | journeyType          | repeatFraudCheck |
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -250,10 +250,10 @@ Feature: Repeat fraud check failures
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
-      Then I get a 'update-details-failed' page response and pageContext
-        | Context                   | Value |
-        | isExistingIdentityInvalid | true  |
-      When I submit a 'return-to-service' event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value            |
+        | journeyType          | repeatFraudCheck |
+      When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I am issued a 'P0' identity

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -226,6 +226,7 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'pyi-no-match' page response
 
+        @amrit
         Scenario: Zero score in fraud CRI - receives old identity (P2)
             When I submit an 'update-name' event
             Then I get an 'identify-device' page response
@@ -256,10 +257,10 @@ Feature: Identity reuse update details failures
             When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
                 | Attribute          | Values                   |
                 | evidence_requested | {"identityFraudScore":2} |
-            Then I get a 'sorry-could-not-confirm-details' page response and pageContext
-                | Context                 | Value |
-                | isExistingIdentityValid | true  |
-            When I submit a 'returnToRp' event
+            Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+                | Context              | Value         |
+                | journeyType          | updateDetails |
+            When I submit a 'continueToService' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
             Then I am issued a 'P2' identity

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -226,7 +226,6 @@ Feature: Identity reuse update details failures
             When I start a new 'medium-confidence' journey
             Then I get a 'pyi-no-match' page response
 
-        @amrit
         Scenario: Zero score in fraud CRI - receives old identity (P2)
             When I submit an 'update-name' event
             Then I get an 'identify-device' page response

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -100,8 +100,10 @@ Feature: Identity reuse update details failures
             And I poll for async DCMAW credential receipt
             Then the poll returns a '201'
             When I submit the returned journey event
-            Then I get an 'update-details-failed' page response
-            When I submit a 'continue' event
+            Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+                | Context              | Value         |
+                | journeyType          | updateDetails |
+            When I submit a 'continueToService' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
             Then I am issued a 'P2' identity

--- a/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
+++ b/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
@@ -208,7 +208,7 @@ Feature: Update details higher strength
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value            |
         | journeyType          | repeatFraudCheck |
-       When I submit an 'passport' event  
+      When I submit an 'passport' event  
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
@@ -303,7 +303,7 @@ Feature: Update details higher strength
         | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response and pageContext
         | Context     | Value |
-        | journeyType | coi   | 
+        | journeyType | coi   |
 
     Scenario: COI recovery fails at final Fraud check
       When I submit a 'given-names-only' event

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -24,6 +24,9 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -90,6 +93,9 @@ states:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
       fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED_NO_TICF
+      fail-with-no-ci-higher-score:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
       fail-with-ci:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -24,7 +24,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
       error:
@@ -95,7 +95,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
       fail-with-ci:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/f2f-hand-off.yaml
@@ -95,9 +95,6 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
-      fail-with-no-ci-fatal:
-        targetJourney: FAILED
-        targetState: FAILED_NO_TICF
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -77,11 +77,18 @@ states:
   FAILED_UPDATE_DETAILS_HIGHER_STRENGTH:
     events:
       next:
-        targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
           successful: false
+        checkJourneyContext:
+          rfc:
+            targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK
+            auditEvents:
+              - IPV_USER_DETAILS_UPDATE_END
+            auditContext:
+              successful: false
   
   FAILED_HIGHER_STRENGTH_DEAD_END:
     events:
@@ -97,27 +104,6 @@ states:
         targetState: NO_MATCH_PAGE
 
   # Journey states
-  PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_UPDATE_DETAILS_HIGHER_STRENGTH:
-    response:
-      type: process
-      lambda: process-candidate-identity
-      lambdaInput:
-        identityType: INCOMPLETE
-    events:
-      next:
-        targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS
-        checkJourneyContext:
-          rfc:
-            targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK
-      account-intervention:
-        targetJourney: FAILED
-        targetState: FAILED_ACCOUNT_INTERVENTION
-      fail-with-ci:
-        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
-      error:
-        targetJourney: TECHNICAL_ERROR
-        targetState: ERROR_NO_TICF
-
   PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH:
     response:
       type: process

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -78,6 +78,10 @@ states:
     events:
       next:
         targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_UPDATE_DETAILS
+        auditEvents:
+          - IPV_USER_DETAILS_UPDATE_END
+        auditContext:
+          successful: false
         checkJourneyContext:
           rfc:
             targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_REPEAT_FRAUD_CHECK

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -77,18 +77,19 @@ states:
   FAILED_UPDATE_DETAILS_HIGHER_STRENGTH:
     events:
       next:
-        targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_UPDATE_DETAILS
+        targetState: PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_UPDATE_DETAILS_HIGHER_STRENGTH
         auditEvents:
           - IPV_USER_DETAILS_UPDATE_END
         auditContext:
           successful: false
+  
+  FAILED_HIGHER_STRENGTH_DEAD_END:
+    events:
+      next:
+        targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_UPDATE_DETAILS
         checkJourneyContext:
           rfc:
             targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_REPEAT_FRAUD_CHECK
-            auditEvents:
-              - IPV_USER_DETAILS_UPDATE_END
-            auditContext:
-              successful: false
 
   FAILED_NO_TICF:
     events:
@@ -96,6 +97,27 @@ states:
         targetState: NO_MATCH_PAGE
 
   # Journey states
+  PROCESS_INCOMPLETE_IDENTITY_COULD_NOT_UPDATE_DETAILS_HIGHER_STRENGTH:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: INCOMPLETE
+    events:
+      next:
+        targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS
+        checkJourneyContext:
+          rfc:
+            targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK
+      account-intervention:
+        targetJourney: FAILED
+        targetState: FAILED_ACCOUNT_INTERVENTION
+      fail-with-ci:
+        targetState: COULD_NOT_UPDATE_DETAILS_PAGE_INVALID_IDENTITY
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+
   PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH:
     response:
       type: process
@@ -299,6 +321,32 @@ states:
         targetState: RETURN_TO_RP
       delete:
         targetState: DELETE_HANDOVER_PAGE
+  
+  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS:
+    response:
+      type: page
+      pageId: need-more-information-confirm-change-details
+      pageContext:
+        journeyType: updateDetails
+    events:
+      passport:
+        targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: RETRY_HIGHER_STRENGTH
+      continueToService:
+        targetState: REINSTATE_EXISTING_IDENTITY
+
+  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK:
+    response:
+      type: page
+      pageId: need-more-information-confirm-change-details
+      pageContext:
+        journeyType: repeatFraudCheck
+    events:
+      passport:
+        targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: RETRY_HIGHER_STRENGTH
+      returnToRp:
+        targetState: RETURN_TO_RP
 
   COULD_NOT_UPDATE_DETAILS_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -81,6 +81,10 @@ states:
         checkJourneyContext:
           rfc:
             targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_REPEAT_FRAUD_CHECK
+            auditEvents:
+              - IPV_USER_DETAILS_UPDATE_END
+            auditContext:
+              successful: false
 
   FAILED_NO_TICF:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -73,22 +73,6 @@ states:
     events:
       next:
         targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_NINO
-
-  FAILED_UPDATE_DETAILS_HIGHER_STRENGTH:
-    events:
-      next:
-        targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS
-        auditEvents:
-          - IPV_USER_DETAILS_UPDATE_END
-        auditContext:
-          successful: false
-        checkJourneyContext:
-          rfc:
-            targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK
-            auditEvents:
-              - IPV_USER_DETAILS_UPDATE_END
-            auditContext:
-              successful: false
   
   FAILED_HIGHER_STRENGTH_DEAD_END:
     events:
@@ -307,32 +291,7 @@ states:
         targetState: RETURN_TO_RP
       delete:
         targetState: DELETE_HANDOVER_PAGE
-  
-  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS:
-    response:
-      type: page
-      pageId: need-more-information-confirm-change-details
-      pageContext:
-        journeyType: updateDetails
-    events:
-      passport:
-        targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
-        targetState: RETRY_HIGHER_STRENGTH
-      continueToService:
-        targetState: REINSTATE_EXISTING_IDENTITY
 
-  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK:
-    response:
-      type: page
-      pageId: need-more-information-confirm-change-details
-      pageContext:
-        journeyType: repeatFraudCheck
-    events:
-      passport:
-        targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
-        targetState: RETRY_HIGHER_STRENGTH
-      returnToRp:
-        targetState: RETURN_TO_RP
 
   COULD_NOT_UPDATE_DETAILS_PAGE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/failed.yaml
@@ -73,7 +73,7 @@ states:
     events:
       next:
         targetState: PROCESS_INCOMPLETE_IDENTITY_BEFORE_NO_MATCH_NINO
-  
+
   FAILED_HIGHER_STRENGTH_DEAD_END:
     events:
       next:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/intervention-reprove-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/intervention-reprove-identity.yaml
@@ -181,7 +181,7 @@ states:
         targetState: COULD_NOT_CONFIRM_IDENTITY
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_IDENTITY
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetState: COULD_NOT_CONFIRM_IDENTITY
       vcs-not-correlated:
         targetJourney: FAILED
@@ -225,7 +225,7 @@ states:
         targetState: ERROR
       fail-with-no-ci:
         targetState: COULD_NOT_CONFIRM_IDENTITY
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetState: COULD_NOT_CONFIRM_IDENTITY
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_IDENTITY
@@ -315,7 +315,7 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetState: COULD_NOT_CONFIRM_IDENTITY
         
 
@@ -416,7 +416,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
       error:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/intervention-reprove-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/intervention-reprove-identity.yaml
@@ -181,6 +181,8 @@ states:
         targetState: COULD_NOT_CONFIRM_IDENTITY
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_IDENTITY
+      fail-with-no-ci-higher-score:
+        targetState: COULD_NOT_CONFIRM_IDENTITY
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED
@@ -222,6 +224,8 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
+        targetState: COULD_NOT_CONFIRM_IDENTITY
+      fail-with-no-ci-higher-score:
         targetState: COULD_NOT_CONFIRM_IDENTITY
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_IDENTITY
@@ -311,6 +315,9 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-no-ci-higher-score:
+        targetState: COULD_NOT_CONFIRM_IDENTITY
+        
 
   PROCESS_NEW_IDENTITY:
     response:
@@ -407,6 +414,9 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       fail-with-no-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+      fail-with-no-ci-higher-score:
         targetJourney: FAILED
         targetState: FAILED
       error:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/intervention-reprove-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/intervention-reprove-identity.yaml
@@ -181,8 +181,6 @@ states:
         targetState: COULD_NOT_CONFIRM_IDENTITY
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_IDENTITY
-      fail-with-no-ci-fatal:
-        targetState: COULD_NOT_CONFIRM_IDENTITY
       vcs-not-correlated:
         targetJourney: FAILED
         targetState: FAILED
@@ -224,8 +222,6 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
-        targetState: COULD_NOT_CONFIRM_IDENTITY
-      fail-with-no-ci-fatal:
         targetState: COULD_NOT_CONFIRM_IDENTITY
       fail-with-ci:
         targetState: COULD_NOT_CONFIRM_IDENTITY
@@ -317,7 +313,6 @@ states:
         targetState: FAILED
       fraud-fail-with-no-ci-fatal:
         targetState: COULD_NOT_CONFIRM_IDENTITY
-        
 
   PROCESS_NEW_IDENTITY:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
@@ -42,5 +42,7 @@ nestedJourneyStates:
         exitEventToEmit: next
       fail-with-no-ci:
         exitEventToEmit: fraud-fail-with-no-ci
+      fail-with-no-ci-higher-score:
+        exitEventToEmit: fraud-fail-with-no-ci-higher-score
       fail-with-ci:
         exitEventToEmit: fraud-fail-with-ci

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
@@ -42,7 +42,7 @@ nestedJourneyStates:
         exitEventToEmit: next
       fail-with-no-ci:
         exitEventToEmit: fraud-fail-with-no-ci
-      fail-with-no-ci-higher-score:
-        exitEventToEmit: fraud-fail-with-no-ci-higher-score
+      fail-with-no-ci-fatal:
+        exitEventToEmit: fraud-fail-with-no-ci-fatal
       fail-with-ci:
         exitEventToEmit: fraud-fail-with-ci

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -112,8 +112,6 @@ nestedJourneyStates:
         targetState: ERROR
       fail-with-no-ci:
         exitEventToEmit: failWithNoCiFromApp
-      fail-with-no-ci-fatal:
-        exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
@@ -146,8 +144,6 @@ nestedJourneyStates:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
-        exitEventToEmit: failWithNoCiFromApp
-      fail-with-no-ci-fatal:
         exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
@@ -202,8 +198,6 @@ nestedJourneyStates:
         targetState: ERROR
       fail-with-no-ci:
         exitEventToEmit: failWithNoCiFromApp
-      fail-with-no-ci-fatal:
-        exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
@@ -236,8 +230,6 @@ nestedJourneyStates:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
-        exitEventToEmit: failWithNoCiFromApp
-      fail-with-no-ci-fatal:
         exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -112,6 +112,8 @@ nestedJourneyStates:
         targetState: ERROR
       fail-with-no-ci:
         exitEventToEmit: failWithNoCiFromApp
+      fail-with-no-ci-higher-score:
+        exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
@@ -144,6 +146,8 @@ nestedJourneyStates:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
+        exitEventToEmit: failWithNoCiFromApp
+      fail-with-no-ci-higher-score:
         exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
@@ -198,6 +202,8 @@ nestedJourneyStates:
         targetState: ERROR
       fail-with-no-ci:
         exitEventToEmit: failWithNoCiFromApp
+      fail-with-no-ci-higher-score:
+        exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
       vcs-not-correlated:
@@ -230,6 +236,8 @@ nestedJourneyStates:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
+        exitEventToEmit: failWithNoCiFromApp
+      fail-with-no-ci-higher-score:
         exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -112,7 +112,7 @@ nestedJourneyStates:
         targetState: ERROR
       fail-with-no-ci:
         exitEventToEmit: failWithNoCiFromApp
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
@@ -147,7 +147,7 @@ nestedJourneyStates:
         targetState: ERROR
       fail-with-no-ci:
         exitEventToEmit: failWithNoCiFromApp
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
@@ -202,7 +202,7 @@ nestedJourneyStates:
         targetState: ERROR
       fail-with-no-ci:
         exitEventToEmit: failWithNoCiFromApp
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp
@@ -237,7 +237,7 @@ nestedJourneyStates:
         targetState: ERROR
       fail-with-no-ci:
         exitEventToEmit: failWithNoCiFromApp
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         exitEventToEmit: failWithNoCiFromApp
       fail-with-ci:
         exitEventToEmit: failWithCiFromApp

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
@@ -75,7 +75,7 @@ nestedJourneyStates:
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
       fraud-fail-with-ci:
@@ -155,7 +155,7 @@ nestedJourneyStates:
         targetState: FAILED
       fraud-fail-with-ci:
         exitEventToEmit: fraud-fail-with-ci
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
   PROVE_ANOTHER_WAY_AFTER_DL:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
@@ -75,6 +75,9 @@ nestedJourneyStates:
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED
       fraud-fail-with-ci:
         exitEventToEmit: fraud-fail-with-ci
   PROVE_ANOTHER_WAY_AFTER_PASSPORT:
@@ -152,6 +155,9 @@ nestedJourneyStates:
         targetState: FAILED
       fraud-fail-with-ci:
         exitEventToEmit: fraud-fail-with-ci
+      fraud-fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED
   PROVE_ANOTHER_WAY_AFTER_DL:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -72,7 +72,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
       error:
@@ -416,7 +416,7 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_NEW_IDENTITY
 
   # F2F journey (J4)
@@ -447,7 +447,7 @@ states:
         checkFeatureFlag:
           mitigations9020Enabled:
             targetState: MITIGATE_CI_VIA_APP
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
 
@@ -496,7 +496,7 @@ states:
         checkFeatureFlag:
           mitigations9020Enabled:
             targetState: MITIGATE_CI_VIA_APP
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -72,6 +72,9 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -413,6 +416,8 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-no-ci-higher-score:
+        targetState: PROCESS_NEW_IDENTITY
 
   # F2F journey (J4)
   CRI_CLAIMED_IDENTITY_J4:
@@ -442,6 +447,9 @@ states:
         checkFeatureFlag:
           mitigations9020Enabled:
             targetState: MITIGATE_CI_VIA_APP
+      fraud-fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED
 
   # No photo id journey
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
@@ -488,6 +496,9 @@ states:
         checkFeatureFlag:
           mitigations9020Enabled:
             targetState: MITIGATE_CI_VIA_APP
+      fraud-fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED
 
   KBV_NO_PHOTO_ID:
     nestedJourney: KBVS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -72,6 +72,9 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -422,6 +425,8 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-no-ci-higher-score:
+        targetState: PROCESS_NEW_IDENTITY
 
   # F2F journey (J4)
   CRI_CLAIMED_IDENTITY_J4:
@@ -451,6 +456,8 @@ states:
         checkFeatureFlag:
           mitigations9020Enabled:
             targetState: MITIGATE_CI_VIA_APP
+      fraud-fail-with-no-ci-higher-score:
+        targetState: PROCESS_NEW_IDENTITY
 
   # No photo id journey (M2B)
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
@@ -511,6 +518,9 @@ states:
         checkFeatureFlag:
           mitigations9020Enabled:
             targetState: MITIGATE_CI_VIA_APP
+      fraud-fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED
 
   KBV_NO_PHOTO_ID:
     nestedJourney: KBVS

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -72,7 +72,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
       error:
@@ -425,7 +425,7 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_NEW_IDENTITY
 
   # F2F journey (J4)
@@ -456,7 +456,7 @@ states:
         checkFeatureFlag:
           mitigations9020Enabled:
             targetState: MITIGATE_CI_VIA_APP
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_NEW_IDENTITY
 
   # No photo id journey (M2B)
@@ -518,7 +518,7 @@ states:
         checkFeatureFlag:
           mitigations9020Enabled:
             targetState: MITIGATE_CI_VIA_APP
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -22,7 +22,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
       error:
@@ -211,7 +211,7 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetState: PROCESS_UPDATE_IDENTITY
 
   PROCESS_UPDATE_IDENTITY:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/repeat-fraud-check.yaml
@@ -22,6 +22,9 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -207,6 +210,8 @@ states:
       next:
         targetState: PROCESS_UPDATE_IDENTITY
       fail-with-no-ci:
+        targetState: PROCESS_UPDATE_IDENTITY
+      fail-with-no-ci-higher-score:
         targetState: PROCESS_UPDATE_IDENTITY
 
   PROCESS_UPDATE_IDENTITY:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -24,7 +24,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_SKIP_MESSAGE
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_SKIP_MESSAGE
       error:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/reverification.yaml
@@ -24,6 +24,9 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_SKIP_MESSAGE
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED_SKIP_MESSAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -21,6 +21,9 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -66,6 +69,8 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-no-ci-higher-score:
+        targetState: PROCESS_UPDATE_IDENTITY
 
   PROCESS_UPDATE_IDENTITY:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -21,7 +21,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
       error:
@@ -69,7 +69,7 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_UPDATE_IDENTITY
 
   PROCESS_UPDATE_IDENTITY:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -37,7 +37,8 @@ states:
       passport:
         targetState: RESET_SESSION_BEFORE_NEW_IDENTITY
       returnToRp:
-        targetState: RETURN_TO_RP
+        targetJourney: FAILED
+        targetState: FAILED_SKIP_MESSAGE
 
   REINSTATE_EXISTING_IDENTITY:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -308,9 +308,6 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
-      fail-with-no-ci-fatal:
-        targetJourney: FAILED
-        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
@@ -369,9 +366,6 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
-        targetJourney: FAILED
-        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
-      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-ci:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -9,38 +9,19 @@ states:
   START_HIGHER_STRENGTH:
     events:
       next:
-        targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS
+        targetJourney: FAILED
+        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
         checkJourneyContext:
           rfc:
+            targetJourney: FAILED
             targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK
 
+  RETRY_HIGHER_STRENGTH:
+    events:
+      next:
+        targetState: RESET_SESSION_BEFORE_NEW_IDENTITY
+
   # Journey States
-  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK:
-    response:
-      type: page
-      pageId: need-more-information-confirm-change-details
-      pageContext:
-        journeyType: repeatFraudCheck
-    events:
-      passport:
-        targetState: RESET_SESSION_BEFORE_NEW_IDENTITY
-      returnToRp:
-        targetJourney: FAILED
-        targetState: FAILED_SKIP_MESSAGE
-
-  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS:
-    response:
-      type: page
-      pageId: need-more-information-confirm-change-details
-      pageContext:
-        journeyType: updateDetails
-    events:
-      passport:
-        targetState: RESET_SESSION_BEFORE_NEW_IDENTITY
-      returnToRp:
-        targetJourney: FAILED
-        targetState: FAILED_SKIP_MESSAGE
-
   POST_APP_DOC_CHECK_NAMES_ONLY:
     response:
       type: page
@@ -71,10 +52,13 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
 
   ADDRESS_AND_FRAUD:
     nestedJourney: ADDRESS_AND_FRAUD
@@ -86,18 +70,9 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
-
-  # Remove all VCs from previous attempts
-  RESET_SESSION_BEFORE_NEW_IDENTITY:
-    response:
-      type: process
-      lambda: reset-session-identity
-      lambdaInput:
-        resetType: ALL_INC_DCMAW_ASYNC_PENDING
-    events:
-      next:
-        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
-        targetEntryEvent: identify-device
+      fraud-fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
 
   PROCESS_UPDATE_IDENTITY:
     response:
@@ -117,13 +92,13 @@ states:
         targetState: FAILED_ACCOUNT_INTERVENTION
       coi-check-failed:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       profile-unmet:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF
@@ -194,10 +169,10 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -233,10 +208,10 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -275,19 +250,22 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       dl-auth-source-check:
         targetState: STRATEGIC_APP_HANDLE_RESULT
         targetEntryEvent: dl-auth-source-check
@@ -297,10 +275,10 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
 
   DAD_ANDROID_START_SESSION:
     response:
@@ -335,19 +313,22 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       dl-auth-source-check:
         targetState: STRATEGIC_APP_HANDLE_RESULT
         targetEntryEvent: dl-auth-source-check
@@ -357,10 +338,10 @@ states:
         checkJourneyContext:
           rfc:
             targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
 
   # Handle app result
   STRATEGIC_APP_HANDLE_RESULT:
@@ -373,7 +354,7 @@ states:
             targetState: POST_APP_DOC_CHECK_NAMES_WITH_ADDRESS
       anotherWay:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       incompleteDlAuthCheckInvalidDlv2:
         targetJourney: UPDATE_NAME
         targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_ONLY
@@ -383,41 +364,55 @@ states:
             targetState: STRATEGIC_APP_PROVE_IDENTITY_ANOTHER_WAY_AFTER_APP_DOC_CHECK_NAMES_WITH_ADDRESS
       failedDlAuthCheckInvalidDl:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       failWithCiFromApp:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       failWithNoCiFromApp:
         targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
 
   # Parent states (needed for STRATEGIC_APP_HANDLE_RESULT)
   CRI_STATE:
     events:
       not-found:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-no-ci:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       access-denied:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       invalid-request:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       temporarily-unavailable:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
       fail-with-ci:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       vcs-not-correlated:
         targetJourney: FAILED
-        targetState: FAILED
+        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       dl-auth-source-check:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
+
+  RESET_SESSION_BEFORE_NEW_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: ALL_INC_DCMAW_ASYNC_PENDING
+    events:
+      next:
+        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
+        targetEntryEvent: identify-device

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -53,7 +53,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-ci:
@@ -70,7 +70,7 @@ states:
       fraud-fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_UPDATE_IDENTITY
 
   PROCESS_UPDATE_IDENTITY:
@@ -256,7 +256,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-ci:
@@ -319,7 +319,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       fail-with-ci:
@@ -380,7 +380,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_HIGHER_STRENGTH_DEAD_END
       error:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -71,8 +71,7 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       fraud-fail-with-no-ci-higher-score:
-        targetJourney: FAILED
-        targetState: FAILED_HIGHER_STRENGTH_DEAD_END
+        targetState: PROCESS_UPDATE_IDENTITY
 
   PROCESS_UPDATE_IDENTITY:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -9,19 +9,71 @@ states:
   START_HIGHER_STRENGTH:
     events:
       next:
-        targetJourney: FAILED
-        targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+        targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS
         checkJourneyContext:
           rfc:
-            targetJourney: FAILED
             targetState: NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK
 
-  RETRY_HIGHER_STRENGTH:
+  # Journey States
+  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_UPDATE_DETAILS:
+    response:
+      type: page
+      pageId: need-more-information-confirm-change-details
+      pageContext:
+        journeyType: updateDetails
+    events:
+      passport:
+        targetState: RESET_SESSION_BEFORE_NEW_IDENTITY
+      continueToService:
+        targetState: REINSTATE_EXISTING_IDENTITY
+
+  NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS_REPEAT_FRAUD_CHECK:
+    response:
+      type: page
+      pageId: need-more-information-confirm-change-details
+      pageContext:
+        journeyType: repeatFraudCheck
+    events:
+      passport:
+        targetState: RESET_SESSION_BEFORE_NEW_IDENTITY
+      returnToRp:
+        targetState: RETURN_TO_RP
+
+  REINSTATE_EXISTING_IDENTITY:
+    response:
+      type: process
+      lambda: reset-session-identity
+      lambdaInput:
+        resetType: REINSTATE
     events:
       next:
-        targetState: RESET_SESSION_BEFORE_NEW_IDENTITY
+        targetState: PROCESS_VALID_IDENTITY
 
-  # Journey States
+  PROCESS_VALID_IDENTITY:
+    response:
+      type: process
+      lambda: process-candidate-identity
+      lambdaInput:
+        identityType: EXISTING
+    events:
+      next:
+        targetState: RETURN_TO_RP
+      account-intervention:
+        targetJourney: FAILED
+        targetState: FAILED_ACCOUNT_INTERVENTION
+      fail-with-ci:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+      profile-unmet:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+      vcs-not-correlated:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR_NO_TICF
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+  
   POST_APP_DOC_CHECK_NAMES_ONLY:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -115,8 +115,8 @@ states:
         journeyContextToUnset: appOnly
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
       returnToRp:
         targetState: RETURN_TO_RP
         journeyContextToUnset: appOnly
@@ -159,8 +159,8 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
@@ -258,8 +258,8 @@ states:
         journeyContextToUnset: appOnly
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
             journeyContextToSet: nameAndAddress
       returnToRp:
         targetState: RETURN_TO_RP
@@ -329,8 +329,8 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
             journeyContextToSet: nameAndAddress
       fraud-fail-with-ci:
         targetJourney: FAILED
@@ -364,8 +364,8 @@ states:
         targetState: FAILED_CONFIRM_DETAILS
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: FAILED
-            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -37,6 +37,9 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
+      fail-with-no-ci-higher-score:
+        targetJourney: FAILED
+        targetState: FAILED_CONFIRM_DETAILS
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -112,8 +115,8 @@ states:
         journeyContextToUnset: appOnly
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
-            targetState: START_HIGHER_STRENGTH
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       returnToRp:
         targetState: RETURN_TO_RP
         journeyContextToUnset: appOnly
@@ -152,10 +155,12 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
+      fail-with-no-ci-higher-score:
+        targetState: PROCESS_UPDATE_IDENTITY
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
-            targetState: START_HIGHER_STRENGTH
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS_INVALID_ID
@@ -253,8 +258,8 @@ states:
         journeyContextToUnset: appOnly
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
-            targetState: START_HIGHER_STRENGTH
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
             journeyContextToSet: nameAndAddress
       returnToRp:
         targetState: RETURN_TO_RP
@@ -320,10 +325,12 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fraud-fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
+      fraud-fail-with-no-ci-higher-score:
+        targetState: PROCESS_UPDATE_IDENTITY
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
-            targetState: START_HIGHER_STRENGTH
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
             journeyContextToSet: nameAndAddress
       fraud-fail-with-ci:
         targetJourney: FAILED
@@ -357,8 +364,8 @@ states:
         targetState: FAILED_CONFIRM_DETAILS
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
-            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
-            targetState: START_HIGHER_STRENGTH
+            targetJourney: FAILED
+            targetState: FAILED_UPDATE_DETAILS_HIGHER_STRENGTH
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NO_TICF

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -37,7 +37,7 @@ states:
       fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED_CONFIRM_DETAILS
       error:
@@ -155,7 +155,7 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
-      fail-with-no-ci-higher-score:
+      fail-with-no-ci-fatal:
         targetState: PROCESS_UPDATE_IDENTITY
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:
@@ -325,7 +325,7 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fraud-fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
-      fraud-fail-with-no-ci-higher-score:
+      fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_UPDATE_IDENTITY
         checkFeatureFlag:
           coi6mfcDeadEndRoutingEnabled:

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
@@ -30,6 +30,8 @@ public class JourneyUris {
     public static final String JOURNEY_F2F_FAIL_PATH = "/journey/f2f-fail";
     public static final String JOURNEY_FAIL_WITH_CI_PATH = "/journey/fail-with-ci";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
+    public static final String JOURNEY_FAIL_WITH_NO_CI_HIGHER_STRENGTH_PATH =
+            "/journey/fail-with-no-ci-higher-score";
     public static final String JOURNEY_FAIL_WITH_NO_CI_LOW_CONFIDENCE_PATH =
             "/journey/fail-with-no-ci-low";
     public static final String JOURNEY_FAIL_WITH_NO_CI_MEDIUM_CONFIDENCE_PATH =

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/JourneyUris.java
@@ -30,8 +30,8 @@ public class JourneyUris {
     public static final String JOURNEY_F2F_FAIL_PATH = "/journey/f2f-fail";
     public static final String JOURNEY_FAIL_WITH_CI_PATH = "/journey/fail-with-ci";
     public static final String JOURNEY_FAIL_WITH_NO_CI_PATH = "/journey/fail-with-no-ci";
-    public static final String JOURNEY_FAIL_WITH_NO_CI_HIGHER_STRENGTH_PATH =
-            "/journey/fail-with-no-ci-higher-score";
+    public static final String JOURNEY_FRAUD_FAIL_WITH_NO_CI_FATAL_PATH =
+            "/journey/fail-with-no-ci-fatal";
     public static final String JOURNEY_FAIL_WITH_NO_CI_LOW_CONFIDENCE_PATH =
             "/journey/fail-with-no-ci-low";
     public static final String JOURNEY_FAIL_WITH_NO_CI_MEDIUM_CONFIDENCE_PATH =

--- a/libs/cri-checking-service/src/main/java/uk/gov/di/ipv/core/library/cricheckingservice/CriCheckingService.java
+++ b/libs/cri-checking-service/src/main/java/uk/gov/di/ipv/core/library/cricheckingservice/CriCheckingService.java
@@ -303,7 +303,7 @@ public class CriCheckingService {
                 }
 
                 if (Cri.EXPERIAN_FRAUD.equals(vc.getCri())
-                        && Boolean.TRUE.equals(VcHelper.checkIfDocUKIssuedForCredential(vc))) {
+                        && !VcHelper.hasNonFatalFraudCheckFailure(vc)) {
                     return JOURNEY_FRAUD_FAIL_WITH_NO_CI_HIGHER_SCORE;
                 }
 

--- a/libs/cri-checking-service/src/main/java/uk/gov/di/ipv/core/library/cricheckingservice/CriCheckingService.java
+++ b/libs/cri-checking-service/src/main/java/uk/gov/di/ipv/core/library/cricheckingservice/CriCheckingService.java
@@ -57,8 +57,8 @@ import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ACCESS_DEN
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DL_AUTH_SOURCE_CHECK_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
-import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_NO_CI_HIGHER_STRENGTH_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_NO_CI_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FRAUD_FAIL_WITH_NO_CI_FATAL_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_TEMPORARILY_UNAVAILABLE_PATH;
 
 public class CriCheckingService {
@@ -67,8 +67,8 @@ public class CriCheckingService {
             new JourneyResponse(JourneyUris.JOURNEY_VCS_NOT_CORRELATED);
     private static final JourneyResponse JOURNEY_FAIL_WITH_NO_CI =
             new JourneyResponse(JOURNEY_FAIL_WITH_NO_CI_PATH);
-    private static final JourneyResponse JOURNEY_FRAUD_FAIL_WITH_NO_CI_HIGHER_SCORE =
-            new JourneyResponse(JOURNEY_FAIL_WITH_NO_CI_HIGHER_STRENGTH_PATH);
+    private static final JourneyResponse JOURNEY_FRAUD_FAIL_WITH_NO_CI_FATAL =
+            new JourneyResponse(JOURNEY_FRAUD_FAIL_WITH_NO_CI_FATAL_PATH);
     private static final JourneyResponse JOURNEY_FAIL_WITH_CI =
             new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
     private static final JourneyResponse JOURNEY_ACCESS_DENIED =
@@ -304,7 +304,7 @@ public class CriCheckingService {
 
                 if (Cri.EXPERIAN_FRAUD.equals(vc.getCri())
                         && !VcHelper.hasNonFatalFraudCheckFailure(vc)) {
-                    return JOURNEY_FRAUD_FAIL_WITH_NO_CI_HIGHER_SCORE;
+                    return JOURNEY_FRAUD_FAIL_WITH_NO_CI_FATAL;
                 }
 
                 return JOURNEY_FAIL_WITH_NO_CI;

--- a/libs/cri-checking-service/src/main/java/uk/gov/di/ipv/core/library/cricheckingservice/CriCheckingService.java
+++ b/libs/cri-checking-service/src/main/java/uk/gov/di/ipv/core/library/cricheckingservice/CriCheckingService.java
@@ -57,6 +57,7 @@ import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ACCESS_DEN
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_DL_AUTH_SOURCE_CHECK_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_ERROR_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_CI_PATH;
+import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_NO_CI_HIGHER_STRENGTH_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_FAIL_WITH_NO_CI_PATH;
 import static uk.gov.di.ipv.core.library.journeys.JourneyUris.JOURNEY_TEMPORARILY_UNAVAILABLE_PATH;
 
@@ -66,6 +67,8 @@ public class CriCheckingService {
             new JourneyResponse(JourneyUris.JOURNEY_VCS_NOT_CORRELATED);
     private static final JourneyResponse JOURNEY_FAIL_WITH_NO_CI =
             new JourneyResponse(JOURNEY_FAIL_WITH_NO_CI_PATH);
+    private static final JourneyResponse JOURNEY_FRAUD_FAIL_WITH_NO_CI_HIGHER_SCORE =
+            new JourneyResponse(JOURNEY_FAIL_WITH_NO_CI_HIGHER_STRENGTH_PATH);
     private static final JourneyResponse JOURNEY_FAIL_WITH_CI =
             new JourneyResponse(JOURNEY_FAIL_WITH_CI_PATH);
     private static final JourneyResponse JOURNEY_ACCESS_DENIED =
@@ -298,6 +301,12 @@ public class CriCheckingService {
                 if (isReverification) {
                     setFailedIdentityCheckOnIpvSessionItem(ipvSessionItem);
                 }
+
+                if (Cri.EXPERIAN_FRAUD.equals(vc.getCri())
+                        && Boolean.TRUE.equals(VcHelper.checkIfDocUKIssuedForCredential(vc))) {
+                    return JOURNEY_FRAUD_FAIL_WITH_NO_CI_HIGHER_SCORE;
+                }
+
                 return JOURNEY_FAIL_WITH_NO_CI;
             }
         }

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -362,7 +362,7 @@ core:
     sisVerificationEnabled: true
     testFeatureFlag: false
     evcsApiUpdatesEnabled: false
-    coi6mfcDeadEndRoutingEnabled: false
+    coi6mfcDeadEndRoutingEnabled: true
   features:
     testFeature:
       self:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -366,7 +366,7 @@ core:
     sisVerificationEnabled: true
     evcsApiUpdatesEnabled: false
     mitigations9020Enabled: false
-    coi6mfcDeadEndRoutingEnabled: false
+    coi6mfcDeadEndRoutingEnabled: true
 
   features:
     coi6mfcDeadEndRouting:


### PR DESCRIPTION
## Proposed changes
### What changed

Main changes:
- Decoupled Failure Page Contexts, split the event logic for the NEED_MORE_INFORMATION_CONFIRM_CHANGE_DETAILS screen in the Failed Journey file into explicit updateDetails and repeatFraudCheck states
- Routed the returnToRp event for the Repeat Fraud Check context directly to RETURN_TO_RP. This prevents a double invocation of process-candidate-identity

### Why did it change

- While disabling the coi6mfcDeadEndRoutingEnabled feature flag under  https://govukverify.atlassian.net/browse/PYIC-9083, routing conflicts were identified.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9149(https://govukverify.atlassian.net/browse/PYIC-9149)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>
