### PR TITLE
PYIC-9165: Add temporary routing for notification banner

### DIFF
--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -220,6 +220,10 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -230,6 +234,10 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
         targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   NINO_START_PAGE:
     response:
@@ -247,6 +255,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -268,6 +280,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -563,6 +579,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -574,6 +594,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
 
@@ -652,6 +676,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -223,6 +223,10 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -236,6 +240,10 @@ states:
         checkIfDisabled:
           bav:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   BANK_ACCOUNT_START_PAGE:
     response:
@@ -248,6 +256,10 @@ states:
           - IPV_NO_PHOTO_ID_JOURNEY_START
       end:
         targetState: PYI_ESCAPE_NO_PHOTO_ID
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MULTIPLE_DOC_CHECK_PAGE:
     response:
@@ -263,6 +275,10 @@ states:
         checkIfDisabled:
           f2f:
             targetState: PYI_ESCAPE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   WEB_DL_OR_PASSPORT:
     nestedJourney: WEB_DL_OR_PASSPORT
@@ -617,6 +633,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   MITIGATION_01_PYI_POST_OFFICE:
     response:
@@ -628,6 +648,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # Mitigation journey (02)
   STRATEGIC_APP_TRIAGE_PYI_ESCAPE:
@@ -705,6 +729,10 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+      # Temporary routing
+      appTriageBanner:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
 
   # Common Mitigation states - invalid-dl/invalid-passport
 


### PR DESCRIPTION
## Proposed changes
### What changed

- Add temporary routing for notification banner

### Why did it change

- Experian will be undertaking its annual scheduled maintenance on Sunday, 14 June 2026  for CrossCore Essential Maintenance

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9165](https://govukverify.atlassian.net/browse/PYIC-9165)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9165]: https://govukverify.atlassian.net/browse/PYIC-9165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ