### PR TITLE
Pyic 9065 mitigation routing

### DIFF
--- a/api-tests/data/cri-stub-requests/fraud/kenneth-score-0-non-breaching/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-score-0-non-breaching/credentialSubject.json
@@ -1,0 +1,32 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "buildingName": "",
+      "streetName": "HADLEY ROAD",
+      "postalCode": "BA2 5AA",
+      "buildingNumber": "8",
+      "addressLocality": "BATH",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-score-0-non-breaching/evidence.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-score-0-non-breaching/evidence.json
@@ -1,0 +1,31 @@
+{
+  "activityHistoryScore": 0,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "none",
+      "activityFrom": "1963-01-01",
+      "checkMethod": "data"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "mortality_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "identity_theft_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "synthetic_identity_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "impersonation_risk_check",
+      "txn": "RB000117397035"
+    }
+  ],
+  "ci": ["NON-BREACHING"],
+  "txn": "RB000117420948",
+  "identityFraudScore": 0,
+  "type": "IdentityCheck"
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-score-2-breaching-p1-when-combined-with-non-breaching/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-score-2-breaching-p1-when-combined-with-non-breaching/credentialSubject.json
@@ -1,0 +1,32 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "buildingName": "",
+      "streetName": "HADLEY ROAD",
+      "postalCode": "BA2 5AA",
+      "buildingNumber": "8",
+      "addressLocality": "BATH",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-score-2-breaching-p1-when-combined-with-non-breaching/evidence.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-score-2-breaching-p1-when-combined-with-non-breaching/evidence.json
@@ -1,0 +1,31 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "none",
+      "activityFrom": "1963-01-01",
+      "checkMethod": "data"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "mortality_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "identity_theft_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "synthetic_identity_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "impersonation_risk_check",
+      "txn": "RB000117397035"
+    }
+  ],
+  "ci": ["BREACHING-P1-WHEN-COMBINED-WITH-NON-BREACHING"],
+  "txn": "RB000117420948",
+  "identityFraudScore": 2,
+  "type": "IdentityCheck"
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-score-2-breaching-p2-when-combined-with-non-breaching/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-score-2-breaching-p2-when-combined-with-non-breaching/credentialSubject.json
@@ -1,0 +1,32 @@
+{
+  "address": [
+    {
+      "addressCountry": "GB",
+      "buildingName": "",
+      "streetName": "HADLEY ROAD",
+      "postalCode": "BA2 5AA",
+      "buildingNumber": "8",
+      "addressLocality": "BATH",
+      "subBuildingName": ""
+    }
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/fraud/kenneth-score-2-breaching-p2-when-combined-with-non-breaching/evidence.json
+++ b/api-tests/data/cri-stub-requests/fraud/kenneth-score-2-breaching-p2-when-combined-with-non-breaching/evidence.json
@@ -1,0 +1,31 @@
+{
+  "activityHistoryScore": 1,
+  "checkDetails": [
+    {
+      "identityCheckPolicy": "none",
+      "activityFrom": "1963-01-01",
+      "checkMethod": "data"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "mortality_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "identity_theft_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "synthetic_identity_check"
+    },
+    {
+      "checkMethod": "data",
+      "fraudCheck": "impersonation_risk_check",
+      "txn": "RB000117397035"
+    }
+  ],
+  "ci": ["BREACHING-P2-WHEN-COMBINED-WITH-NON-BREACHING"],
+  "txn": "RB000117420948",
+  "identityFraudScore": 2,
+  "type": "IdentityCheck"
+}

--- a/api-tests/data/cri-stub-requests/nino/kenneth-score-2-non-breaching/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/nino/kenneth-score-2-non-breaching/credentialSubject.json
@@ -1,0 +1,26 @@
+{
+  "name": [
+    {
+      "nameParts": [
+        {
+          "value": "Kenneth",
+          "type": "GivenName"
+        },
+        {
+          "value": "Decerqueira",
+          "type": "FamilyName"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ],
+  "socialSecurityRecord": [
+    {
+      "personalNumber": "AA000003D"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/nino/kenneth-score-2-non-breaching/evidence.json
+++ b/api-tests/data/cri-stub-requests/nino/kenneth-score-2-non-breaching/evidence.json
@@ -1,0 +1,12 @@
+{
+  "type": "IdentityCheck",
+  "txn": "RB000117420948",
+  "strengthScore": 2,
+  "validityScore": 2,
+  "checkDetails": [
+    {
+      "checkMethod": "data"
+    }
+  ],
+  "ci": ["NON-BREACHING"]
+}

--- a/api-tests/features/fraud-mitigation/p1-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p1-mitigation.feature
@@ -1,0 +1,184 @@
+@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
+Feature: P1 Fraud mitigation
+  Background: Enable fraud mitigation
+    Given I activate the 'mitigations9020' feature set
+
+  Rule: No photo ID journey
+    Background: Start P1 no photo id
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-no-photo-id' page response and pageContext
+        | Context  | Value |
+        | ninoOnly | true  |
+      When I submit an 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details with attributes to the CRI stub
+        | Attribute | Values         |
+        | context   | "hmrc_check" |
+      Then I get a 'nino' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+
+    Scenario: Non-breaching, non-failing fraud CI continues on journey
+      When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+
+    Scenario: Non-breaching, failing fraud CI fails journey
+      When I submit 'kenneth-score-0-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Breaching fraud CI goes to mitigation route
+      When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+
+    Scenario: Breaching fraud CI goes back to RP
+      When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+  Rule: Combined CI score breach
+    Scenario: Combined breaching fraud CI goes to mitigation route
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-no-photo-id' page response and pageContext
+        | Context  | Value |
+        | ninoOnly | true  |
+      When I submit an 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details with attributes to the CRI stub
+        | Attribute | Values         |
+        | context   | "hmrc_check" |
+      Then I get a 'nino' CRI response
+      When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2-breaching-p1-when-combined-with-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+
+  Rule: Web document journey
+    Background: Start P1 web document journey
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response and pageContext
+        | Context   | Value |
+        | allowNino | true  |
+
+    Scenario Outline: Non-breaching, failing fraud CI fails <cri> journey
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-0-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
+
+    Scenario Outline: Breaching fraud CI after <cri> goes to mitigation route
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
+
+  Rule: F2F journey
+    Background: Start P1 F2F journey
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-no-photo-id' page response and pageContext
+        | Context  | Value |
+        | ninoOnly | true  |
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+
+    Scenario: Non-breaching, failing fraud CI fails journey
+      When I submit 'kenneth-score-0-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Breaching fraud CI goes to mitigation route
+      When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response

--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -1,0 +1,190 @@
+@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
+Feature: P2 Fraud mitigation
+  Background: Enable fraud mitigation
+    Given I activate the 'mitigations9020' feature set
+
+  Rule: No photo ID journey
+    Background: Start P2 no photo id
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-no-photo-id' page response
+      When I submit an 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details with attributes to the CRI stub
+        | Attribute | Values         |
+        | context   | "bank_account" |
+      Then I get a 'bav' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'nino' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+
+    Scenario: Non-breaching, non-failing fraud CI continues on journey
+      When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+
+    Scenario: Non-breaching, failing fraud CI fails journey
+      When I submit 'kenneth-score-0-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Breaching fraud CI goes to mitigation route
+      When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+
+    Scenario: Breaching fraud CI goes back to RP
+      When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+  Rule: Combined CI score breach
+    Scenario: Combined breaching fraud CI goes to mitigation route
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-no-photo-id' page response
+      When I submit an 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details with attributes to the CRI stub
+        | Attribute | Values         |
+        | context   | "bank_account" |
+      Then I get a 'bav' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'nino' CRI response
+      When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2-breaching-p2-when-combined-with-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+
+  Rule: Web document journey
+    Background: Start P2 web document journey
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response
+
+    Scenario Outline: Non-breaching, failing fraud CI fails <cri> journey
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-0-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
+
+    Scenario Outline: Breaching fraud CI after <cri> goes to mitigation route
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
+
+  Rule: F2F journey
+    Background: Start P2 F2F journey
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+
+    Scenario: Non-breaching, failing fraud CI fails journey
+      When I submit 'kenneth-score-0-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Breaching fraud CI goes to mitigation route
+      When I submit 'kenneth-breaching-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -561,7 +561,6 @@ When(
     ciType:
       | "NON-BREACHING"
       | "BREACHING"
-      | "BREACHING-P1-ONLY"
       | "NEEDS-ENHANCED-VERIFICATION"
       | "NEEDS-ALTERNATE-DOC"
       | "ALWAYS-REQUIRED"

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/intervention-reprove-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/intervention-reprove-identity.yaml
@@ -308,6 +308,9 @@ states:
         targetState: PROCESS_NEW_IDENTITY
       fraud-fail-with-no-ci:
         targetState: PROCESS_NEW_IDENTITY
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
 
   PROCESS_NEW_IDENTITY:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/address-and-fraud.yaml
@@ -43,5 +43,4 @@ nestedJourneyStates:
       fail-with-no-ci:
         exitEventToEmit: fraud-fail-with-no-ci
       fail-with-ci:
-        targetJourney: FAILED
-        targetState: FAILED
+        exitEventToEmit: fraud-fail-with-ci

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/web-dl-or-passport.yaml
@@ -75,6 +75,8 @@ nestedJourneyStates:
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-ci:
+        exitEventToEmit: fraud-fail-with-ci
   PROVE_ANOTHER_WAY_AFTER_PASSPORT:
     response:
       type: page
@@ -148,6 +150,8 @@ nestedJourneyStates:
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-ci:
+        exitEventToEmit: fraud-fail-with-ci
   PROVE_ANOTHER_WAY_AFTER_DL:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -298,7 +298,7 @@ states:
         targetState: FAILED
         checkFeatureFlag:
           mitigations9020Enabled:
-            targetState: MITIGATE_FRAUD_CI_VIA_APP
+            targetState: MITIGATE_CI_VIA_APP
 
   PYI_ESCAPE:
     response:
@@ -425,7 +425,7 @@ states:
         targetState: FAILED
         checkFeatureFlag:
           mitigations9020Enabled:
-            targetState: MITIGATE_FRAUD_CI_VIA_APP
+            targetState: MITIGATE_CI_VIA_APP
 
   # No photo id journey
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
@@ -471,7 +471,7 @@ states:
         targetState: FAILED
         checkFeatureFlag:
           mitigations9020Enabled:
-            targetState: MITIGATE_FRAUD_CI_VIA_APP
+            targetState: MITIGATE_CI_VIA_APP
 
   KBV_NO_PHOTO_ID:
     nestedJourney: KBVS
@@ -675,17 +675,17 @@ states:
         targetState: INELIGIBLE
 
   # Fraud mitigation journey
-  MITIGATE_FRAUD_CI_VIA_APP:
+  MITIGATE_CI_VIA_APP:
     response:
       type: page
       pageId: retry-prove-identity-app
     events:
       useApp:
-        targetState: FRAUD_MITIGATION_PASSPORT_BIOMETRIC_CHIP
+        targetState: MITIGATION_PASSPORT_BIOMETRIC_CHIP
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
-  FRAUD_MITIGATION_PASSPORT_BIOMETRIC_CHIP:
+  MITIGATION_PASSPORT_BIOMETRIC_CHIP:
     response:
       type: page
       pageId: passport-biometric-chip
@@ -695,9 +695,9 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       abandon:
-        targetState: FRAUD_MITIGATION_NEED_BIOMETRIC_PASSPORT
+        targetState: MITIGATION_NEED_BIOMETRIC_PASSPORT
 
-  FRAUD_MITIGATION_NEED_BIOMETRIC_PASSPORT:
+  MITIGATION_NEED_BIOMETRIC_PASSPORT:
     response:
       type: page
       pageId: need-biometric-passport

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -293,6 +293,12 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp-cri-error:
         targetState: PROCESS_INCOMPLETE_IDENTITY
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+        checkFeatureFlag:
+          mitigations9020Enabled:
+            targetState: MITIGATE_FRAUD_CI_VIA_APP
 
   PYI_ESCAPE:
     response:
@@ -388,6 +394,9 @@ states:
         targetState: PROCESS_NEW_IDENTITY
       fraud-fail-with-no-ci:
         targetState: PROCESS_NEW_IDENTITY
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
 
   # F2F journey (J4)
   CRI_CLAIMED_IDENTITY_J4:
@@ -411,6 +420,12 @@ states:
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+        checkFeatureFlag:
+          mitigations9020Enabled:
+            targetState: MITIGATE_FRAUD_CI_VIA_APP
 
   # No photo id journey
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
@@ -451,6 +466,12 @@ states:
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+        checkFeatureFlag:
+          mitigations9020Enabled:
+            targetState: MITIGATE_FRAUD_CI_VIA_APP
 
   KBV_NO_PHOTO_ID:
     nestedJourney: KBVS
@@ -652,6 +673,42 @@ states:
       end:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE
+
+  # Fraud mitigation journey
+  MITIGATE_FRAUD_CI_VIA_APP:
+    response:
+      type: page
+      pageId: retry-prove-identity-app
+    events:
+      useApp:
+        targetState: FRAUD_MITIGATION_PASSPORT_BIOMETRIC_CHIP
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+
+  FRAUD_MITIGATION_PASSPORT_BIOMETRIC_CHIP:
+    response:
+      type: page
+      pageId: passport-biometric-chip
+    events:
+      next:
+        # PYIC-9068 Implement mitigation route
+        targetJourney: FAILED
+        targetState: FAILED
+      abandon:
+        targetState: FRAUD_MITIGATION_NEED_BIOMETRIC_PASSPORT
+
+  FRAUD_MITIGATION_NEED_BIOMETRIC_PASSPORT:
+    response:
+      type: page
+      pageId: need-biometric-passport
+    events:
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+      useApp:
+        # PYIC-9068 Implement mitigation route
+        targetJourney: FAILED
+        targetState: FAILED
+
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -287,6 +287,12 @@ states:
         targetState: CRI_CLAIMED_IDENTITY_J4
       return-to-rp-cri-error:
         targetState: PROCESS_INCOMPLETE_IDENTITY
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+        checkFeatureFlag:
+          mitigations9020Enabled:
+            targetState: MITIGATE_FRAUD_CI_VIA_APP
 
   CHECK_FRAUD_AFTER_DL:
     response:
@@ -397,6 +403,9 @@ states:
         targetState: PROCESS_NEW_IDENTITY
       fraud-fail-with-no-ci:
         targetState: PROCESS_NEW_IDENTITY
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
 
   # F2F journey (J4)
   CRI_CLAIMED_IDENTITY_J4:
@@ -420,6 +429,12 @@ states:
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+        checkFeatureFlag:
+          mitigations9020Enabled:
+            targetState: MITIGATE_FRAUD_CI_VIA_APP
 
   # No photo id journey (M2B)
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
@@ -474,6 +489,12 @@ states:
       fraud-fail-with-no-ci:
         targetJourney: FAILED
         targetState: FAILED
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
+        checkFeatureFlag:
+          mitigations9020Enabled:
+            targetState: MITIGATE_FRAUD_CI_VIA_APP
 
   KBV_NO_PHOTO_ID:
     nestedJourney: KBVS
@@ -786,6 +807,41 @@ states:
         journeyContextToSet: appOnly
       end:
         targetState: PROCESS_INCOMPLETE_IDENTITY
+
+  # Fraud mitigation journey
+  MITIGATE_FRAUD_CI_VIA_APP:
+    response:
+      type: page
+      pageId: retry-prove-identity-app
+    events:
+      useApp:
+        targetState: FRAUD_MITIGATION_PASSPORT_BIOMETRIC_CHIP
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+
+  FRAUD_MITIGATION_PASSPORT_BIOMETRIC_CHIP:
+    response:
+      type: page
+      pageId: passport-biometric-chip
+    events:
+      next:
+        # PYIC-9068 Implement mitigation route
+        targetJourney: FAILED
+        targetState: FAILED
+      abandon:
+        targetState: NEED_BIOMETRIC_PASSPORT
+
+  FRAUD_MITIGATION_NEED_BIOMETRIC_PASSPORT:
+    response:
+      type: page
+      pageId: need-biometric-passport
+    events:
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+      useApp:
+        # PYIC-9068 Implement mitigation route
+        targetJourney: FAILED
+        targetState: FAILED
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -292,7 +292,7 @@ states:
         targetState: FAILED
         checkFeatureFlag:
           mitigations9020Enabled:
-            targetState: MITIGATE_FRAUD_CI_VIA_APP
+            targetState: MITIGATE_CI_VIA_APP
 
   CHECK_FRAUD_AFTER_DL:
     response:
@@ -434,7 +434,7 @@ states:
         targetState: FAILED
         checkFeatureFlag:
           mitigations9020Enabled:
-            targetState: MITIGATE_FRAUD_CI_VIA_APP
+            targetState: MITIGATE_CI_VIA_APP
 
   # No photo id journey (M2B)
   CRI_CLAIMED_IDENTITY_NO_PHOTO_ID:
@@ -494,7 +494,7 @@ states:
         targetState: FAILED
         checkFeatureFlag:
           mitigations9020Enabled:
-            targetState: MITIGATE_FRAUD_CI_VIA_APP
+            targetState: MITIGATE_CI_VIA_APP
 
   KBV_NO_PHOTO_ID:
     nestedJourney: KBVS
@@ -809,17 +809,17 @@ states:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
   # Fraud mitigation journey
-  MITIGATE_FRAUD_CI_VIA_APP:
+  MITIGATE_CI_VIA_APP:
     response:
       type: page
       pageId: retry-prove-identity-app
     events:
       useApp:
-        targetState: FRAUD_MITIGATION_PASSPORT_BIOMETRIC_CHIP
+        targetState: MITIGATION_PASSPORT_BIOMETRIC_CHIP
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
-  FRAUD_MITIGATION_PASSPORT_BIOMETRIC_CHIP:
+  MITIGATION_PASSPORT_BIOMETRIC_CHIP:
     response:
       type: page
       pageId: passport-biometric-chip
@@ -829,9 +829,9 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       abandon:
-        targetState: NEED_BIOMETRIC_PASSPORT
+        targetState: MITIGATION_NEED_BIOMETRIC_PASSPORT
 
-  FRAUD_MITIGATION_NEED_BIOMETRIC_PASSPORT:
+  MITIGATION_NEED_BIOMETRIC_PASSPORT:
     response:
       type: page
       pageId: need-biometric-passport

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -63,6 +63,9 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fraud-fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
 
   PROCESS_UPDATE_IDENTITY:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -83,6 +83,9 @@ states:
         targetState: PROCESS_UPDATE_IDENTITY
       fraud-fail-with-no-ci:
         targetState: PROCESS_UPDATE_IDENTITY
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
 
   # Remove all VCs from previous attempts
   RESET_SESSION_BEFORE_NEW_IDENTITY:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-name.yaml
@@ -325,6 +325,9 @@ states:
             targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
             targetState: START_HIGHER_STRENGTH
             journeyContextToSet: nameAndAddress
+      fraud-fail-with-ci:
+        targetJourney: FAILED
+        targetState: FAILED
 
   # SHARED STATES
   PROCESS_UPDATE_IDENTITY:

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/service/AppConfigServiceTest.java
@@ -327,8 +327,8 @@ class AppConfigServiceTest {
         var map = configService.getContraIndicatorConfigMap();
 
         assertTrue(map.containsKey("NEEDS-ALTERNATE-DOC"));
-        assertEquals(20, map.get("NEEDS-ALTERNATE-DOC").getDetectedScore());
-        assertEquals(-20, map.get("NEEDS-ALTERNATE-DOC").getCheckedScore());
+        assertEquals(31, map.get("NEEDS-ALTERNATE-DOC").getDetectedScore());
+        assertEquals(-31, map.get("NEEDS-ALTERNATE-DOC").getCheckedScore());
         assertEquals("needs-alternate-doc", map.get("NEEDS-ALTERNATE-DOC").getReturnCode());
 
         assertTrue(map.containsKey("ALWAYS-REQUIRED"));

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -23,29 +23,25 @@ core:
     oauthKeyCacheDurationMins: 5
     # Test CI scoring values
     ciScoringThresholdByVot:
-      P1: 5
-      P2: 10
+      P1: 30
+      P2: 20
       P3: 10
     ciScoringConfig:
       - ci: "NON-BREACHING"
-        detectedScore: 2
-        checkedScore: -2
+        detectedScore: 10
+        checkedScore: -10
         returnCode: "non-breaching"
       - ci: "BREACHING"
-        detectedScore: 20
-        checkedScore: -20
+        detectedScore: 31
+        checkedScore: -31
         returnCode: "breaching"
-      - ci: "BREACHING-P1-ONLY"
-        detectedScore: 7
-        checkedScore: -7
-        returnCode: "breaching-p1-only"
       - ci: "NEEDS-ENHANCED-VERIFICATION"
-        detectedScore: 20
-        checkedScore: -20
+        detectedScore: 31
+        checkedScore: -31
         returnCode: "needs-enhanced-verification"
       - ci: "NEEDS-ALTERNATE-DOC"
-        detectedScore: 20
-        checkedScore: -20
+        detectedScore: 31
+        checkedScore: -31
         returnCode: "needs-alternate-doc"
       - ci: "ALWAYS-REQUIRED"
         detectedScore: 1

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -31,6 +31,18 @@ core:
         detectedScore: 10
         checkedScore: -10
         returnCode: "non-breaching"
+      - ci: "BREACHING-P1-WHEN-COMBINED-WITH-NON-BREACHING"
+        detectedScore: 21
+        checkedScore: -21
+        returnCode: "breaching-p1-when-combined-with-non-breaching"
+      - ci: "BREACHING-P2-WHEN-COMBINED-WITH-NON-BREACHING"
+        detectedScore: 11
+        checkedScore: -11
+        returnCode: "breaching-p2-when-combined-with-non-breaching"
+      - ci: "BREACHING-P3-WHEN-COMBINED-WITH-NON-BREACHING"
+        detectedScore: 1
+        checkedScore: -1
+        returnCode: "breaching-p3-when-combined-with-non-breaching"
       - ci: "BREACHING"
         detectedScore: 31
         checkedScore: -31

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -25,32 +25,28 @@ core:
     # Test CI scoring values
     ciScoringConfig:
       - ci: "NON-BREACHING"
-        detectedScore: 2
-        checkedScore: -2
+        detectedScore: 10
+        checkedScore: -10
         returnCode: "non-breaching"
       - ci: "BREACHING"
-        detectedScore: 20
-        checkedScore: -20
+        detectedScore: 31
+        checkedScore: -31
         returnCode: "breaching"
-      - ci: "BREACHING-P1-ONLY"
-        detectedScore: 7
-        checkedScore: -7
-        returnCode: "breaching-p1-only"
       - ci: "NEEDS-ENHANCED-VERIFICATION"
-        detectedScore: 20
-        checkedScore: -20
+        detectedScore: 31
+        checkedScore: -31
         returnCode: "needs-enhanced-verification"
       - ci: "NEEDS-ALTERNATE-DOC"
-        detectedScore: 20
-        checkedScore: -20
+        detectedScore: 31
+        checkedScore: -31
         returnCode: "needs-alternate-doc"
       - ci: "ALWAYS-REQUIRED"
         detectedScore: 1
         checkedScore: -1
         returnCode: "always-required"
     ciScoringThresholdByVot:
-      P1: 5
-      P2: 10
+      P1: 30
+      P2: 20
       P3: 10
     returnCodes:
       alwaysRequired: always-required

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -28,6 +28,18 @@ core:
         detectedScore: 10
         checkedScore: -10
         returnCode: "non-breaching"
+      - ci: "BREACHING-P1-WHEN-COMBINED-WITH-NON-BREACHING"
+        detectedScore: 21
+        checkedScore: -21
+        returnCode: "breaching-p1-when-combined-with-non-breaching"
+      - ci: "BREACHING-P2-WHEN-COMBINED-WITH-NON-BREACHING"
+        detectedScore: 11
+        checkedScore: -11
+        returnCode: "breaching-p2-when-combined-with-non-breaching"
+      - ci: "BREACHING-P3-WHEN-COMBINED-WITH-NON-BREACHING"
+        detectedScore: 1
+        checkedScore: -1
+        returnCode: "breaching-p3-when-combined-with-non-breaching"
       - ci: "BREACHING"
         detectedScore: 31
         checkedScore: -31


### PR DESCRIPTION
## Proposed changes
### What changed

Routing for fraud CI mitigation

### Why did it change

We're adding new routes

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9065](https://govukverify.atlassian.net/browse/PYIC-9065)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated

[PYIC-9065]: https://govukverify.atlassian.net/browse/PYIC-9065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ