### PR TITLE
PYIC-9065: Re-instate failing tests with extra logging

### DIFF
--- a/api-tests/features/fraud-mitigation/p1-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p1-mitigation.feature
@@ -60,32 +60,32 @@ Feature: P1 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-#  Rule: Combined CI score breach
-#    Scenario: Combined breaching fraud CI goes to mitigation route
-#      When I start a new 'low-confidence' journey
-#      Then I get a 'page-ipv-identity-document-start' page response
-#      When I submit an 'end' event
-#      Then I get a 'prove-identity-no-photo-id' page response and pageContext
-#        | Context  | Value |
-#        | ninoOnly | true  |
-#      When I submit an 'next' event
-#      Then I get a 'claimedIdentity' CRI response
-#      When I submit 'kenneth-current' details with attributes to the CRI stub
-#        | Attribute | Values         |
-#        | context   | "hmrc_check" |
-#      Then I get a 'nino' CRI response
-#      When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
-#        | Attribute          | Values                                      |
-#        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-#      Then I get an 'address' CRI response
-#      When I submit 'kenneth-current' details to the CRI stub
-#      Then I get a 'fraud' CRI response
-#      When I submit 'kenneth-score-2-breaching-p1-when-combined-with-non-breaching' details with attributes to the CRI stub
-#        | Attribute          | Values                   |
-#        | evidence_requested | {"identityFraudScore":2} |
-#      Then I get a 'retry-prove-identity-app' page response
-#      When I submit a 'useApp' event
-#      Then I get a 'passport-biometric-chip' page response
+  Rule: Combined CI score breach
+    Scenario: Combined breaching fraud CI goes to mitigation route
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-no-photo-id' page response and pageContext
+        | Context  | Value |
+        | ninoOnly | true  |
+      When I submit an 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details with attributes to the CRI stub
+        | Attribute | Values         |
+        | context   | "hmrc_check" |
+      Then I get a 'nino' CRI response
+      When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2-breaching-p1-when-combined-with-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
 
   Rule: Web document journey
     Background: Start P1 web document journey

--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -64,36 +64,36 @@ Feature: P2 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-#  Rule: Combined CI score breach
-#    Scenario: Combined breaching fraud CI goes to mitigation route
-#      When I start a new 'medium-confidence' journey
-#      Then I get a 'live-in-uk' page response
-#      When I submit a 'uk' event
-#      Then I get a 'page-ipv-identity-document-start' page response
-#      When I submit an 'end' event
-#      Then I get a 'page-ipv-identity-postoffice-start' page response
-#      When I submit an 'end' event
-#      Then I get a 'prove-identity-no-photo-id' page response
-#      When I submit an 'next' event
-#      Then I get a 'claimedIdentity' CRI response
-#      When I submit 'kenneth-current' details with attributes to the CRI stub
-#        | Attribute | Values         |
-#        | context   | "bank_account" |
-#      Then I get a 'bav' CRI response
-#      When I submit 'kenneth' details to the CRI stub
-#      Then I get a 'nino' CRI response
-#      When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
-#        | Attribute          | Values                                      |
-#        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-#      Then I get an 'address' CRI response
-#      When I submit 'kenneth-current' details to the CRI stub
-#      Then I get a 'fraud' CRI response
-#      When I submit 'kenneth-score-2-breaching-p2-when-combined-with-non-breaching' details with attributes to the CRI stub
-#        | Attribute          | Values                   |
-#        | evidence_requested | {"identityFraudScore":2} |
-#      Then I get a 'retry-prove-identity-app' page response
-#      When I submit a 'useApp' event
-#      Then I get a 'passport-biometric-chip' page response
+  Rule: Combined CI score breach
+    Scenario: Combined breaching fraud CI goes to mitigation route
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-no-photo-id' page response
+      When I submit an 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details with attributes to the CRI stub
+        | Attribute | Values         |
+        | context   | "bank_account" |
+      Then I get a 'bav' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'nino' CRI response
+      When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2-breaching-p2-when-combined-with-non-breaching' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
 
   Rule: Web document journey
     Background: Start P2 web document journey

--- a/api-tests/src/clients/core-back-internal-client.ts
+++ b/api-tests/src/clients/core-back-internal-client.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/internal-api.js";
 import { ApiRequestError } from "../types/errors.js";
 import { World } from "../types/world.js";
+import { inspect } from "util";
 
 const JOURNEY_PREFIX = "/journey/";
 const POST = "POST";
@@ -136,6 +137,9 @@ export const processCriCallback = async (
   featureSet: string | undefined,
 ): Promise<JourneyResponse | PageResponse> => {
   const url = `${config.core.internalApiUrl}/cri/callback`;
+  console.info(
+    `QQ About to call core back. URL: "${url}" requestBody: "${JSON.stringify(requestBody)}"`,
+  );
   const response = await fetch(url, {
     method: POST,
     headers: {
@@ -147,6 +151,10 @@ export const processCriCallback = async (
   });
 
   const result = await response.json();
+  console.info(
+    `QQ response received: ${inspect(response, { depth: null, showHidden: true })}`,
+  );
+  console.info(`QQ response body: ${JSON.stringify(result)}`);
   if (!response.ok && !result.page) {
     console.error(
       `Error response received from core back process CRI callback end point`,

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -68,11 +68,13 @@ const submitAndProcessCriAction = async (
     redirectUrl,
     body: criStubRequest,
   };
+  console.info("QQ Calling stub headkess API");
   const criStubResponse = await criStubClient.callHeadlessApi(
     redirectUrl,
     criStubRequest,
   );
 
+  console.info("QQ Calling core-back processCriCallback");
   const response = await internalClient.processCriCallback(
     generateProcessCriCallbackBody(criStubResponse),
     world.ipvSessionId,

--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -151,19 +151,24 @@ public class ProcessCriCallbackHandler
         CriCallbackRequest callbackRequest = null;
 
         try {
+            LOGGER.info("Parsing request");
             callbackRequest = parseCallbackRequest(input);
 
+            LOGGER.info("Calling getJourneyResponse");
             var journeyResponse = getJourneyResponse(callbackRequest);
 
+            LOGGER.info("Returning journey response");
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.OK, journeyResponse);
         } catch (ParseCriCallbackRequestException e) {
+            LOGGER.error("Caught ParseCriCallbackRequestException", e);
             return buildErrorResponse(
                     e,
                     HttpStatusCode.BAD_REQUEST,
                     ErrorResponse.FAILED_TO_PARSE_CRI_CALLBACK_REQUEST,
                     Level.ERROR);
         } catch (InvalidCriCallbackRequestException e) {
+            LOGGER.error("Caught InvalidCriCallbackRequestException", e);
             switch (e.getErrorResponse()) {
                 case NO_IPV_FOR_CRI_OAUTH_SESSION -> {
                     LOGGER.warn(LogHelper.buildErrorMessage(e.getErrorResponse()));
@@ -202,36 +207,43 @@ public class ProcessCriCallbackHandler
                 }
             }
         } catch (HttpResponseExceptionWithErrorBody | VerifiableCredentialException e) {
+            LOGGER.error(
+                    "Caught HttpResponseExceptionWithErrorBody | VerifiableCredentialException", e);
             if (ErrorResponse.FAILED_NAME_CORRELATION.equals(e.getErrorResponse())) {
                 return buildErrorResponse(
                         e, e.getResponseCode(), ErrorResponse.FAILED_NAME_CORRELATION, Level.INFO);
             }
             return buildErrorResponse(e, e.getResponseCode(), e.getErrorResponse(), Level.ERROR);
         } catch (JsonProcessingException e) {
+            LOGGER.error("Caught JsonProcessingException", e);
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_SEND_AUDIT_EVENT,
                     Level.ERROR);
         } catch (UnrecognisedVotException | CredentialParseException e) {
+            LOGGER.error("Caught UnrecognisedVotException | CredentialParseException", e);
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS,
                     Level.ERROR);
         } catch (CiPutException | CiPostMitigationsException e) {
+            LOGGER.error("Caught CiPutException | CiPostMitigationsException", e);
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_SAVE_CREDENTIAL,
                     Level.ERROR);
         } catch (CiRetrievalException e) {
+            LOGGER.error("Caught CiRetrievalException", e);
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_GET_STORED_CIS,
                     Level.ERROR);
         } catch (CriApiException e) {
+            LOGGER.error("Caught CriApiException", e);
             if (DCMAW.equals(callbackRequest.getCredentialIssuer())
                     && e.getHttpStatusCode() == HTTPResponse.SC_NOT_FOUND) {
                 LOGGER.error(
@@ -242,18 +254,21 @@ public class ProcessCriCallbackHandler
             }
             return buildErrorResponse(e, e.getHttpStatusCode(), e.getErrorResponse(), Level.ERROR);
         } catch (CiExtractionException e) {
+            LOGGER.error("Caught CiExtractionException", e);
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     ErrorResponse.FAILED_TO_EXTRACT_CIS_FROM_VC,
                     Level.ERROR);
         } catch (IpvSessionNotFoundException e) {
+            LOGGER.error("Caught IpvSessionNotFoundException", e);
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
                     ErrorResponse.IPV_SESSION_NOT_FOUND,
                     Level.ERROR);
         } catch (MissingSecurityCheckCredential e) {
+            LOGGER.error("Caught MissingSecurityCheckCredential", e);
             return buildErrorResponse(
                     e,
                     HttpStatusCode.INTERNAL_SERVER_ERROR,

--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandlerTest.java
@@ -452,7 +452,7 @@ class ProcessCriCallbackHandlerTest {
 
         // Assert
         assertEquals("Test error", thrown.getMessage());
-        var logMessage = logCollector.getLogMessages().get(0);
+        var logMessage = logCollector.getLogMessages().getLast();
         assertThat(logMessage, containsString("Unhandled lambda exception"));
         assertThat(logMessage, containsString("Test error"));
     }


### PR DESCRIPTION
## Proposed changes
### What changed

Re-instate failing tests with extra logging

### Why did it change

To try to work out why these test fail in the build pipeline

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9065](https://govukverify.atlassian.net/browse/PYIC-9065)


[PYIC-9065]: https://govukverify.atlassian.net/browse/PYIC-9065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ