### PR TITLE
PYIC-9161: Add test for expired DCMAW async DL permit.

### DIFF
--- a/api-tests/features/evcs-api-updates/p2-journey.feature
+++ b/api-tests/features/evcs-api-updates/p2-journey.feature
@@ -202,3 +202,57 @@ Feature: P2 EvcsUpdates journeys
       And my identity 'GivenName' is 'Ken'
       And my identity 'FamilyName' is 'Decerqueira'
       And I have a stored identity record with a 'P3' max vot
+
+  Rule: Expired DCMAW async DL permit
+    Scenario: An expired successful DCMAW driving permit and current date is past the validity period should result in identity reprove
+    # This creates a DCMAW Async VC which has nbf 26/07/2022 and driving permit expiry date set to 180 days before the nbf
+      Given the subject already has the following expired credentials with overridden document expiry date
+        | CRI            | scenario                       | documentType  |
+        | dcmawAsync     | kenneth-driving-permit-valid   | drivingPermit |
+      And the subject already has the following credentials
+        | CRI            | scenario                       |
+        | drivingLicence | kenneth-driving-permit-valid   |
+        | address        | kenneth-current                |
+        | fraud          | kenneth-score-2                |
+      And I activate the 'evcsApiUpdates' feature set
+
+      When I start a new 'medium-confidence' journey
+      Then I get a 'reprove-identity-start' page response
+      When I submit a 'next' event
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
+    # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot


### PR DESCRIPTION
## Proposed changes
### What changed

- Added API test for P2 journey with DCMAW async DL permit expired >180 days scenario that verifies users are redirected to Reprove Identity journey when evcsApiUpdates feature flag is enabled.

### Why did it change

Users with expired DL VCs >180 days were not being redirected to Reprove Identity when the evcsApiUpdates feature flag was enabled.

⚠️ ROOT CAUSE HAPPENED IN EVCS STUB - [PR](https://github.com/govuk-one-login/ipv-stubs/pull/2140)
The root cause was that validateStateTransitions was iterating over all existing VCs and attempting to find matching VCs in the request. When a VC existed in EVCS but wasn't included in the PATCH request, the validation would fail because it couldn't find a matching signature in the request.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9161](https://govukverify.atlassian.net/browse/PYIC-9161)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9161]: https://govukverify.atlassian.net/browse/PYIC-9161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ