### PR TITLE
PYIC-9149: Mistake to enable the feature flag locally

### DIFF
--- a/api-tests/features/m1c-journeys.feature
+++ b/api-tests/features/m1c-journeys.feature
@@ -397,10 +397,10 @@ Feature: M1C Unavailable Journeys
       When I submit 'kenneth-changed-family-name-unavailable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
-        | Context              | Value          |
-        | journeyType          | updateDetails  |
-      When I submit a 'continueToService' event
+      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
+        | Context                 | Value |
+        | isExistingIdentityValid | true  |
+      When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I am issued a 'P2' identity

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -70,9 +70,9 @@ Feature: Repeat fraud check failures
       When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
-        | Context              | Value            |
-        | journeyType          | repeatFraudCheck |
+      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
+        | Context                 | Value |
+        | isExistingIdentityValid | false |
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -109,9 +109,9 @@ Feature: Repeat fraud check failures
       When I submit 'kenneth-unavailable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
-        | Context              | Value            |
-        | journeyType          | repeatFraudCheck |
+      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
+        | Context                 | Value |
+        | isExistingIdentityValid | false |
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -250,10 +250,10 @@ Feature: Repeat fraud check failures
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
-      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
-        | Context              | Value            |
-        | journeyType          | repeatFraudCheck |
-      When I submit a 'returnToRp' event
+      Then I get an 'update-details-failed' page response and pageContext
+        | Context                   | Value |
+        | isExistingIdentityInvalid | true  |
+      When I submit a 'return-to-service' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I am issued a 'P0' identity

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -100,10 +100,8 @@ Feature: Identity reuse update details failures
             And I poll for async DCMAW credential receipt
             Then the poll returns a '201'
             When I submit the returned journey event
-            Then I get an 'need-more-information-confirm-change-details' page response and pageContext
-                | Context              | Value         |
-                | journeyType          | updateDetails |
-            When I submit a 'continueToService' event
+            Then I get an 'update-details-failed' page response
+            When I submit a 'continue' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
             Then I am issued a 'P2' identity
@@ -256,10 +254,10 @@ Feature: Identity reuse update details failures
             When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
                 | Attribute          | Values                   |
                 | evidence_requested | {"identityFraudScore":2} |
-            Then I get an 'need-more-information-confirm-change-details' page response and pageContext
-                | Context              | Value         |
-                | journeyType          | updateDetails |
-            When I submit a 'continueToService' event
+            Then I get an 'sorry-could-not-confirm-details' page response and pageContext
+                | Context                 | Value |
+                | isExistingIdentityValid | true  |
+            When I submit a 'returnToRp' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
             Then I am issued a 'P2' identity

--- a/libs/test-data/src/main/resources/test-parameters.yaml
+++ b/libs/test-data/src/main/resources/test-parameters.yaml
@@ -362,7 +362,7 @@ core:
     sisVerificationEnabled: true
     testFeatureFlag: false
     evcsApiUpdatesEnabled: false
-    coi6mfcDeadEndRoutingEnabled: true
+    coi6mfcDeadEndRoutingEnabled: false
   features:
     testFeature:
       self:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -366,7 +366,7 @@ core:
     sisVerificationEnabled: true
     evcsApiUpdatesEnabled: false
     mitigations9020Enabled: false
-    coi6mfcDeadEndRoutingEnabled: true
+    coi6mfcDeadEndRoutingEnabled: false
 
   features:
     coi6mfcDeadEndRouting:


### PR DESCRIPTION

## Proposed changes
### What changed

- This broke tests in build, there is a seperate ticket to enable in build


### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9149](https://govukverify.atlassian.net/browse/PYIC-9149)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9149]: https://govukverify.atlassian.net/browse/PYIC-9149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ