### PR TITLE
OJ-3742: Remove exp from ninoCri credential pact

### DIFF
--- a/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/CredentialTests.java
+++ b/lambdas/process-cri-callback/src/test/java/uk/gov/di/ipv/core/processcricallback/pact/ninoCri/CredentialTests.java
@@ -416,7 +416,6 @@ class CredentialTests {
               "sub": "test",
               "nbf": 4070908800,
               "iss": "dummyNinoComponentId",
-              "exp": 4070909400,
               "vc": {
                 "evidence": [
                   {
@@ -473,7 +472,7 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String VALID_NINO_IDENTITY_CHECK_VC_SIGNATURE =
-            "SnthjM7v9cnoNMT0QgrhgkYnd4U_X1F8fNYzNT8GeEIvSgjBVSaAR_fvDLl4a-DFtvwUENQZV8XyhhB8oscu8Q"; // pragma: allowlist secret
+            "_rkNlljsUu1APxU9iM5NThI9hNeb11wKh1I09FAlrHi3-fEMdWJqNlFo9plcAKwviJE-E1Q_qgeyJAblTrLhWw"; // pragma: allowlist secret
 
     private static final String FAILED_NINO_IDENTITY_CHECK_VC_BODY =
             """
@@ -481,7 +480,6 @@ class CredentialTests {
               "sub": "test",
               "nbf": 4070908800,
               "iss": "dummyNinoComponentId",
-              "exp": 4070909400,
               "vc": {
                 "evidence": [
                   {
@@ -541,5 +539,5 @@ class CredentialTests {
     // valid signature (using https://jwt.io works well) and record it here so the PACT file doesn't
     // change each time we run the tests.
     private static final String FAILED_NINO_IDENTITY_CHECK_VC_SIGNATURE =
-            "n_JVP1topSmn-_XVRHChwrZZ-vZkADhGRuSvBparwYIIwp3sxkyThtEZZs2evCICrt5ihdWAFDxUsE1kbCCcWQ"; // pragma: allowlist secret
+            "lMrdrcMTHTHRUk2PvIvobqaLyqqzXzbXQHB0pM-w3lBerQMQbHeuqOGYrjXCeIU-ls7TFJ3Hf5oY0PPGafW9_Q"; // pragma: allowlist secret
 }


### PR DESCRIPTION
## Proposed changes
### What changed

- Remove `exp` from the VC for the NINO CRI.

### Why did it change

- Since "exp" is no longer being used in the VC based on this [decision](https://github.com/govuk-one-login/architecture/blob/main/adr/0076-vc-lifetime.md). This has already been removed from Address & KBV CRI: https://github.com/govuk-one-login/ipv-core-back/pull/3973
- Nino PR ready to merge after: https://github.com/govuk-one-login/ipv-cri-check-hmrc-api/pull/777

### Issue tracking
- [OJ-3724](https://govukverify.atlassian.net/browse/OJ-3724)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>

[OJ-3724]: https://govukverify.atlassian.net/browse/OJ-3724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ