### PR TITLE
PYIC-9170: Rename KBV find-another-way pages.

### DIFF
--- a/api-tests/features/app-cross-browser/p2-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p2-cross-browser.feature
@@ -199,7 +199,7 @@ Feature: P2 V2 App Cross Browser Scenario
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event

--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-dcmaw.feature
@@ -35,7 +35,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
 
     Scenario: Same session DCMAW enhanced verification mitigation - successful
       When I submit an 'appTriage' event

--- a/api-tests/features/cimit/p1-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p1-enhanced-verification-mitigation-f2f.feature
@@ -34,7 +34,7 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-web-find-another-way' page response
 
   Rule: Same session journeys
 

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
@@ -34,7 +34,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-web-find-another-way' page response
     When I submit an 'appTriage' event
     Then I get an 'identify-device' page response
     When I submit an 'appTriage' event
@@ -101,7 +101,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-web-find-another-way' page response
 
     # Separate session
     When I start a new '<journey-type>' journey
@@ -181,7 +181,7 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
 
     Scenario: Same session DCMAW enhanced verification mitigation - user abandons DCMAW then escapes
       When I submit an 'appTriage' event

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
@@ -34,7 +34,7 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-web-find-another-way' page response
 
   Rule: Same session journeys
 

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -46,7 +46,7 @@ Feature: Disabled CRI journeys
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response and pageContext
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
         | Context | Value   |
         | reason  | dropout |
       When I submit an 'appTriage' event
@@ -90,7 +90,7 @@ Feature: Disabled CRI journeys
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-technical' page response
 

--- a/api-tests/features/dl-auth-source-checks/p1-enhanced-verification-mitigation.feature
+++ b/api-tests/features/dl-auth-source-checks/p1-enhanced-verification-mitigation.feature
@@ -36,7 +36,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -305,7 +305,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event

--- a/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
+++ b/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
@@ -340,7 +340,7 @@ Feature: P2 Journeys with DL authoritative source check
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response and pageContext
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
         | Context | Value   |
         | reason  | dropout |
       When I submit an 'appTriage' event
@@ -392,7 +392,7 @@ Feature: P2 Journeys with DL authoritative source check
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -433,7 +433,7 @@ Feature: P2 Journeys with DL authoritative source check
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event

--- a/api-tests/features/dl-auth-source-checks/p2-enhanced-verification-mitigation.feature
+++ b/api-tests/features/dl-auth-source-checks/p2-enhanced-verification-mitigation.feature
@@ -36,7 +36,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
@@ -304,7 +304,7 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
       When I submit an 'appTriage' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event

--- a/api-tests/features/dwp-kbv/p1-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p1-web-journey.feature
@@ -192,7 +192,7 @@ Feature: P1 Web Journeys - DWP KBV
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response
       When I submit a 'end' event
-      Then I get a 'no-photo-id-security-questions-find-another-way' page response and pageContext
+      Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
         | Context | Value   |
         | reason  | dropout |
       When I submit an 'appTriage' event

--- a/api-tests/features/dwp-kbv/p2-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p2-web-journey.feature
@@ -93,7 +93,7 @@ Feature: P2 Web document journey - DWP KBV
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
     When I submit a 'end' event
-    Then I get a 'photo-id-security-questions-find-another-way' page response and pageContext
+    Then I get a 'photo-id-web-find-another-way' page response and pageContext
       | Context | Value   |
       | reason  | dropout |
     When I submit an 'appTriage' event
@@ -137,7 +137,7 @@ Feature: P2 Web document journey - DWP KBV
     When I submit a 'next' event
     Then I get a 'page-pre-dwp-kbv-transition' page response
     When I submit a 'end' event
-    Then I get a 'photo-id-security-questions-find-another-way' page response and pageContext
+    Then I get a 'photo-id-web-find-another-way' page response and pageContext
       | Context | Value   |
       | reason  | dropout |
     When I submit an 'appTriage' event

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -133,7 +133,7 @@ Feature: P1 No Photo Id Journey
     When I submit 'kenneth-score-0' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'no-photo-id-security-questions-find-another-way' page response and pageContext
+    Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
       | Context | Value   |
       | reason  | dropout |
     When I submit an 'appTriage' event
@@ -253,4 +253,4 @@ Feature: P1 No Photo Id Journey
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'no-photo-id-security-questions-find-another-way' page response
+    Then I get a 'no-photo-id-web-find-another-way' page response

--- a/api-tests/features/p1-web-journey.feature
+++ b/api-tests/features/p1-web-journey.feature
@@ -36,7 +36,7 @@ Feature: P1 Web Journeys
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-web-find-another-way' page response
     When I submit a 'f2f' event
     Then I get a 'f2f' CRI response
     When I get an error from the async CRI stub
@@ -167,7 +167,7 @@ Feature: P1 Web Journeys
     When I submit 'kenneth-score-0' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response and pageContext
+    Then I get a 'photo-id-web-find-another-way' page response and pageContext
       | Context | Value   |
       | reason  | dropout |
 
@@ -194,7 +194,7 @@ Feature: P1 Web Journeys
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-web-find-another-way' page response
 
   Scenario Outline: P1 journey used when both P1 and P2 are present in JAR request
     When I start a new 'low-medium-confidence' journey

--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -113,7 +113,7 @@ Feature: P2 no photo id journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'no-photo-id-security-questions-find-another-way' page response and pageContext
+      Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
         | Context | Value   |
         | reason  | dropout |
 
@@ -167,7 +167,7 @@ Feature: P2 no photo id journey
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'no-photo-id-security-questions-find-another-way' page response
+      Then I get a 'no-photo-id-web-find-another-way' page response
 
     Scenario: P2 no photo id journey - Experian - Breaching BAV CI
       When I submit 'kenneth-current' details with attributes to the CRI stub
@@ -294,7 +294,7 @@ Feature: P2 no photo id journey
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'no-photo-id-security-questions-find-another-way' page response
+      Then I get a 'no-photo-id-web-find-another-way' page response
 
     Scenario: P2 no photo id journey - KBV mitigation - Strategic app
       Given I activate the 'strategicApp' feature set
@@ -341,7 +341,7 @@ Feature: P2 no photo id journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'no-photo-id-security-questions-find-another-way' page response and pageContext
+      Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
         | Context | Value   |
         | reason  | dropout |
 

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -133,7 +133,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
       When I submit a 'f2f' event
       Then I get a 'f2f' CRI response
       When I get an error from the async CRI stub
@@ -331,7 +331,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response and pageContext
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
         | Context | Value   |
         | reason  | dropout |
       When I submit an 'appTriage' event
@@ -365,7 +365,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response and pageContext
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
         | Context | Value   |
         | reason  | dropout |
       When I submit an 'f2f' event
@@ -387,7 +387,7 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-0' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response and pageContext
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
         | Context | Value   |
         | reason  | dropout |
       When I submit an 'appTriage' event

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -93,7 +93,7 @@ Feature: Return exit codes
     When I submit 'kenneth-score-0' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response and pageContext
+    Then I get a 'photo-id-web-find-another-way' page response and pageContext
       | Context | Value   |
       | reason  | dropout |
     When I submit a 'f2f' event
@@ -227,7 +227,7 @@ Feature: Return exit codes
     When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'photo-id-security-questions-find-another-way' page response
+    Then I get a 'photo-id-web-find-another-way' page response
     When I submit an 'f2f' event
     Then I get a 'f2f' CRI response
     When I call the CRI stub with attributes and get an 'access_denied' OAuth error

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -35,7 +35,7 @@ Feature: TICF failed/error journeys
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
 
     Scenario: TICF failed enhanced-verification journey - PYI_NO_MATCH
       When I submit a 'appTriage' event

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -642,7 +642,7 @@ Feature: Handling unexpected CRI errors
       When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'photo-id-security-questions-find-another-way' page response
+      Then I get a 'photo-id-web-find-another-way' page response
 
     Scenario: Same session mitigation via F2F - return to RP
       When I submit a 'f2f' event

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -10,11 +10,13 @@ public class PageContextValidator extends AbstractPageContextValidator {
                     Map.entry(
                             "need-more-information-confirm-change-details", Set.of("journeyType")),
                     Map.entry("no-photo-id-security-questions-find-another-way", Set.of("reason")),
+                    Map.entry("no-photo-id-web-find-another-way", Set.of("reason")),
                     Map.entry("page-dcmaw-success", Set.of("noAddress")),
                     Map.entry("page-ipv-success", Set.of("journeyType")),
                     Map.entry("page-multiple-doc-check", Set.of("allowNino")),
                     Map.entry("page-update-name", Set.of("journeyType")),
                     Map.entry("photo-id-security-questions-find-another-way", Set.of("reason")),
+                    Map.entry("photo-id-web-find-another-way", Set.of("reason")),
                     Map.entry("prove-identity-another-type-photo-id", Set.of("invalidDoc")),
                     Map.entry("prove-identity-another-way", Set.of("removeF2f")),
                     Map.entry("prove-identity-no-other-photo-id", Set.of("invalidDoc")),

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -314,10 +314,10 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  PYI_KBV_DROPOUT_PHOTO_ID:
+  DROPOUT_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
     response:
       type: page
-      pageId: photo-id-security-questions-find-another-way
+      pageId: photo-id-web-find-another-way
       pageContext:
         reason: dropout
     events:
@@ -340,7 +340,7 @@ states:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
-        targetState: PYI_KBV_DROPOUT_PHOTO_ID
+        targetState: DROPOUT_PHOTO_ID_WEB_FIND_ANOTHER_WAY
         checkMitigation:
           alternate-doc-invalid-passport:
             targetJourney: INELIGIBLE
@@ -349,7 +349,7 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       end:
-        targetState: PYI_KBV_DROPOUT_PHOTO_ID
+        targetState: DROPOUT_PHOTO_ID_WEB_FIND_ANOTHER_WAY
         checkMitigation:
           alternate-doc-invalid-passport:
             targetJourney: INELIGIBLE
@@ -364,7 +364,7 @@ states:
         targetState: FAILED
         checkMitigation:
           enhanced-verification:
-            targetState: MITIGATION_KBV_FAIL_PHOTO_ID
+            targetState: MITIGATION_PHOTO_ID_WEB_FIND_ANOTHER_WAY
             auditEvents:
               - IPV_MITIGATION_START
             auditContext:
@@ -488,9 +488,9 @@ states:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
-        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+        targetState: DROPOUT_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY
       end:
-        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+        targetState: DROPOUT_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY
       next:
         targetState: PROCESS_NEW_IDENTITY
       fail-with-ci:
@@ -498,7 +498,7 @@ states:
         targetState: FAILED
         checkMitigation:
           enhanced-verification:
-            targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
+            targetState: MITIGATION_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY
             auditEvents:
               - IPV_MITIGATION_START
             auditContext:
@@ -515,10 +515,10 @@ states:
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
-  MITIGATION_KBV_FAIL_NO_PHOTO_ID:
+  MITIGATION_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
     response:
       type: page
-      pageId: no-photo-id-security-questions-find-another-way
+      pageId: no-photo-id-web-find-another-way
     events:
       f2f:
         targetJourney: F2F_HAND_OFF
@@ -560,10 +560,10 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  PYI_KBV_DROPOUT_NO_PHOTO_ID:
+  DROPOUT_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
     response:
       type: page
-      pageId: no-photo-id-security-questions-find-another-way
+      pageId: no-photo-id-web-find-another-way
       pageContext:
         reason: dropout
     events:
@@ -654,10 +654,10 @@ states:
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
-  MITIGATION_KBV_FAIL_PHOTO_ID:
+  MITIGATION_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
     response:
       type: page
-      pageId: photo-id-security-questions-find-another-way
+      pageId: photo-id-web-find-another-way
     events:
       appTriage:
         targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -344,12 +344,33 @@ states:
             targetJourney: TECHNICAL_ERROR
             targetState: ERROR
 
+  DROPOUT_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: photo-id-web-find-another-way
+      pageContext:
+        reason: dropout
+    events:
+      appTriage:
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmawAsync:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
   # Common pages
   KBV_PHOTO_ID:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
-        targetState: PYI_KBV_DROPOUT_PHOTO_ID
+        targetState: DROPOUT_PHOTO_ID_WEB_FIND_ANOTHER_WAY
         checkMitigation:
           alternate-doc-invalid-passport:
             targetJourney: INELIGIBLE
@@ -358,7 +379,7 @@ states:
             targetJourney: INELIGIBLE
             targetState: INELIGIBLE
       end:
-        targetState: PYI_KBV_DROPOUT_PHOTO_ID
+        targetState: DROPOUT_PHOTO_ID_WEB_FIND_ANOTHER_WAY
         checkMitigation:
           alternate-doc-invalid-passport:
             targetJourney: INELIGIBLE
@@ -373,7 +394,7 @@ states:
         targetState: FAILED
         checkMitigation:
           enhanced-verification:
-            targetState: MITIGATION_KBV_FAIL_PHOTO_ID
+            targetState: MITIGATION_PHOTO_ID_WEB_FIND_ANOTHER_WAY
             auditEvents:
               - IPV_MITIGATION_START
             auditContext:
@@ -510,9 +531,9 @@ states:
     nestedJourney: KBVS
     exitEvents:
       fail-with-no-ci:
-        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+        targetState: DROPOUT_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY
       end:
-        targetState: PYI_KBV_DROPOUT_NO_PHOTO_ID
+        targetState: DROPOUT_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY
       next:
         targetState: PROCESS_NEW_IDENTITY
       fail-with-ci:
@@ -520,7 +541,7 @@ states:
         targetState: FAILED
         checkMitigation:
           enhanced-verification:
-            targetState: MITIGATION_KBV_FAIL_NO_PHOTO_ID
+            targetState: MITIGATION_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY
             auditEvents:
               - IPV_MITIGATION_START
             auditContext:
@@ -541,6 +562,28 @@ states:
     response:
       type: page
       pageId: no-photo-id-security-questions-find-another-way
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriage:
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmawAsync:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  MITIGATION_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: no-photo-id-web-find-another-way
     events:
       f2f:
         targetJourney: F2F_HAND_OFF
@@ -599,6 +642,30 @@ states:
     response:
       type: page
       pageId: no-photo-id-security-questions-find-another-way
+      pageContext:
+        reason: dropout
+    events:
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      appTriage:
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmawAsync:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      end:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+
+  DROPOUT_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: no-photo-id-web-find-another-way
       pageContext:
         reason: dropout
     events:
@@ -710,6 +777,25 @@ states:
     response:
       type: page
       pageId: photo-id-security-questions-find-another-way
+    events:
+      appTriage:
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        checkIfDisabled:
+          dcmawAsync:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      f2f:
+        targetJourney: F2F_HAND_OFF
+        targetState: START_MEDIUM_CONFIDENCE
+        checkIfDisabled:
+          f2f:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+
+  MITIGATION_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: photo-id-web-find-another-way
     events:
       appTriage:
         targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE


### PR DESCRIPTION
## Proposed changes
### What changed

P2 Journey Updates
Introduced four new states for the P2 journey:
  - MITIGATION_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY
  - MITIGATION_PHOTO_ID_WEB_FIND_ANOTHER_WAY
  - DROPOUT_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY
  - DROPOUT_PHOTO_ID_WEB_FIND_ANOTHER_WAY
  
Additionally: 
  - Pinned the journey flow to these new states.
  - The previous states have been retained to avoid impacting users currently progressing through journeys.

P1 Journey Updates
  - Renamed state names, response page ids, and pinned journey map states 
  - Unlike the P2 changes, no state duplication or staging was required for P1, as there is currently no live traffic on these journeys.
  
API Tests
  - Updated all occurrences of the above pages to match new name

### Why did it change

The URL paths associated with the "KBV find another way" screens have been updated to support new dynamic Post Open Banking frontend pages.

Previously, these pages were dedicated to users who reached the route following KBV outcomes. The new implementation allows the same frontend pages to be reused dynamically for both KBV and Open Banking user journeys.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9170](https://govukverify.atlassian.net/browse/PYIC-9170)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9170]: https://govukverify.atlassian.net/browse/PYIC-9170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ