### PR TITLE
PYIC-9170: Clean unused states after renaming find-another-way pages.

### DIFF
--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/AbstractPageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/AbstractPageContextValidator.java
@@ -8,6 +8,21 @@ import java.util.Set;
 public abstract class AbstractPageContextValidator implements IPageContextValidator {
     abstract Map<String, Set<String>> getAllowedContextsByPage();
 
+    public static final String JOURNEY_TYPE = "journeyType";
+    public static final String REASON = "reason";
+    public static final String NO_ADDRESS = "noAddress";
+    public static final String ALLOW_NINO = "allowNino";
+    public static final String INVALID_DOC = "invalidDoc";
+    public static final String REMOVE_F2F = "removeF2f";
+    public static final String NINO_ONLY = "ninoOnly";
+    public static final String IS_UNRECOVERABLE = "isUnrecoverable";
+    public static final String SMARTPHONE = "smartphone";
+    public static final String IS_APP_ONLY = "isAppOnly";
+    public static final String DEVICE_TYPE = "deviceType";
+    public static final String IS_EXISTING_IDENTITY_VALID = "isExistingIdentityValid";
+    public static final String IS_EXISTING_IDENTITY_INVALID = "isExistingIdentityInvalid";
+    public static final String IS_FROM_STRATEGIC_APP = "isFromStrategicApp";
+
     @Override
     public void validate(String pageId, Map<String, Object> pageContext) {
         if (pageContext == null || pageContext.isEmpty()) {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -4,32 +4,34 @@ import java.util.Map;
 import java.util.Set;
 
 public class PageContextValidator extends AbstractPageContextValidator {
+
     private static final Map<String, Set<String>> ALLOWED_CONTEXTS_BY_PAGE =
             Map.ofEntries(
-                    Map.entry("delete-handover", Set.of("journeyType")),
+                    Map.entry("delete-handover", Set.of(JOURNEY_TYPE)),
+                    Map.entry("need-more-information-confirm-change-details", Set.of(JOURNEY_TYPE)),
+                    Map.entry("no-photo-id-web-find-another-way", Set.of(REASON)),
+                    Map.entry("page-dcmaw-success", Set.of(NO_ADDRESS)),
+                    Map.entry("page-ipv-success", Set.of(JOURNEY_TYPE)),
+                    Map.entry("page-multiple-doc-check", Set.of(ALLOW_NINO)),
+                    Map.entry("page-update-name", Set.of(JOURNEY_TYPE)),
+                    Map.entry("photo-id-web-find-another-way", Set.of(REASON)),
+                    Map.entry("prove-identity-another-type-photo-id", Set.of(INVALID_DOC)),
+                    Map.entry("prove-identity-another-way", Set.of(REMOVE_F2F)),
+                    Map.entry("prove-identity-no-other-photo-id", Set.of(INVALID_DOC)),
+                    Map.entry("prove-identity-no-photo-id", Set.of(NINO_ONLY)),
+                    Map.entry("pyi-no-match", Set.of(REASON)),
+                    Map.entry("pyi-technical", Set.of(IS_UNRECOVERABLE)),
+                    Map.entry("pyi-triage-desktop-download-app", Set.of(SMARTPHONE, IS_APP_ONLY)),
+                    Map.entry("pyi-triage-mobile-download-app", Set.of(SMARTPHONE, IS_APP_ONLY)),
+                    Map.entry("pyi-triage-select-smartphone", Set.of(DEVICE_TYPE)),
                     Map.entry(
-                            "need-more-information-confirm-change-details", Set.of("journeyType")),
-                    Map.entry("no-photo-id-web-find-another-way", Set.of("reason")),
-                    Map.entry("page-dcmaw-success", Set.of("noAddress")),
-                    Map.entry("page-ipv-success", Set.of("journeyType")),
-                    Map.entry("page-multiple-doc-check", Set.of("allowNino")),
-                    Map.entry("page-update-name", Set.of("journeyType")),
-                    Map.entry("photo-id-web-find-another-way", Set.of("reason")),
-                    Map.entry("prove-identity-another-type-photo-id", Set.of("invalidDoc")),
-                    Map.entry("prove-identity-another-way", Set.of("removeF2f")),
-                    Map.entry("prove-identity-no-other-photo-id", Set.of("invalidDoc")),
-                    Map.entry("prove-identity-no-photo-id", Set.of("ninoOnly")),
-                    Map.entry("pyi-no-match", Set.of("reason")),
-                    Map.entry("pyi-technical", Set.of("isUnrecoverable")),
-                    Map.entry("pyi-triage-desktop-download-app", Set.of("smartphone", "isAppOnly")),
-                    Map.entry("pyi-triage-mobile-download-app", Set.of("smartphone", "isAppOnly")),
-                    Map.entry("pyi-triage-select-smartphone", Set.of("deviceType")),
-                    Map.entry("sorry-could-not-confirm-details", Set.of("isExistingIdentityValid")),
-                    Map.entry("sorry-technical-problem", Set.of("reason")),
+                            "sorry-could-not-confirm-details", Set.of(IS_EXISTING_IDENTITY_VALID)),
+                    Map.entry("sorry-technical-problem", Set.of(REASON)),
                     Map.entry(
-                            "uk-driving-licence-details-not-correct", Set.of("isFromStrategicApp")),
-                    Map.entry("update-details-failed", Set.of("isExistingIdentityInvalid")),
-                    Map.entry("update-name-date-birth", Set.of("journeyType")));
+                            "uk-driving-licence-details-not-correct",
+                            Set.of(IS_FROM_STRATEGIC_APP)),
+                    Map.entry("update-details-failed", Set.of(IS_EXISTING_IDENTITY_INVALID)),
+                    Map.entry("update-name-date-birth", Set.of(JOURNEY_TYPE)));
 
     @Override
     Map<String, Set<String>> getAllowedContextsByPage() {

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -9,13 +9,11 @@ public class PageContextValidator extends AbstractPageContextValidator {
                     Map.entry("delete-handover", Set.of("journeyType")),
                     Map.entry(
                             "need-more-information-confirm-change-details", Set.of("journeyType")),
-                    Map.entry("no-photo-id-security-questions-find-another-way", Set.of("reason")),
                     Map.entry("no-photo-id-web-find-another-way", Set.of("reason")),
                     Map.entry("page-dcmaw-success", Set.of("noAddress")),
                     Map.entry("page-ipv-success", Set.of("journeyType")),
                     Map.entry("page-multiple-doc-check", Set.of("allowNino")),
                     Map.entry("page-update-name", Set.of("journeyType")),
-                    Map.entry("photo-id-security-questions-find-another-way", Set.of("reason")),
                     Map.entry("photo-id-web-find-another-way", Set.of("reason")),
                     Map.entry("prove-identity-another-type-photo-id", Set.of("invalidDoc")),
                     Map.entry("prove-identity-another-way", Set.of("removeF2f")),

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -323,27 +323,6 @@ states:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
 
-  PYI_KBV_DROPOUT_PHOTO_ID:
-    response:
-      type: page
-      pageId: photo-id-security-questions-find-another-way
-      pageContext:
-        reason: dropout
-    events:
-      appTriage:
-        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmawAsync:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START_MEDIUM_CONFIDENCE
-        checkIfDisabled:
-          f2f:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-
   DROPOUT_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
     response:
       type: page
@@ -558,28 +537,6 @@ states:
       return-to-rp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
-  MITIGATION_KBV_FAIL_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: no-photo-id-security-questions-find-another-way
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START_MEDIUM_CONFIDENCE
-        checkIfDisabled:
-          f2f:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriage:
-        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmawAsync:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
-
   MITIGATION_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
     response:
       type: page
@@ -637,30 +594,6 @@ states:
       relyingParty:
         targetJourney: INELIGIBLE
         targetState: INELIGIBLE_SKIP_MESSAGE
-
-  PYI_KBV_DROPOUT_NO_PHOTO_ID:
-    response:
-      type: page
-      pageId: no-photo-id-security-questions-find-another-way
-      pageContext:
-        reason: dropout
-    events:
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START_MEDIUM_CONFIDENCE
-        checkIfDisabled:
-          f2f:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      appTriage:
-        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmawAsync:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      end:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
 
   DROPOUT_NO_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
     response:
@@ -772,25 +705,6 @@ states:
             targetState: INELIGIBLE
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
-
-  MITIGATION_KBV_FAIL_PHOTO_ID:
-    response:
-      type: page
-      pageId: photo-id-security-questions-find-another-way
-    events:
-      appTriage:
-        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
-        checkIfDisabled:
-          dcmawAsync:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
-      f2f:
-        targetJourney: F2F_HAND_OFF
-        targetState: START_MEDIUM_CONFIDENCE
-        checkIfDisabled:
-          f2f:
-            targetJourney: TECHNICAL_ERROR
-            targetState: ERROR
 
   MITIGATION_PHOTO_ID_WEB_FIND_ANOTHER_WAY:
     response:

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/TestPageContextValidator.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/TestPageContextValidator.java
@@ -6,8 +6,8 @@ import java.util.Set;
 public class TestPageContextValidator extends AbstractPageContextValidator {
     private static final Map<String, Set<String>> ALLOWED_CONTEXTS_BY_PAGE =
             Map.ofEntries(
-                    Map.entry("page-id-for-page-state", Set.of("reason")),
-                    Map.entry("page-with-missing-context", Set.of("reason", "journeyType")));
+                    Map.entry("page-id-for-page-state", Set.of(REASON)),
+                    Map.entry("page-with-missing-context", Set.of(REASON, JOURNEY_TYPE)));
 
     @Override
     Map<String, Set<String>> getAllowedContextsByPage() {


### PR DESCRIPTION
## Proposed changes
### What changed

- Clean unused resources

### Why did it change

Pages:
 - photo-id-security-questions-find-another-way
 - no-photo-id-security-questions-find-another-way
 
renamed to:
 - photo-id-web-find-another-way
 - no-photo-id-web-find-another-way


### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

⚠️ REBASING REQUIRED AFTER THIS [PR](https://github.com/govuk-one-login/ipv-core-back/pull/4050) ⚠️ 

- [PYIC-9170](https://govukverify.atlassian.net/browse/PYIC-9170)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9170]: https://govukverify.atlassian.net/browse/PYIC-9170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ