### PR TITLE
Pyic 9028 add journey count alarm

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3908,6 +3908,62 @@ Resources:
           Label: "DWP KBV CRI Return Rate"
           ReturnData: true
 
+  JourneyStartsTooHighAlarm:
+    Condition: IsNotDevelopment
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: "Trigger the alarm if we have a high enough rate of journey starts to cause issues for downstream services"
+      AlarmName: !Sub "${AWS::StackName}-JourneyStartsTooHighAlarm"
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue di-ipv-core-notifications-WarningAlertsTopicArn
+      OKActions:
+        - !ImportValue di-ipv-core-notifications-WarningAlertsTopicArn
+      InsufficientDataActions: [ ]
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: processJourneyEvent
+          MetricStat:
+            Metric:
+              Namespace: !Sub "CoreBackEmbeddedMetrics-${Environment}"
+              MetricName: identityProving
+              Dimensions:
+                - Name: Service
+                  Value: !Sub "process-journey-event-${Environment}"
+            Period: 300 # 5 minutes
+            Stat: Sum
+          ReturnData: false
+        - Id: checkExistingIdentity
+          MetricStat:
+            Metric:
+              Namespace: !Sub "CoreBackEmbeddedMetrics-${Environment}"
+              MetricName: identityProving
+              Dimensions:
+                - Name: Service
+                  Value: !Sub "check-existing-identity-${Environment}"
+            Period: 300 # 5 minutes
+            Stat: Sum
+          ReturnData: false
+        - Id: checkReverificationIdentity
+          MetricStat:
+            Metric:
+              Namespace: !Sub "CoreBackEmbeddedMetrics-${Environment}"
+              MetricName: identityProving
+              Dimensions:
+                - Name: Service
+                  Value: !Sub "check-reverification-identity-${Environment}"
+            Period: 300 # 5 minutes
+            Stat: Sum
+          ReturnData: false
+        - Id: totalJps
+          Expression: "(processJourneyEvent + checkExistingIdentity + checkReverificationIdentity) / 300"
+          Label: "Total journey starts per second"
+          ReturnData: true
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 18
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+
   ####################################################################
   #                                                                  #
   # Canary Alarms for individual lambdas                             #

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3908,13 +3908,13 @@ Resources:
           Label: "DWP KBV CRI Return Rate"
           ReturnData: true
 
-  JourneyStartsTooHighAlarm:
+  ProvingJourneyStartsTooHighAlarm:
 #    Condition: IsNotDevelopment
     Condition: IsBuild
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmDescription: "Trigger the alarm if we have a high enough rate of journey starts to cause issues for downstream services"
-      AlarmName: !Sub "${AWS::StackName}-JourneyStartsTooHighAlarm"
+      AlarmName: !Sub "${AWS::StackName}-ProvingJourneyStartsTooHighAlarm"
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue di-ipv-core-notifications-WarningAlertsTopicArn

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -3909,7 +3909,8 @@ Resources:
           ReturnData: true
 
   JourneyStartsTooHighAlarm:
-    Condition: IsNotDevelopment
+#    Condition: IsNotDevelopment
+    Condition: IsBuild
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmDescription: "Trigger the alarm if we have a high enough rate of journey starts to cause issues for downstream services"
@@ -3961,7 +3962,8 @@ Resources:
           ReturnData: true
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: 18
+#      Threshold: 18
+      Threshold: 0.017 # 1 journey per minute
       ComparisonOperator: GreaterThanOrEqualToThreshold
 
   ####################################################################


### PR DESCRIPTION
## Proposed changes
### What changed

Added alarm that triggers in build if there is more than 1 journey per minute for 5 minutes

### Why did it change

To test the alarm config so we can use it in prod

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9028](https://govukverify.atlassian.net/browse/PYIC-9028)


[PYIC-9028]: https://govukverify.atlassian.net/browse/PYIC-9028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ