### PR TITLE
PYIC-9083: Enable coi6mfcDeadEndRoutingEnabled feature flag in local environment.

### DIFF
--- a/api-tests/features/coi6mfcDeadEndRoutingDisbaled.feature
+++ b/api-tests/features/coi6mfcDeadEndRoutingDisbaled.feature
@@ -1,0 +1,256 @@
+# Remove this file as part of PYIC-9123
+Feature: coi6mfcDeadEndRouting disabled
+  Rule: Given name change only - disabled coi6mfcDeadEndRoutingEnabled
+    Background:
+      Given the subject already has the following credentials
+      | CRI     | scenario               |
+      | dcmaw   | kenneth-passport-valid |
+      | address | kenneth-current        |
+      And the subject already has the following expired credentials
+      | CRI   | scenario        |
+      | fraud | kenneth-score-2 |
+      And I activate the 'coi6mfcDeadEndRoutingDisabled' feature set
+      And I have an existing stored identity record with a 'P3' vot
+      When I start a new 'medium-confidence' journey
+      Then I get a 'confirm-your-details' page response
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response and pageContext
+      | Context     | Value            |
+      | journeyType | repeatFraudCheck |
+
+    Scenario: Applicable authoritative source failed check evidence too weak - disabled coi6mfcDeadEndRoutingEnabled
+      When I submit a 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+      | Context    | Value   |
+      | smartphone | android |
+      | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response and pageContext
+      | Context   | Value |
+      | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
+      | Context                 | Value |
+      | isExistingIdentityValid | false |
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I have a stored identity record with a 'P3' max vot that is 'invalid'
+
+    Scenario: Available authoritative source failed check evidence too weak - disabled coi6mfcDeadEndRoutingEnabled
+      When I submit a 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+      | Context    | Value   |
+      | smartphone | android |
+      | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response and pageContext
+      | Context   | Value |
+      | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
+      | Context                 | Value |
+      | isExistingIdentityValid | false |
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I have a stored identity record with a 'P3' max vot that is 'invalid'
+
+    Scenario: Failed update name due to DCMAW Async
+      And I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | true   |
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'fail' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'update-details-failed' page response and pageContext
+        | Context                   | Value |
+        | isExistingIdentityInvalid | true  |
+      When I submit a 'return-to-service' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+
+  Rule: M1A
+    Scenario: Existing M1A user cannot change name with DL and unavailable fraud check
+      Given the subject already has the following credentials
+      | CRI           | scenario                     |
+      | dcmawAsync    | kenneth-passport-valid       |
+      | address       | kenneth-current              |
+      | fraud         | kenneth-score-2              |
+      And I activate the 'coi6mfcDeadEndRoutingDisabled' feature set
+      And I have an existing stored identity record with a 'P3' vot
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-reuse' page response
+      When I submit a 'update-details' event
+      Then I get a 'update-details' page response
+      When I submit a 'family-name-only' event
+      Then I get a 'page-update-name' page response
+      When I submit a 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+      | Context    | Value   |
+      | smartphone | android |
+      | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-changed-family-name-driving-permit-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-changed-family-name-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response and pageContext
+      | Context   | Value |
+      | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-family-name-unavailable' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
+      | Context                 | Value |
+      | isExistingIdentityValid | true  |
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+
+  Rule: Update given name only - disabled coi6mfcDeadEndRoutingEnabled
+    Background:
+      Given the subject already has the following credentials
+      | CRI     | scenario               |
+      | dcmaw   | kenneth-passport-valid |
+      | address | kenneth-current        |
+      | fraud   | kenneth-score-2        |
+      And I activate the 'coi6mfcDeadEndRoutingDisabled' feature set
+      And I have an existing stored identity record with a 'P3' vot
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-reuse' page response
+      When I submit an 'update-details' event
+      Then I get an 'update-details' page response
+      When I submit a 'given-names-only' event
+      Then I get a 'page-update-name' page response
+
+    Scenario: Zero score in fraud CRI - receives old identity (P2)
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+      | Context    | Value   |
+      | smartphone | android |
+      | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-changed-given-name-driving-permit-valid' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response and pageContext
+      | Context   | Value |
+      | noAddress | true  |
+      When I submit a 'next' event
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
+      | Context                 | Value |
+      | isExistingIdentityValid | true  |
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+
+    Scenario: fail-with-no-ci from DCMAW
+      When I submit an 'update-name' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+      | Context    | Value   |
+      | smartphone | android |
+      | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'update-details-failed' page response
+      When I submit a 'continue' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+      When I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-reuse' page response

--- a/api-tests/features/m1c-journeys.feature
+++ b/api-tests/features/m1c-journeys.feature
@@ -397,10 +397,10 @@ Feature: M1C Unavailable Journeys
       When I submit 'kenneth-changed-family-name-unavailable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
-        | Context                 | Value |
-        | isExistingIdentityValid | true  |
-      When I submit a 'returnToRp' event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value             |
+        | journeyType          | updateDetails     |
+      When I submit a 'continueToService' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I am issued a 'P2' identity

--- a/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
+++ b/api-tests/features/repeat-fraud-check/p2-repeat-fraud-check-failure.feature
@@ -70,9 +70,9 @@ Feature: Repeat fraud check failures
       When I submit 'kenneth-no-applicable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
-        | Context                 | Value |
-        | isExistingIdentityValid | false |
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value             |
+        | journeyType          | repeatFraudCheck     |
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -109,9 +109,9 @@ Feature: Repeat fraud check failures
       When I submit 'kenneth-unavailable' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get an 'sorry-could-not-confirm-details' page response and pageContext
-        | Context                 | Value |
-        | isExistingIdentityValid | false |
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value             |
+        | journeyType          | repeatFraudCheck     |
       When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
@@ -250,10 +250,10 @@ Feature: Repeat fraud check failures
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
-      Then I get an 'update-details-failed' page response and pageContext
-        | Context                   | Value |
-        | isExistingIdentityInvalid | true  |
-      When I submit a 'return-to-service' event
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value             |
+        | journeyType          | repeatFraudCheck  |
+      When I submit a 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I am issued a 'P0' identity

--- a/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
+++ b/api-tests/features/reuse-update-details/p2-reuse-update-details-failure.feature
@@ -100,8 +100,10 @@ Feature: Identity reuse update details failures
             And I poll for async DCMAW credential receipt
             Then the poll returns a '201'
             When I submit the returned journey event
-            Then I get an 'update-details-failed' page response
-            When I submit a 'continue' event
+            Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+                | Context              | Value             |
+                | journeyType          | updateDetails     |
+            When I submit a 'continueToService' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
             Then I am issued a 'P2' identity
@@ -254,10 +256,10 @@ Feature: Identity reuse update details failures
             When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
                 | Attribute          | Values                   |
                 | evidence_requested | {"identityFraudScore":2} |
-            Then I get an 'sorry-could-not-confirm-details' page response and pageContext
-                | Context                 | Value |
-                | isExistingIdentityValid | true  |
-            When I submit a 'returnToRp' event
+            Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+                | Context              | Value             |
+                | journeyType          | updateDetails     |
+            When I submit a 'continueToService' event
             Then I get an OAuth response
             When I use the OAuth response to get my identity
             Then I am issued a 'P2' identity

--- a/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
+++ b/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
@@ -10,7 +10,6 @@ Feature: Update details higher strength
         | CRI   | scenario        |
         | fraud | kenneth-score-2 |
       And I have an existing stored identity record with a 'P3' vot
-      And I activate the 'coi6mfcDeadEndRouting' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'confirm-your-details' page response
 
@@ -40,7 +39,7 @@ Feature: Update details higher strength
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value             |
         | journeyType          | repeatFraudCheck  |
-      When I submit an 'passport' event  
+      When I submit an 'passport' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
@@ -67,7 +66,7 @@ Feature: Update details higher strength
         | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response and pageContext
         | Context     | Value |
-        | journeyType | coi   | 
+        | journeyType | coi   |
 
     Scenario: Successful 6MFC identity recovery via App for Name change only
       When I submit a 'given-names-only' event
@@ -95,7 +94,7 @@ Feature: Update details higher strength
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value             |
         | journeyType          | repeatFraudCheck  |
-      When I submit an 'passport' event  
+      When I submit an 'passport' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
@@ -122,7 +121,7 @@ Feature: Update details higher strength
         | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response and pageContext
         | Context     | Value |
-        | journeyType | coi   | 
+        | journeyType | coi   |
 
     Scenario: User abandons 6MFC App recovery
       When I submit a 'given-names-only' event
@@ -150,7 +149,7 @@ Feature: Update details higher strength
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value            |
         | journeyType          | repeatFraudCheck |
-      When I submit an 'passport' event  
+      When I submit an 'passport' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
@@ -171,7 +170,7 @@ Feature: Update details higher strength
       Then I get a 'pyi-no-match' page response and pageContext
         | Context | Value            |
         | reason  | repeatFraudCheck |
-    
+
     Scenario: 6MFC identity recovery via App for Name change only profile unmet
       When I submit a 'given-names-only' event
       Then I get a 'page-update-name' page response and pageContext
@@ -208,7 +207,7 @@ Feature: Update details higher strength
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value            |
         | journeyType          | repeatFraudCheck |
-      When I submit an 'passport' event  
+      When I submit an 'passport' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
@@ -235,7 +234,7 @@ Feature: Update details higher strength
         | evidence_requested | {"identityFraudScore":1} |
       Then I get a 'page-ipv-success' page response and pageContext
         | Context     | Value |
-        | journeyType | coi   | 
+        | journeyType | coi   |
 
 
   Rule: Update details
@@ -246,7 +245,6 @@ Feature: Update details higher strength
         | address | kenneth-current        |
         | fraud   | kenneth-score-2        |
       And I have an existing stored identity record with a 'P3' vot
-      And I activate the 'coi6mfcDeadEndRouting' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'page-ipv-reuse' page response
       When I submit a 'update-details' event
@@ -276,7 +274,7 @@ Feature: Update details higher strength
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value         |
         | journeyType          | updateDetails |
-      When I submit an 'passport' event  
+      When I submit an 'passport' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
@@ -329,7 +327,7 @@ Feature: Update details higher strength
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value         |
         | journeyType          | updateDetails |
-      When I submit an 'passport' event  
+      When I submit an 'passport' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
@@ -382,7 +380,7 @@ Feature: Update details higher strength
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value         |
         | journeyType          | updateDetails |
-      When I submit an 'passport' event  
+      When I submit an 'passport' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
@@ -427,7 +425,7 @@ Feature: Update details higher strength
       Then I get an 'need-more-information-confirm-change-details' page response and pageContext
         | Context              | Value         |
         | journeyType          | updateDetails |
-      When I submit an 'passport' event  
+      When I submit an 'passport' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -382,7 +382,7 @@ core:
     sisVerificationEnabled: true
     evcsApiUpdatesEnabled: true
     mitigations9020Enabled: false
-    coi6mfcDeadEndRoutingEnabled: false
+    coi6mfcDeadEndRoutingEnabled: true
 
   features:
     coi6mfcDeadEndRouting:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -388,6 +388,9 @@ core:
     coi6mfcDeadEndRouting:
       featureFlags:
         coi6mfcDeadEndRoutingEnabled: true
+    coi6mfcDeadEndRoutingDisabled:
+      featureFlags:
+        coi6mfcDeadEndRoutingEnabled: false
     openBanking:
       credentialIssuers:
         openBanking:


### PR DESCRIPTION
## Proposed changes
### What changed

- Enabled coi6mfcDeadEndRoutingEnabled in local environment
- Removed feature flag enabling step in api tests for above flag

### Why did it change

After PYIC-8711: Avoid a dead end for COI users- part 3 (routing scenarios) has been completed, and the Contact Centre are ready for IPV Core to launch this piece of work (agreed anytime from 18th May), the feature flag can be enabled for lower environments.

This was previously done but reverted in order to fix an issue found:
PYIC-9149: Fix COI/6MFC dead end routing M1C profile matching.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9083](https://govukverify.atlassian.net/browse/PYIC-9083)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9083]: https://govukverify.atlassian.net/browse/PYIC-9083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ