### PR TITLE
BAU: Adjust test data user age

### DIFF
--- a/api-tests/data/audit-events/repeat-fraud-check-no-update.json
+++ b/api-tests/data/audit-events/repeat-fraud-check-no-update.json
@@ -76,7 +76,7 @@
         }
       ],
       "successful": true,
-      "age": 60
+      "age": 61
     },
     "restricted": {
       "device_information": {}


### PR DESCRIPTION

## Proposed changes
### What changed

- Update test user age
- A ticket will be raised to handle this more efficiently

### Why did it change

- As of today the test user has turned a year older and therefore causing api-test to fail


## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>
