### PR TITLE
PYIC-9189: Update awsSdk and jackson dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-awsSdk = "2.46.11"
-jackson = "2.22.0"
+awsSdk = "2.47.3"
+jackson = "2.22.1"
 log4j = "2.26.0"
 mockito = "5.21.0"
 pact = "4.7.3"


### PR DESCRIPTION
## Proposed changes
### What changed

- Update awsSdk and jackson dependencies

### Why did it change

- To resolve security vulnerabilities

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9189](https://govukverify.atlassian.net/browse/PYIC-9189)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9189]: https://govukverify.atlassian.net/browse/PYIC-9189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ