### PR TITLE
PYIC-9213: Update journey state for coi/6mfc address only failure

### DIFF
--- a/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
+++ b/api-tests/features/update-details-higher-strengh/update-details-higher-strengh.feature
@@ -303,7 +303,7 @@ Feature: Update details higher strength
         | Context     | Value |
         | journeyType | coi   |
 
-    Scenario: COI recovery fails at final Fraud check
+    Scenario: COI recovery fails at final Fraud check - given name only
       When I submit a 'given-names-only' event
       Then I get a 'page-update-name' page response
       When I submit an 'update-name' event
@@ -355,6 +355,18 @@ Feature: Update details higher strength
       Then I get a 'pyi-no-match' page response and pageContext
         | Context | Value         |
         | reason  | updateDetails |
+
+    Scenario: COI recovery when failing initial fraud check - address only
+      When I submit a 'address-only' event
+      Then I get a 'address' CRI response
+      When I submit 'kenneth-changed' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-changed-given-name-score-0' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get an 'need-more-information-confirm-change-details' page response and pageContext
+        | Context              | Value         |
+        | journeyType          | updateDetails |
 
     Scenario: User fails twice with app
       When I submit a 'given-names-only' event

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-address.yaml
@@ -71,6 +71,10 @@ states:
         targetState: FAILED
       fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_UPDATE_IDENTITY
+        checkFeatureFlag:
+          coi6mfcDeadEndRoutingEnabled:
+            targetJourney: UPDATE_DETAILS_HIGHER_STRENGTH
+            targetState: START_HIGHER_STRENGTH
 
   PROCESS_UPDATE_IDENTITY:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/update-details-higher-strength.yaml
@@ -1,7 +1,7 @@
 name: Update Name Higher Strength
 
 description: >-
-  A journey for users to retry with higher srength doc
+  A journey for users to retry with higher strength doc
 
 states:
 
@@ -23,7 +23,10 @@ states:
         journeyType: updateDetails
     events:
       passport:
-        targetState: RESET_IDENTITY_BEFORE_NEW_IDENTITY
+        targetState: RESET_IDENTITY_BEFORE_NEW_IDENTITY_NAMES_ONLY
+        checkJourneyContext:
+          nameAndAddress:
+            targetState: RESET_IDENTITY_BEFORE_NEW_IDENTITY_NAMES_WITH_ADDRESS
       continueToService:
         targetState: REINSTATE_EXISTING_IDENTITY
 
@@ -35,7 +38,10 @@ states:
         journeyType: repeatFraudCheck
     events:
       passport:
-        targetState: RESET_IDENTITY_BEFORE_NEW_IDENTITY
+        targetState: RESET_IDENTITY_BEFORE_NEW_IDENTITY_NAMES_ONLY
+        checkJourneyContext:
+          nameAndAddress:
+            targetState: RESET_IDENTITY_BEFORE_NEW_IDENTITY_NAMES_WITH_ADDRESS
       returnToRp:
         targetJourney: FAILED
         targetState: FAILED_SKIP_MESSAGE
@@ -452,7 +458,18 @@ states:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
 
-  RESET_IDENTITY_BEFORE_NEW_IDENTITY:
+  RESET_IDENTITY_BEFORE_NEW_IDENTITY_NAMES_ONLY:
+    response:
+      type: process
+      lambda: reset-identity
+      lambdaInput:
+        resetType: NAME_ONLY_CHANGE
+    events:
+      next:
+        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
+        targetEntryEvent: identify-device
+
+  RESET_IDENTITY_BEFORE_NEW_IDENTITY_NAMES_WITH_ADDRESS:
     response:
       type: process
       lambda: reset-identity

--- a/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
+++ b/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
@@ -41,6 +41,7 @@ import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
+import static uk.gov.di.ipv.core.library.enums.IdentityResetType.NAME_ONLY_CHANGE;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.PENDING_DCMAW_ASYNC_ALL;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.REINSTATE;
@@ -159,7 +160,7 @@ public class ResetIdentityHandler implements RequestHandler<ProcessRequest, Map<
                                         input.getDeviceInformation())));
             }
 
-            if (resetType.equals(PENDING_DCMAW_ASYNC_ALL)) {
+            if (resetType.equals(PENDING_DCMAW_ASYNC_ALL) || resetType.equals(NAME_ONLY_CHANGE)) {
                 resetPendingIdentity(clientOAuthSessionItem, DCMAW_ASYNC);
             }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/IdentityResetType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/IdentityResetType.java
@@ -7,7 +7,7 @@ public enum IdentityResetType {
     DCMAW,
     /** Deletes only DCMAW_ASYNC VC from session. */
     DCMAW_ASYNC,
-    /** Deletes all session VCs except address. */
+    /** Deletes all session + pending VCs except address. */
     NAME_ONLY_CHANGE,
     /** Deletes address + fraud VCs from session. */
     ADDRESS_ONLY_CHANGE,

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -257,18 +257,34 @@ class SessionCredentialsServiceTest {
             var fraudVc =
                     generateVerifiableCredential(
                             "userId", EXPERIAN_FRAUD, vcClaimFailedWithCis(null));
+            var dcmawAsyncVc =
+                    generateVerifiableCredential("userId", DCMAW_ASYNC, vcClaimFailedWithCis(null));
+            var dcmawVc = generateVerifiableCredential("userId", DCMAW, vcClaimFailedWithCis(null));
 
-            var sessionFraudCredentialItem = fraudVc.toSessionCredentialItem(SESSION_ID, true);
             var sessionAddressCredentialItem = addressVc.toSessionCredentialItem(SESSION_ID, true);
+            var sessionFraudCredentialItem = fraudVc.toSessionCredentialItem(SESSION_ID, true);
+            var sessionDcmawAsyncCredentialItem =
+                    dcmawAsyncVc.toSessionCredentialItem(SESSION_ID, true);
+            var sessionDcmawCredentialItem = dcmawVc.toSessionCredentialItem(SESSION_ID, true);
 
             when(mockDataStore.getItems(SESSION_ID))
-                    .thenReturn(List.of(sessionFraudCredentialItem, sessionAddressCredentialItem));
+                    .thenReturn(
+                            List.of(
+                                    sessionAddressCredentialItem,
+                                    sessionFraudCredentialItem,
+                                    sessionDcmawAsyncCredentialItem,
+                                    sessionDcmawCredentialItem));
 
             sessionCredentialService.deleteSessionCredentialsForResetType(
                     SESSION_ID, NAME_ONLY_CHANGE);
 
             verify(mockDataStore).getItems(SESSION_ID);
-            verify(mockDataStore).delete(List.of(sessionFraudCredentialItem));
+            verify(mockDataStore)
+                    .delete(
+                            List.of(
+                                    sessionFraudCredentialItem,
+                                    sessionDcmawAsyncCredentialItem,
+                                    sessionDcmawCredentialItem));
         }
 
         @Test
@@ -279,7 +295,6 @@ class SessionCredentialsServiceTest {
             var fraudVc =
                     generateVerifiableCredential(
                             "userId", EXPERIAN_FRAUD, vcClaimFailedWithCis(null));
-
             var dcmawVc = generateVerifiableCredential("userId", DCMAW, vcClaimFailedWithCis(null));
 
             var sessionFraudCredentialItem = fraudVc.toSessionCredentialItem(SESSION_ID, true);


### PR DESCRIPTION
## Proposed changes
### What changed

- Update journey state for coi/6mfc address only failure

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9213](https://govukverify.atlassian.net/browse/PYIC-9213)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9213]: https://govukverify.atlassian.net/browse/PYIC-9213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ