### PR TITLE
PYIC-9067: Add mitigation routes for returning users

### DIFF
--- a/api-tests/features/fraud-mitigation/p1-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p1-mitigation.feature
@@ -60,6 +60,31 @@ Feature: P1 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
+    Scenario: Breaching fraud CI goes to mitigation route
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      # New journey
+      When I start a new 'low-confidence' journey
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+
+    Scenario: Breaching fraud CI goes back to RP
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      # New journey
+      When I start a new 'low-confidence' journey
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
   Rule: Photo ID app journey
     Background: Start P1 driving licence app journey
       When I start a new 'low-confidence' journey

--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -64,6 +64,31 @@ Feature: P2 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
+    Scenario: Breaching fraud CI and user returns later goes to mitigation route
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      # New journey
+      When I start a new 'medium-confidence' journey
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+
+    Scenario: Breaching fraud CI and user returns later goes back to RP
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      # New journey
+      When I start a new 'medium-confidence' journey
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
   Rule: Photo ID app journey
     Background: Start P2 driving licence app journey
       When I start a new 'medium-confidence' journey

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -23,6 +23,8 @@ states:
               - IPV_MITIGATION_START
             auditContext:
               mitigationType: enhanced-verification
+          liveness-likeness:
+            targetState: MITIGATE_CI_VIA_APP
 
   KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
     events:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -23,6 +23,8 @@ states:
               - IPV_MITIGATION_START
             auditContext:
               mitigationType: enhanced-verification
+          liveness-likeness:
+            targetState: MITIGATE_CI_VIA_APP
 
   KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
     events:


### PR DESCRIPTION
## Proposed changes
### What changed

Added routing for returning users with unmitigated CIs

### Why did it change

We're adding new routes

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9067](https://govukverify.atlassian.net/browse/PYIC-9067)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated

[PYIC-9067]: https://govukverify.atlassian.net/browse/PYIC-9067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ