### PR TITLE
Pyic 9059 post ob photo id routing

### DIFF
--- a/api-tests/data/audit-events/dwp-kbv-dropout-user-abandons-cri-no-open-banking.json
+++ b/api-tests/data/audit-events/dwp-kbv-dropout-user-abandons-cri-no-open-banking.json
@@ -201,33 +201,6 @@
     }
   },
   {
-    "event_name": "IPV_REDIRECT_TO_CRI",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_CRI_AUTH_RESPONSE_RECEIVED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "extensions": {
-      "error_code": "access_denied",
-      "error_description": "No error description provided",
-      "credential_issuer_id": null
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_DWP_KBV_HANDOFF_START",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
@@ -268,20 +241,9 @@
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
-      "error_code": "invalid_request",
+      "error_code": "access_denied",
       "error_description": "No error description provided",
       "credential_issuer_id": null
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_DWP_KBV_CRI_THIN_FILE_ENCOUNTERED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/dwp-kbv-dropout-user-abandons-cri.json
+++ b/api-tests/data/audit-events/dwp-kbv-dropout-user-abandons-cri.json
@@ -201,6 +201,33 @@
     }
   },
   {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CRI_AUTH_RESPONSE_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "error_code": "access_denied",
+      "error_description": "No error description provided",
+      "credential_issuer_id": null
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_DWP_KBV_HANDOFF_START",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {

--- a/api-tests/data/audit-events/dwp-kbv-dropout-via-thin-file-no-open-banking.json
+++ b/api-tests/data/audit-events/dwp-kbv-dropout-via-thin-file-no-open-banking.json
@@ -201,33 +201,6 @@
     }
   },
   {
-    "event_name": "IPV_REDIRECT_TO_CRI",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_CRI_AUTH_RESPONSE_RECEIVED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "extensions": {
-      "error_code": "access_denied",
-      "error_description": "No error description provided",
-      "credential_issuer_id": null
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_DWP_KBV_HANDOFF_START",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {

--- a/api-tests/data/audit-events/dwp-kbv-successful-journey-no-open-banking.json
+++ b/api-tests/data/audit-events/dwp-kbv-successful-journey-no-open-banking.json
@@ -201,33 +201,6 @@
     }
   },
   {
-    "event_name": "IPV_REDIRECT_TO_CRI",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_CRI_AUTH_RESPONSE_RECEIVED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "extensions": {
-      "error_code": "access_denied",
-      "error_description": "No error description provided",
-      "credential_issuer_id": null
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_DWP_KBV_HANDOFF_START",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
@@ -261,27 +234,232 @@
     }
   },
   {
-    "event_name": "IPV_CRI_AUTH_RESPONSE_RECEIVED",
+    "event_name": "IPV_DWP_KBV_CRI_VC_ISSUED",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
-      "error_code": "invalid_request",
-      "error_description": "No error description provided",
-      "credential_issuer_id": null
+      "iss": "https://dwp-kbv-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "checkDetails": [
+            {
+              "checkMethod": "kbv",
+              "kbvQuality": 3,
+              "kbvResponseMode": "multiple_choice"
+            },
+            {
+              "checkMethod": "kbv",
+              "kbvQuality": 3,
+              "kbvResponseMode": "multiple_choice"
+            },
+            {
+              "checkMethod": "kbv",
+              "kbvQuality": 2,
+              "kbvResponseMode": "multiple_choice"
+            }
+          ],
+          "type": "IdentityCheck",
+          "verificationScore": 2
+        }
+      ],
+      "successful": true,
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}
     }
   },
   {
-    "event_name": "IPV_DWP_KBV_CRI_THIN_FILE_ENCOUNTERED",
+    "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "iss": "https://dwp-kbv-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "checkDetails": [
+            {
+              "checkMethod": "kbv",
+              "kbvQuality": 3,
+              "kbvResponseMode": "multiple_choice"
+            },
+            {
+              "checkMethod": "kbv",
+              "kbvQuality": 3,
+              "kbvResponseMode": "multiple_choice"
+            },
+            {
+              "checkMethod": "kbv",
+              "kbvQuality": 2,
+              "kbvResponseMode": "multiple_choice"
+            }
+          ],
+          "type": "IdentityCheck",
+          "verificationScore": 2
+        }
+      ],
+      "successful": true,
+      "age": "type[number]"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "cri": "dwpKbv",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "type": "STANDARD"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "type": "STANDARD",
+      "successful": true
+    },
+    "restricted": {
+      "newName": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "KENNETH"
+            },
+            {
+              "type": "FamilyName",
+              "value": "DECERQUEIRA"
+            }
+          ]
+        }
+      ],
+      "newBirthDate": [
+        {
+          "value": "1965-07-08"
+        }
+      ],
+      "newAddress": [
+        {
+          "addressCountry": "GB",
+          "addressLocality": "BATH",
+          "buildingName": "",
+          "buildingNumber": "8",
+          "postalCode": "BA2 5AA",
+          "streetName": "HADLEY ROAD",
+          "subBuildingName": "",
+          "uprn": 100120012077,
+          "validFrom": "1000-01-01"
+        }
+      ],
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 2
+      },
+      "vcTxnIds": ["type[string]", "type[string]", "type[string]"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "identity_type": "new",
+      "sis_record_created": true,
+      "vot": "P2",
+      "max_vot": "P2"
     },
     "restricted": {
       "device_information": {}

--- a/api-tests/data/audit-events/dwp-kbv-successful-journey.json
+++ b/api-tests/data/audit-events/dwp-kbv-successful-journey.json
@@ -201,6 +201,33 @@
     }
   },
   {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CRI_AUTH_RESPONSE_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "error_code": "access_denied",
+      "error_description": "No error description provided",
+      "credential_issuer_id": null
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
     "event_name": "IPV_DWP_KBV_HANDOFF_START",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {

--- a/api-tests/data/audit-events/new-identity-p2-web-journey-kbv.json
+++ b/api-tests/data/audit-events/new-identity-p2-web-journey-kbv.json
@@ -4,6 +4,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
@@ -18,6 +19,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
@@ -32,6 +34,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "restricted": {
@@ -43,6 +46,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
@@ -75,6 +79,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
@@ -90,6 +95,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "restricted": {
@@ -101,6 +107,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
@@ -117,6 +124,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
@@ -132,6 +140,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "restricted": {
@@ -143,6 +152,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
@@ -190,6 +200,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
@@ -201,37 +212,11 @@
     }
   },
   {
-    "event_name": "IPV_REDIRECT_TO_CRI",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_CRI_AUTH_RESPONSE_RECEIVED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "extensions": {
-      "error_code": "access_denied",
-      "error_description": "No error description provided",
-      "credential_issuer_id": null
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_DWP_KBV_HANDOFF_START",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "restricted": {
@@ -243,6 +228,7 @@
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "restricted": {
@@ -250,41 +236,231 @@
     }
   },
   {
-    "event_name": "IPV_DWP_KBV_CRI_START",
+    "event_name": "IPV_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
-    "event_name": "IPV_CRI_AUTH_RESPONSE_RECEIVED",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
-      "error_code": "invalid_request",
-      "error_description": "No error description provided",
-      "credential_issuer_id": null
+      "iss": "https://experian-kbv-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "checkDetails": [
+            {
+              "checkMethod": "kbv",
+              "kbvQuality": 3,
+              "kbvResponseMode": "multiple_choice"
+            },
+            {
+              "checkMethod": "kbv",
+              "kbvQuality": 3,
+              "kbvResponseMode": "multiple_choice"
+            },
+            {
+              "checkMethod": "kbv",
+              "kbvQuality": 2,
+              "kbvResponseMode": "multiple_choice"
+            }
+          ],
+          "type": "IdentityCheck",
+          "verificationScore": 2
+        }
+      ],
+      "successful": true,
+      "age": "type[number]"
     },
     "restricted": {
       "device_information": {}
     }
   },
   {
-    "event_name": "IPV_DWP_KBV_CRI_THIN_FILE_ENCOUNTERED",
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
       "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "cri": "experianKbv",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "type": "STANDARD"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CONTINUITY_OF_IDENTITY_CHECK_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "type": "STANDARD",
+      "successful": true
+    },
+    "restricted": {
+      "newName": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "KENNETH"
+            },
+            {
+              "type": "FamilyName",
+              "value": "DECERQUEIRA"
+            }
+          ]
+        }
+      ],
+      "newBirthDate": [
+        {
+          "value": "1965-07-08"
+        }
+      ],
+      "newAddress": [
+        {
+          "addressCountry": "GB",
+          "addressLocality": "BATH",
+          "buildingName": "",
+          "buildingNumber": "8",
+          "postalCode": "BA2 5AA",
+          "streetName": "HADLEY ROAD",
+          "subBuildingName": "",
+          "uprn": 100120012077,
+          "validFrom": "1000-01-01"
+        }
+      ],
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_GPG45_PROFILE_MATCHED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "gpg45Profile": "M1B",
+      "gpg45Scores": {
+        "evidences": [
+          {
+            "strength": 3,
+            "validity": 2
+          }
+        ],
+        "activity": 1,
+        "fraud": 2,
+        "verification": 2
+      },
+      "vcTxnIds": ["type[string]", "type[string]", "type[string]"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "iss": "https://ticf.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "type": "RiskAssessment"
+        }
+      ],
+      "successful": true
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "cri": "ticf",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_STORED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "identity_type": "new",
+      "sis_record_created": true,
+      "vot": "P2",
+      "max_vot": "P2"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_JOURNEY_END",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
       "govuk_signin_journey_id": "type[string]"
     },
     "restricted": {
       "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_IDENTITY_ISSUED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "levelOfConfidence": "P2",
+      "ciFail": false,
+      "hasMitigations": false,
+      "returnCodes": []
     }
   }
 ]

--- a/api-tests/data/audit-events/new-identity-p2-web-journey.json
+++ b/api-tests/data/audit-events/new-identity-p2-web-journey.json
@@ -212,18 +212,6 @@
     }
   },
   {
-    "event_name": "IPV_DWP_KBV_HANDOFF_START",
-    "component_id": "https://identity.local.account.gov.uk",
-    "user": {
-      "user_id": "type[string]",
-      "session_id": "type[string]",
-      "govuk_signin_journey_id": "type[string]"
-    },
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_REDIRECT_TO_CRI",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
@@ -244,24 +232,12 @@
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
-      "iss": "https://experian-kbv-cri.stubs.account.gov.uk",
+      "iss": "https://open-banking-cri.stubs.account.gov.uk",
       "evidence": [
         {
           "checkDetails": [
             {
-              "checkMethod": "kbv",
-              "kbvQuality": 3,
-              "kbvResponseMode": "multiple_choice"
-            },
-            {
-              "checkMethod": "kbv",
-              "kbvQuality": 3,
-              "kbvResponseMode": "multiple_choice"
-            },
-            {
-              "checkMethod": "kbv",
-              "kbvQuality": 2,
-              "kbvResponseMode": "multiple_choice"
+              "checkMethod": "data"
             }
           ],
           "type": "IdentityCheck",
@@ -284,7 +260,7 @@
       "govuk_signin_journey_id": "type[string]"
     },
     "extensions": {
-      "cri": "experianKbv",
+      "cri": "openBanking",
       "type": "vc"
     },
     "restricted": {
@@ -368,7 +344,7 @@
         "evidences": [
           {
             "strength": 3,
-            "validity": 2
+            "validity": 3
           }
         ],
         "activity": 1,

--- a/api-tests/data/cri-stub-requests/openBanking/kenneth-score-0/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/openBanking/kenneth-score-0/credentialSubject.json
@@ -1,0 +1,21 @@
+{
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/openBanking/kenneth-score-0/evidence.json
+++ b/api-tests/data/cri-stub-requests/openBanking/kenneth-score-0/evidence.json
@@ -1,0 +1,12 @@
+{
+  "type": "IdentityCheck",
+  "txn": "RB000117420948",
+  "verificationScore": 0,
+  "checkDetails": [
+    {
+      "checkMethod": "auth"
+    }
+  ],
+  "failedCheckDetails": [],
+  "ci": []
+}

--- a/api-tests/data/cri-stub-requests/openBanking/kenneth-with-breaching-ci/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/openBanking/kenneth-with-breaching-ci/credentialSubject.json
@@ -1,0 +1,21 @@
+{
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/openBanking/kenneth-with-breaching-ci/evidence.json
+++ b/api-tests/data/cri-stub-requests/openBanking/kenneth-with-breaching-ci/evidence.json
@@ -1,0 +1,14 @@
+{
+  "type": "IdentityCheck",
+  "txn": "RB000117420948",
+  "strengthScore": 0,
+  "validityScore": 0,
+  "verificationScore": 0,
+  "ci": ["BREACHING"],
+  "checkDetails": [],
+  "failedCheckDetails": [
+    {
+      "checkMethod": "auth"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/openBanking/kenneth/credentialSubject.json
+++ b/api-tests/data/cri-stub-requests/openBanking/kenneth/credentialSubject.json
@@ -1,0 +1,21 @@
+{
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ]
+}

--- a/api-tests/data/cri-stub-requests/openBanking/kenneth/evidence.json
+++ b/api-tests/data/cri-stub-requests/openBanking/kenneth/evidence.json
@@ -1,0 +1,16 @@
+{
+  "type": "IdentityCheck",
+  "txn": "RB000117420948",
+  "strengthScore": 3,
+  "validityScore": 3,
+  "verificationScore": 2,
+  "checkDetails": [
+    {
+      "checkMethod": "data",
+      "identityCheckPolicy": "none"
+    },
+    {
+      "checkMethod": "auth"
+    }
+  ]
+}

--- a/api-tests/features/app-cross-browser/p2-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p2-cross-browser.feature
@@ -82,7 +82,45 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I am issued a 'P2' identity
       And I have a stored identity record with a 'P2' max vot
 
-    # PYIC-9059 We need a version of this for open banking when we have the full route implemented
+    Scenario: MAM journey cross-browser scenario unsuccessful VC without CI
+      When I activate the 'openBanking' feature set
+      And the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+        # This simulates the user clicking continue on the problem-different-browser
+        # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+        # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+        # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'medium-confidence' journey
+      Then I get a 'select-photo-id' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
     Scenario: MAM journey cross-browser scenario unsuccessful VC without CI - no Open Banking
       When I activate the 'openBankingDisabled' feature set
       And the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
@@ -142,8 +180,132 @@ Feature: P2 V2 App Cross Browser Scenario
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
+
+  Rule: Cross-browser during same-session enhanced verification mitigation
+    Background: Submit web passport details, then navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+
+    Scenario: Successful mitigation with DL auth source check
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+        # This simulates the user clicking continue on the problem-different-browser
+        # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+        # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+        # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'medium-confidence' journey
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Same session DCMAW enhanced verification mitigation - DL auth check acquires CI
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+      # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+      # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'medium-confidence' journey
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
   Rule: Cross-browser during same-session enhanced verification mitigation - no Open Banking
-    # PYIC-9059 We need versions of these tests for open banking when we have the full route implemented
     Background: Submit web passport details, then navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
       Given I activate the 'openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -39,7 +39,6 @@ Feature: Audit Events
     And I have a stored identity record with a 'P3' max vot
     And audit events for 'new-identity-p2-app-journey' are recorded [local only]
 
-  #  PYIC-9059 this test will need an equivalent duplicate version once it is possible to get complete a journey via Open Banking
   @QualityGateRegressionTest
   Scenario: New identity - p2 web journey - no Open Banking
     Given I activate the 'openBankingDisabled' feature set
@@ -76,6 +75,50 @@ Feature: Audit Events
     When I submit 'kenneth-score-2' details with attributes to the CRI stub
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a 'P2' identity
+    And I have a stored identity record with a 'P2' max vot
+    And audit events for 'new-identity-p2-web-journey-kbv' are recorded [local only]
+
+  @QualityGateRegressionTest
+  Scenario: New identity - p2 web journey
+    Given I activate the 'openBanking' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+    When I submit a 'neither' event
+    Then I get a 'pyi-triage-buffer' page response
+    When I submit an 'anotherWay' event
+    Then I get a 'select-photo-id' page response
+    When I submit an 'drivingLicence' event
+    Then I get a 'prove-identity-online' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
+    When I submit a 'next' event
+    Then I get a 'prove-identity-online-banking' page response
+    When I submit a 'next' event
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get an 'openBanking' CRI response
+    When I submit 'kenneth' details to the CRI stub
     Then I get a 'page-ipv-success' page response
     When I submit a 'next' event
     Then I get an OAuth response
@@ -637,8 +680,7 @@ Feature: Audit Events
     Then I get an unsuccessful MFA reset result with failure code 'identity_check_failed'
     And audit events for 'reverification-failed-journey' are recorded [local only]
 
-  #  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to get to KBVs via Open Banking
-  Rule: DWP KBV
+  Rule: DWP KBV - no Open Banking
     Background: Start a journey to DWP KBV CRI
       Given I activate the 'openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey
@@ -666,6 +708,74 @@ Feature: Audit Events
       When I submit 'kenneth-score-2' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+
+    @QualityGateNewFeatureTest
+    Scenario: DWP KBV - successful response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      And audit events for 'dwp-kbv-successful-journey-no-open-banking' are recorded [local only]
+
+    @QualityGateNewFeatureTest
+    Scenario: DWP KBV - dropout via thin file
+      When I call the CRI stub with attributes and get an 'invalid_request' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-different-security-questions' page response
+      And audit events for 'dwp-kbv-dropout-via-thin-file-no-open-banking' are recorded [local only]
+
+    @QualityGateNewFeatureTest
+    Scenario: DWP KBV - user abandons CRI
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error with error description 'user_abandoned'
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      And audit events for 'dwp-kbv-dropout-user-abandons-cri-no-open-banking' are recorded [local only]
+
+  Rule: DWP KBV
+    Background: Start a journey to DWP KBV CRI
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
       Then I get a 'personal-independence-payment' page response
       When I submit a 'next' event
       Then I get a 'page-pre-dwp-kbv-transition' page response

--- a/api-tests/features/cimit/p2-alternate-doc.feature
+++ b/api-tests/features/cimit/p2-alternate-doc.feature
@@ -1,7 +1,164 @@
-#  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to complete a journey via Open Banking
-
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
-Feature: P2 CIMIT - Alternate doc - Experian KBV
+Feature: P2 CIMIT - Alternate doc
+  Rule: No existing identity
+    Background:
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+
+    Scenario Outline: Alternate doc mitigation via passport or DL
+      When I submit an '<initialCri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport    | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence| kenneth-driving-permit-valid |
+
+    Scenario Outline: Alternate doc mitigation via passport or DL - separate session
+      When I submit an '<initialCri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+
+      # User drops out of previous CRI without mitigating and starts a new journey
+      Given I start a new 'medium-confidence' journey
+      Then I get a '<separateSessionNoMatch>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigationStart>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | separateSessionNoMatch       | mitigationStart                   |mitigatingCri   | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | pyi-driving-licence-no-match | pyi-continue-with-passport        | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | pyi-passport-no-match        | pyi-continue-with-driving-licence | drivingLicence | kenneth-driving-permit-valid |
+
+    Scenario Outline: Mitigation of alternate-doc CI via <mitigating-cri> when user initially drops out of <mitigating-cri>
+      When I submit a '<initial-cri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<initial-cri>' CRI response
+      When I submit '<initial-invalid-doc>' details to the CRI stub
+      Then I get a '<no-match-page>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigating-cri>' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'prove-identity-no-other-photo-id' page response and pageContext
+        | Context    | Value                 |
+        | invalidDoc | <invalid-doc-context> |
+      When I submit a 'back' event
+      Then I get a '<mitigating-cri>' CRI response
+      When I submit '<mitigating-doc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | initial-cri    | initial-invalid-doc                        | no-match-page                            | mitigating-cri | mitigating-doc               | invalid-doc-context |
+        | ukPassport     | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid | drivingLicence      |
+        | drivingLicence | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       | passport            |
+
+    Scenario: Returns P0 when user continues to service from prove-identity-no-other-photo-id page during CI mitigation
+      When I submit a 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-needs-alternate-doc' details to the CRI stub
+      Then I get a 'pyi-passport-no-match-another-way' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'prove-identity-no-other-photo-id' page response and pageContext
+        | Context    | Value          |
+        | invalidDoc | drivingLicence |
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
   Rule: No existing identity
     Background:
       Given I activate the 'openBankingDisabled' feature set
@@ -207,6 +364,59 @@ Feature: P2 CIMIT - Alternate doc - Experian KBV
 #      Then I get a 'pyi-no-match' page response
 
   Rule: High-medium confidence journey
+    Scenario Outline: High-medium confidence journey - alternate-doc mitigation
+      Given I activate the 'openBanking' feature set
+      When I start a new 'high-medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an '<initialCri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+
+
+  Rule: High-medium confidence journey - no Open Banking
     Scenario Outline: High-medium confidence journey - alternate-doc mitigation
       Given I activate the 'openBankingDisabled' feature set
       When I start a new 'high-medium-confidence' journey

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
@@ -1,8 +1,85 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 # These tests check what happens if a user gets to KBVs and then needs enhanced verification with DCMAW
-#  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to get to KBVs via Open Banking
 Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
   Scenario Outline: Same session mitigation via app - successful <attained-vot> attained
+    Given I activate the 'openBanking' feature set
+    When I start a new '<journey-type>' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+    When I submit a 'neither' event
+    Then I get a 'pyi-triage-buffer' page response
+    When I submit an 'anotherWay' event
+    Then I get a 'select-photo-id' page response
+    When I submit an 'drivingLicence' event
+    Then I get a 'prove-identity-online' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
+    When I submit a 'next' event
+    Then I get a 'prove-identity-online-banking' page response
+    When I submit a 'next' event
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get an 'openBanking' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'photo-id-banking-another-way' page response
+    When I submit an 'answerSecurityQuestions' event
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'experianKbv' CRI response
+    When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+    Then I get a 'photo-id-web-find-another-way' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | mam   |
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+      | Context    | Value  |
+      | smartphone | iphone |
+      | isAppOnly  | false  |
+    When the async DCMAW CRI produces a '<document-details>' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get a 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a '<attained-vot>' identity
+    And I have a stored identity record with a 'P3' max vot
+
+    Examples:
+      | journey-type           | attained-vot | document-details             |
+      | medium-confidence      | P2           | kenneth-passport-valid       |
+      | high-medium-confidence | P3           | kenneth-passport-valid       |
+
+  Scenario Outline: Same session mitigation via app - successful <attained-vot> attained - no Open Banking
     Given I activate the 'openBankingDisabled' feature set
     When I start a new '<journey-type>' journey
     Then I get a 'live-in-uk' page response
@@ -66,11 +143,101 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
     And I have a stored identity record with a 'P3' max vot
 
     Examples:
-    | journey-type           | attained-vot | document-details             |
-    | medium-confidence      | P2           | kenneth-passport-valid       |
-    | high-medium-confidence | P3           | kenneth-passport-valid       |
+      | journey-type           | attained-vot | document-details             |
+      | medium-confidence      | P2           | kenneth-passport-valid       |
+      | high-medium-confidence | P3           | kenneth-passport-valid       |
 
   Scenario Outline: Separate session mitigation - <journey-type> - successful <attained-vot> attained - passport
+    Given I activate the 'openBanking' feature set
+    When I start a new '<journey-type>' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+    When I submit a 'neither' event
+    Then I get a 'pyi-triage-buffer' page response
+    When I submit an 'anotherWay' event
+    Then I get a 'select-photo-id' page response
+    When I submit an 'drivingLicence' event
+    Then I get a 'prove-identity-online' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
+    When I submit a 'next' event
+    Then I get a 'prove-identity-online-banking' page response
+    When I submit a 'next' event
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get an 'openBanking' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'photo-id-banking-another-way' page response
+    When I submit an 'answerSecurityQuestions' event
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'experianKbv' CRI response
+    When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+    Then I get a 'photo-id-web-find-another-way' page response
+
+    # Separate session
+    When I start a new '<journey-type>' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | mam   |
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+      | Context    | Value  |
+      | smartphone | iphone |
+      | isAppOnly  | false  |
+    When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get a 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a '<attained-vot>' identity
+    And I have a stored identity record with a 'P3' max vot
+
+    Examples:
+      | journey-type           | attained-vot |
+      | medium-confidence      | P2           |
+      | high-medium-confidence | P3           |
+
+  Scenario Outline: Separate session mitigation - <journey-type> - successful <attained-vot> attained - passport - no Open Banking
     Given I activate the 'openBankingDisabled' feature set
     When I start a new '<journey-type>' journey
     Then I get a 'live-in-uk' page response

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
@@ -1,4 +1,4 @@
-@Build @QualityGateIntegrationTest @QualityGateRegressionTest @qqqq
+@Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: Mitigating CIs with enhanced verification using the F2F CRI
   Rule: Same session journeys
     Background:

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
@@ -1,45 +1,172 @@
-#  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to get to KBVs via Open Banking
-
-@Build @QualityGateIntegrationTest @QualityGateRegressionTest
+@Build @QualityGateIntegrationTest @QualityGateRegressionTest @qqqq
 Feature: Mitigating CIs with enhanced verification using the F2F CRI
-  Background:
-    Given I activate the 'openBankingDisabled' feature set
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get an 'identify-device' page response
-    When I submit an 'appTriage' event
-    Then I get a 'pyi-triage-select-device' page response
-    When I submit a 'computer-or-tablet' event
-    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
-      | Context    | Value |
-      | deviceType | dad   |
-    When I submit a 'neither' event
-    Then I get a 'pyi-triage-buffer' page response
-    When I submit an 'anotherWay' event
-    Then I get a 'page-multiple-doc-check' page response
-    When I submit a 'ukPassport' event
-    Then I get a 'ukPassport' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'end' event
-    Then I get a 'page-pre-experian-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'experianKbv' CRI response
-    When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'photo-id-web-find-another-way' page response
-
   Rule: Same session journeys
+    Background:
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+
+    Scenario Outline: Same session F2F enhanced verification mitigation - successful
+      When I submit an 'f2f' event
+      Then I get an 'f2f' CRI response
+      When I submit '<document-details>' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | document-details             |
+        | kenneth-passport-valid       |
+        | kenneth-driving-permit-valid |
+
+    Scenario: Same session F2F enhanced verification mitigation - OAuth error from F2F CRI
+      When I submit an 'f2f' event
+      Then I get an 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'temporarily_unavailable' OAuth error
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'pyi-technical' page response
+
+    Scenario: Same session F2F enhanced verification mitigation - async queue error - dropout
+      When I submit an 'f2f' event
+      Then I get an 'f2f' CRI response
+      When I get an error from the async CRI stub
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'pyi-f2f-technical' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity without a TICF VC
+      And I don't have a stored identity in EVCS
+
+    Scenario: Same session F2F enhanced verification mitigation - async queue error - continue from pyi-f2f-technical page
+      When I submit an 'f2f' event
+      Then I get an 'f2f' CRI response
+      When I get an error from the async CRI stub
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'pyi-f2f-technical' page response
+      When I submit a 'next' event
+      Then I get a 'page-ipv-identity-document-start' page response
+
+    Scenario: Same session F2F enhanced verification mitigation - user abandons DCMAW then mitigates with F2F
+      When I submit a 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get an 'f2f' CRI response
+      When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+  Rule: Same session journeys - no Open Banking
+    Background:
+      Given I activate the 'openBankingDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
 
     Scenario Outline: Same session F2F enhanced verification mitigation - successful
       When I submit an 'f2f' event
@@ -124,6 +251,251 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
       And I have a stored identity record with a 'P2' max vot
 
   Rule: Separate session journeys
+    Background:
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+
+    Scenario Outline: Separate session F2F enhanced verification mitigation - successful
+      When I start a new 'medium-confidence' journey
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'f2f' CRI response
+      When I submit '<document-details>' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | document-details             |
+        | kenneth-passport-valid       |
+        | kenneth-driving-permit-valid |
+
+    Scenario: Separate session F2F enhanced verification mitigation - OAuth error from F2F CRI
+      When I start a new 'medium-confidence' journey
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'temporarily_unavailable' OAuth error
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'pyi-technical' page response
+
+    Scenario: Separate session F2F enhanced verification mitigation - async queue error
+      When I start a new 'medium-confidence' journey
+      When I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'f2f' CRI response
+      When I get an error from the async CRI stub
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'pyi-f2f-technical' page response
+      When I submit a 'end' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity without a TICF VC
+      And I don't have a stored identity in EVCS
+
+    Scenario: Separate session F2F enhanced verification mitigation - user abandons DCMAW and mitigates with F2F
+      Given I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'f2f' CRI response
+      When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Separate session F2F enhanced verification mitigation - user fails DCMAW (e.g. failed likeness) - mitigate via F2F
+      Given I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
+    # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'f2f' CRI response
+      When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+  Rule: Separate session journeys - no Open Banking
+    Background:
+      Given I activate the 'openBankingDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
 
     Scenario Outline: Separate session F2F enhanced verification mitigation - successful
       When I start a new 'medium-confidence' journey

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -21,8 +21,48 @@ Feature: Disabled CRI journeys
       When I submit an 'appTriage' event
       Then I get a 'page-multiple-doc-check' page response
 
-    #  PYIC-9059 this test will need an equivalent duplicate version once it is possible to get to KBVs via Open Banking
     Scenario: Choosing DCMAW after escaping from KBV CRIs leads to technical failure
+      Given I activate the 'dcmawAsyncDisabled,openBanking' feature set
+      Given I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-0' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value   |
+        | reason  | dropout |
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-technical' page response
+
+    Scenario: Choosing DCMAW after escaping from KBV CRIs leads to technical failure - no Open Banking
       Given I activate the 'dcmawAsyncDisabled,openBankingDisabled' feature set
       Given I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
@@ -66,8 +106,46 @@ Feature: Disabled CRI journeys
       When I submit an 'appTriage' event
       Then I get a 'pyi-technical' page response
 
-    #  PYIC-9059 this test will need an equivalent duplicate version once it is possible to get to KBVs via Open Banking
     Scenario: Same session enhanced verification mitigation with DCMAW leads to technical failure
+      Given I activate the 'dcmawAsyncDisabled,openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-technical' page response
+
+    Scenario: Same session enhanced verification mitigation with DCMAW leads to technical failure - no Open Banking
       Given I activate the 'dcmawAsyncDisabled,openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
@@ -387,8 +465,63 @@ Feature: Disabled CRI journeys
       When I submit an 'end' event
       Then I get a 'pyi-escape' page response
 
-  #  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to get to KBVs via Open Banking
   Rule: DWP KBVs are disabled or unsuitable
+    Background: User starts a web journey to KBV
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+
+    Scenario: Experian KBV is offered first
+      Given I activate the 'dwpKbvDisabled' feature sets
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+
+    Scenario: Experian KBV is offered if DWP KBV unsuitable
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit an 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+
+  Rule: DWP KBVs are disabled or unsuitable - no Open Banking
     Background: User starts a web journey to KBV
       Given I activate the 'openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey

--- a/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
+++ b/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
@@ -304,8 +304,195 @@ Feature: P2 Journeys with DL authoritative source check
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-  #  PYIC-9059 these tests will need equivalent Open Banking versions once it is possible to get an identity via Open Banking
   Rule: Web Journey
+    Background: Start web journey
+      Given I activate the 'drivingLicenceAuthCheck,openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+
+    Scenario Outline: KBV thin file
+      When I submit a 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-0' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value   |
+        | reason  | dropout |
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit '<dl_details>' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a '<page_response>' page response
+
+      Examples:
+        | dl_details                                 | page_response    |
+        | kenneth-driving-permit-valid               | page-ipv-success |
+        | kenneth-driving-permit-needs-alternate-doc | pyi-no-match     |
+
+    Scenario: Auth source check is not required if user already has a good driving licence VC even with different case
+      When I submit a 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+
+    Scenario: Auth source check is required if doc identifiers do not match
+      When I submit a 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-dva-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-dva-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-ipv-success' page response
+
+  Rule: Web Journey - no Open Banking
     Background: Start web journey
       Given I activate the 'drivingLicenceAuthCheck,openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey

--- a/api-tests/features/dl-auth-source-checks/p2-enhanced-verification-mitigation.feature
+++ b/api-tests/features/dl-auth-source-checks/p2-enhanced-verification-mitigation.feature
@@ -1,7 +1,186 @@
 @Build @InitialisesDCMAWSessionState @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI and driving licence authoritative source check
-  #  PYIC-9059 these tests will need equivalent Open Banking versions once it is possible to get an identity via Open Banking
   Rule: Same session mitigation
+    Background: Submit web passport details, then navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
+      Given I activate the 'drivingLicenceAuthCheck,openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+
+    Scenario: Same session DCMAW enhanced verification mitigation - successful
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Same session DCMAW enhanced verification mitigation - DL auth check acquires CI
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Same session DCMAW enhanced verification mitigation - dropout DL auth source check - mitigate via f2f
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'uk-driving-licence-details-not-correct' page response and pageContext
+        | Context            | Value |
+        | isFromStrategicApp | true  |
+      When I submit an 'end' event
+      Then I get a 'prove-identity-another-way' page response
+      When I submit a 'postOffice' event
+      Then I get a 'pyi-post-office' page response
+
+    Scenario: Same session DCMAW enhanced verification mitigation - DL auth check incomplete
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'uk-driving-licence-details-not-correct' page response and pageContext
+        | Context            | Value |
+        | isFromStrategicApp | true  |
+      When I submit a 'next' event
+
+      # Attempt 2 - retry after viewing prove-identity-another-way
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'uk-driving-licence-details-not-correct' page response and pageContext
+        | Context            | Value |
+        | isFromStrategicApp | true  |
+      When I submit an 'end' event
+      Then I get a 'prove-identity-another-way' page response
+      When I submit an 'anotherTypePhotoId' event
+
+      # Attempt 3 - give up
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'uk-driving-licence-details-not-correct' page response and pageContext
+        | Context            | Value |
+        | isFromStrategicApp | true  |
+      When I submit an 'end' event
+      Then I get a 'prove-identity-another-way' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+  Rule: Same session mitigation - no Open Banking
     Background: Submit web passport details, then navigate to KBV CRI and apply NEEDS-ENHANCED-VERIFICATION CI
       Given I activate the 'drivingLicenceAuthCheck,openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey
@@ -270,8 +449,85 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
       And I don't have a stored identity in EVCS
 
   Rule: Web journey via DL initially
-    #  PYIC-9059 this test will need an equivalent version once it is possible to get an identity via Open Banking
     Scenario Outline: Same session - DL auth source check not required when user already has a DL VC - <journey-type>
+      Given I activate the 'drivingLicenceAuthCheck,openBanking' feature set
+      When I start a new '<journey-type>' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | journey-type           |
+        | medium-confidence      |
+        | high-medium-confidence |
+
+    Scenario Outline: Same session - DL auth source check not required when user already has a DL VC - <journey-type> - no Open Banking
       Given I activate the 'drivingLicenceAuthCheck,openBankingDisabled' feature set
       When I start a new '<journey-type>' journey
       Then I get a 'live-in-uk' page response

--- a/api-tests/features/dwp-kbv/p2-alternate-doc-mitigation.feature
+++ b/api-tests/features/dwp-kbv/p2-alternate-doc-mitigation.feature
@@ -1,210 +1,361 @@
-#  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to get to KBVs via Open Banking
-
 @Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
 Feature: P2 CIMIT - Alternate doc - DWP KBV
-  Background: Start web journey
-    Given I activate the 'openBankingDisabled' feature set
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get an 'identify-device' page response
-    When I submit an 'appTriage' event
-    Then I get a 'pyi-triage-select-device' page response
-    When I submit a 'computer-or-tablet' event
-    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
-      | Context    | Value |
-      | deviceType | dad   |
-    When I submit a 'neither' event
-    Then I get a 'pyi-triage-buffer' page response
-    When I submit an 'anotherWay' event
-    Then I get a 'page-multiple-doc-check' page response
+  Rule: Open Banking
+    Background: Start web journey
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
 
-  Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV
-    When I submit an '<initialCri>' event
-    Then I get a '<initialCri>' CRI response
-    When I submit '<initialInvalidDoc>' details to the CRI stub
-    Then I get a '<noMatchPage>' page response
-    When I submit a 'next' event
-    Then I get a '<mitigatingCri>' CRI response
-    When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-dwp-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'dwpKbv' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P2' identity
-    And I have a stored identity record with a 'P2' max vot
+    Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV
+      When I submit an '<initialCri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-    Examples:
-      | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
-      | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
-      | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
 
-  Scenario Outline: Alternate doc mitigation user drops out of DWP KBV CRI via thin file
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get an 'identify-device' page response
-    When I submit an 'appTriage' event
-    Then I get a 'pyi-triage-select-device' page response
-    When I submit a 'computer-or-tablet' event
-    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
-      | Context    | Value |
-      | deviceType | dad   |
-    When I submit a 'neither' event
-    Then I get a 'pyi-triage-buffer' page response
-    When I submit an 'anotherWay' event
-    Then I get a 'page-multiple-doc-check' page response
-    When I submit an '<initialCri>' event
-    Then I get a '<initialCri>' CRI response
-    When I submit '<initialInvalidDoc>' details to the CRI stub
-    Then I get a '<noMatchPage>' page response
-    When I submit a 'next' event
-    Then I get a '<mitigatingCri>' CRI response
-    When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-dwp-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'dwpKbv' CRI response
-    When I call the CRI stub with attributes and get an 'invalid_request' OAuth error
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-different-security-questions' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-experian-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'experianKbv' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P2' identity
-    And I have a stored identity record with a 'P2' max vot
+    Scenario Outline: Alternate doc mitigation user drops out of DWP KBV CRI via thin file
+      When I submit an '<initialCri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I call the CRI stub with attributes and get an 'invalid_request' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-different-security-questions' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-    Examples:
-      | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
-      | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
-      | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
 
-  Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV PIP page dropout
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get an 'identify-device' page response
-    When I submit an 'appTriage' event
-    Then I get a 'pyi-triage-select-device' page response
-    When I submit a 'computer-or-tablet' event
-    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
-      | Context    | Value |
-      | deviceType | dad   |
-    When I submit a 'neither' event
-    Then I get a 'pyi-triage-buffer' page response
-    When I submit an 'anotherWay' event
-    Then I get a 'page-multiple-doc-check' page response
-    When I submit an '<initialCri>' event
-    Then I get a '<initialCri>' CRI response
-    When I submit '<initialInvalidDoc>' details to the CRI stub
-    Then I get a '<noMatchPage>' page response
-    When I submit a 'next' event
-    Then I get a '<mitigatingCri>' CRI response
-    When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'end' event
-    Then I get a 'page-pre-experian-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'experianKbv' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P2' identity
-    And I have a stored identity record with a 'P2' max vot
+    Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV PIP page dropout
+      When I submit an '<initialCri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-    Examples:
-      | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
-      | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
-      | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
 
-  Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV transition page dropout
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get an 'identify-device' page response
-    When I submit an 'appTriage' event
-    Then I get a 'pyi-triage-select-device' page response
-    When I submit a 'computer-or-tablet' event
-    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
-      | Context    | Value |
-      | deviceType | dad   |
-    When I submit a 'neither' event
-    Then I get a 'pyi-triage-buffer' page response
-    When I submit an 'anotherWay' event
-    Then I get a 'page-multiple-doc-check' page response
-    When I submit an '<initialCri>' event
-    Then I get a '<initialCri>' CRI response
-    When I submit '<initialInvalidDoc>' details to the CRI stub
-    Then I get a '<noMatchPage>' page response
-    When I submit a 'next' event
-    Then I get a '<mitigatingCri>' CRI response
-    When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-dwp-kbv-transition' page response
-    When I submit a 'end' event
-    Then I get a 'pyi-another-way' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P0' identity
-    And I don't have a stored identity in EVCS
+    Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV transition page dropout
+      When I submit an '<initialCri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'end' event
+      Then I get a 'pyi-another-way' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
 
-    Examples:
-      | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
-      | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
-      | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+
+  Rule: No Open Banking
+    Background: Start web journey
+      Given I activate the 'openBankingDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response
+
+    Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+
+    Scenario Outline: Alternate doc mitigation user drops out of DWP KBV CRI via thin file
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I call the CRI stub with attributes and get an 'invalid_request' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-different-security-questions' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+
+    Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV PIP page dropout
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+
+    Scenario Outline: Alternate doc mitigation via passport or DL - DWP KBV transition page dropout
+      When I submit an '<initialCri>' event
+      Then I get a '<initialCri>' CRI response
+      When I submit '<initialInvalidDoc>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigatingCri>' CRI response
+      When I submit '<mitigatingDoc>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'end' event
+      Then I get a 'pyi-another-way' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+      Examples:
+        | initialCri        | initialInvalidDoc                          | noMatchPage                              | mitigatingCri  | mitigatingDoc                |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |

--- a/api-tests/features/dwp-kbv/p2-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p2-web-journey.feature
@@ -1,288 +1,651 @@
-#  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to get to KBVs via Open Banking
-
 @Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
 Feature: P2 Web document journey - DWP KBV
+  Rule: Open Banking
+    Background: Start web journey
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
 
-  Background: Start web journey
-    Given I activate the 'openBankingDisabled' feature set
-    When I start a new 'medium-confidence' journey
-    Then I get a 'live-in-uk' page response
-    When I submit a 'uk' event
-    Then I get a 'page-ipv-identity-document-start' page response
-    When I submit an 'appTriage' event
-    Then I get an 'identify-device' page response
-    When I submit an 'appTriage' event
-    Then I get a 'pyi-triage-select-device' page response
-    When I submit a 'computer-or-tablet' event
-    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
-      | Context    | Value |
-      | deviceType | dad   |
-    When I submit a 'neither' event
-    Then I get a 'pyi-triage-buffer' page response
-    When I submit an 'anotherWay' event
-    Then I get a 'page-multiple-doc-check' page response
+    Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV
+      When I submit a '<cri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-  Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV
-    When I submit a '<cri>' event
-    Then I get a '<cri>' CRI response
-    When I submit '<details>' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-dwp-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'dwpKbv' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P2' identity
-    And I have a stored identity record with a 'P2' max vot
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
 
-    Examples:
-      | cri            | details                      |
-      | drivingLicence | kenneth-driving-permit-valid |
-      | ukPassport     | kenneth-passport-valid       |
+    Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV PIP page dropout
+      When I submit a '<cri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-  Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV PIP page dropout
-    When I submit a '<cri>' event
-    Then I get a '<cri>' CRI response
-    When I submit '<details>' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'end' event
-    Then I get a 'page-pre-experian-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'experianKbv' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P2' identity
-    And I have a stored identity record with a 'P2' max vot
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
 
-    Examples:
-      | cri            | details                      |
-      | drivingLicence | kenneth-driving-permit-valid |
-      | ukPassport     | kenneth-passport-valid       |
+    Scenario: Successful P2 identity via Web using - DWP KBV transition page dropout - DL
+      When I submit a 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'end' event
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value   |
+        | reason  | dropout |
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-  Scenario: Successful P2 identity via Web using - DWP KBV transition page dropout - DL
-    When I submit a 'drivingLicence' event
-    Then I get a 'drivingLicence' CRI response
-    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-dwp-kbv-transition' page response
-    When I submit a 'end' event
-    Then I get a 'photo-id-web-find-another-way' page response and pageContext
-      | Context | Value   |
-      | reason  | dropout |
-    When I submit an 'appTriage' event
-    Then I get an 'identify-device' page response
-    When I submit an 'appTriage' event
-    Then I get a 'pyi-triage-select-device' page response
-    When I submit a 'smartphone' event
-    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
-      | Context    | Value |
-      | deviceType | mam   |
-    When I submit an 'iphone' event
-    Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
-      | Context    | Value  |
-      | smartphone | iphone |
-      | isAppOnly  | false  |
-    When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
+    Scenario: Successful P2 identity via Web using - DWP KBV transition page dropout - Passport and DL auth source check
+      When I submit a 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'end' event
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value   |
+        | reason  | dropout |
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario Outline: User drops out of DWP KBV CRI via thin file - DWP KBV
+      When I submit a '<cri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I call the CRI stub with attributes and get an 'invalid_request' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-different-security-questions' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
+
+    Scenario Outline: User drops out of DWP KBV CRI - unable to answer questions - DWP KBV
+      When I submit a '<cri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I call the CRI stub with attributes and get an '<oauth_error>' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | cri            | details                      | oauth_error             |
+        | drivingLicence | kenneth-driving-permit-valid | access_denied           |
+        | ukPassport     | kenneth-passport-valid       | access_denied           |
+        | ukPassport     | kenneth-passport-valid       | server_error            |
+
+    Scenario: User drops out of DWP KBV due to a temporarily_unavailable error
+      When I submit a 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I call the CRI stub with attributes and get an 'temporarily_unavailable' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'pyi-technical' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Experian KBV is offered first if DWP is disabled
+      When I submit a 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      Given I activate the 'dwpKbvDisabled' feature sets
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+
+  Rule: No Open Banking
+    Background: Start web journey
+      Given I activate the 'openBankingDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response
+
+    Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
+
+    Scenario Outline: Successful P2 identity via Web using <cri> - DWP KBV PIP page dropout
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
+
+    Scenario: Successful P2 identity via Web using - DWP KBV transition page dropout - DL
+      When I submit a 'drivingLicence' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'end' event
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value   |
+        | reason  | dropout |
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
     # And the user returns from the app to core-front
-    And I pass on the DCMAW callback
-    Then I get a 'check-mobile-app-result' page response
-    When I poll for async DCMAW credential receipt
-    Then the poll returns a '201'
-    When I submit the returned journey event
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P2' identity
-    And I have a stored identity record with a 'P2' max vot
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-  Scenario: Successful P2 identity via Web using - DWP KBV transition page dropout - Passport and DL auth source check
-    When I submit a 'ukPassport' event
-    Then I get a 'ukPassport' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-dwp-kbv-transition' page response
-    When I submit a 'end' event
-    Then I get a 'photo-id-web-find-another-way' page response and pageContext
-      | Context | Value   |
-      | reason  | dropout |
-    When I submit an 'appTriage' event
-    Then I get an 'identify-device' page response
-    When I submit an 'appTriage' event
-    Then I get a 'pyi-triage-select-device' page response
-    When I submit a 'smartphone' event
-    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
-      | Context    | Value |
-      | deviceType | mam   |
-    When I submit an 'iphone' event
-    Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
-      | Context    | Value  |
-      | smartphone | iphone |
-      | isAppOnly  | false  |
-    When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
+    Scenario: Successful P2 identity via Web using - DWP KBV transition page dropout - Passport and DL auth source check
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'end' event
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value   |
+        | reason  | dropout |
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
     # And the user returns from the app to core-front
-    And I pass on the DCMAW callback
-    Then I get a 'check-mobile-app-result' page response
-    When I poll for async DCMAW credential receipt
-    Then the poll returns a '201'
-    When I submit the returned journey event
-    Then I get a 'drivingLicence' CRI response
-    When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
-      | Attribute | Values          |
-      | context   | "check_details" |
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P2' identity
-    And I have a stored identity record with a 'P2' max vot
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-  Scenario Outline: User drops out of DWP KBV CRI via thin file - DWP KBV
-    When I submit a '<cri>' event
-    Then I get a '<cri>' CRI response
-    When I submit '<details>' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-dwp-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'dwpKbv' CRI response
-    When I call the CRI stub with attributes and get an 'invalid_request' OAuth error
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-different-security-questions' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-experian-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'experianKbv' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P2' identity
-    And I have a stored identity record with a 'P2' max vot
+    Scenario Outline: User drops out of DWP KBV CRI via thin file - DWP KBV
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I call the CRI stub with attributes and get an 'invalid_request' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-different-security-questions' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-    Examples:
-      | cri            | details                      |
-      | drivingLicence | kenneth-driving-permit-valid |
-      | ukPassport     | kenneth-passport-valid       |
+      Examples:
+        | cri            | details                      |
+        | drivingLicence | kenneth-driving-permit-valid |
+        | ukPassport     | kenneth-passport-valid       |
 
-  Scenario Outline: User drops out of DWP KBV CRI - unable to answer questions - DWP KBV
-    When I submit a '<cri>' event
-    Then I get a '<cri>' CRI response
-    When I submit '<details>' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-dwp-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'dwpKbv' CRI response
-    When I call the CRI stub with attributes and get an '<oauth_error>' OAuth error
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-pre-experian-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'experianKbv' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'page-ipv-success' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P2' identity
-    And I have a stored identity record with a 'P2' max vot
+    Scenario Outline: User drops out of DWP KBV CRI - unable to answer questions - DWP KBV
+      When I submit a '<cri>' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I call the CRI stub with attributes and get an '<oauth_error>' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
-    Examples:
-      | cri            | details                      | oauth_error             |
-      | drivingLicence | kenneth-driving-permit-valid | access_denied           |
-      | ukPassport     | kenneth-passport-valid       | access_denied           |
-      | ukPassport     | kenneth-passport-valid       | server_error            |
+      Examples:
+        | cri            | details                      | oauth_error             |
+        | drivingLicence | kenneth-driving-permit-valid | access_denied           |
+        | ukPassport     | kenneth-passport-valid       | access_denied           |
+        | ukPassport     | kenneth-passport-valid       | server_error            |
 
-  Scenario: User drops out of DWP KBV due to a temporarily_unavailable error
-    When I submit a 'ukPassport' event
-    Then I get a 'ukPassport' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'personal-independence-payment' page response
-    When I submit a 'next' event
-    Then I get a 'page-pre-dwp-kbv-transition' page response
-    When I submit a 'next' event
-    Then I get a 'dwpKbv' CRI response
-    When I call the CRI stub with attributes and get an 'temporarily_unavailable' OAuth error
-      | Attribute          | Values                                          |
-      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-    Then I get a 'pyi-technical' page response
-    When I submit a 'next' event
-    Then I get an OAuth response
-    When I use the OAuth response to get my identity
-    Then I am issued a 'P0' identity
-    And I don't have a stored identity in EVCS
+    Scenario: User drops out of DWP KBV due to a temporarily_unavailable error
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I call the CRI stub with attributes and get an 'temporarily_unavailable' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'pyi-technical' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
 
-  Scenario: Experian KBV is offered first if DWP is disabled
-    When I submit a 'ukPassport' event
-    Then I get a 'ukPassport' CRI response
-    When I submit 'kenneth-passport-valid' details to the CRI stub
-    Then I get an 'address' CRI response
-    When I submit 'kenneth-current' details to the CRI stub
-    Then I get a 'fraud' CRI response
-    Given I activate the 'dwpKbvDisabled' feature sets
-    When I submit 'kenneth-score-2' details with attributes to the CRI stub
-      | Attribute          | Values                   |
-      | evidence_requested | {"identityFraudScore":2} |
-    Then I get a 'page-pre-experian-kbv-transition' page response
+    Scenario: Experian KBV is offered first if DWP is disabled
+      When I submit a 'ukPassport' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      Given I activate the 'dwpKbvDisabled' feature sets
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'page-pre-experian-kbv-transition' page response

--- a/api-tests/features/m1c-journeys.feature
+++ b/api-tests/features/m1c-journeys.feature
@@ -2,7 +2,7 @@
 Feature: M1C Unavailable Journeys
   Rule: Medium-confidence journeys
     Background:
-      Given I activate the 'openBankingDisabled' feature set
+      Given I activate the 'openBanking' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
@@ -46,7 +46,79 @@ Feature: M1C Unavailable Journeys
       | kenneth-passport-valid |
       | kenneth-brp-valid      |
 
-    #  PYIC-9059 this test will need an equivalent duplicate version once it is possible to complete a journey via Open Banking
+    Scenario: Unsuccessful M1C P2 identity via web DL using DL
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit a 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+  Rule: Medium-confidence journeys - no Open Banking
+    Background:
+      Given I activate the 'openBankingDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+
+    Scenario Outline: Successful M1C P2 identity via <details>
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a '<details>' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-unavailable' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | details                |
+        | kenneth-passport-valid |
+        | kenneth-brp-valid      |
+
     Scenario: Unsuccessful M1C P2 identity via web DL using DL
       When I submit a 'neither' event
       Then I get a 'pyi-triage-buffer' page response

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -369,7 +369,51 @@ Feature: P2 App journey
       When I submit the returned journey event
       Then I get an 'pyi-no-match' page response
 
-    #  PYIC-9059 this test will need an equivalent version once it is possible to get an identity via Open Banking
+    Scenario: MAM journey - passport fails with ci (score 1) and goes to alternative document check
+      Given I activate the 'openBanking' feature set
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'ALWAYS-REQUIRED' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
     Scenario: MAM journey - passport fails with ci (score 1) and goes to alternative document check - no Open Banking
       Given I activate the 'openBankingDisabled' feature set
       When I submit an 'appTriage' event
@@ -433,7 +477,48 @@ Feature: P2 App journey
       When I submit the returned journey event
       Then I get an 'page-multiple-doc-check' page response
 
-    #  PYIC-9059 this test will need an equivalent version once it is possible to get an identity via Open Banking
+    Scenario: DAD journey - BRP fails with with ci (score 1) goes to alternative document check
+      Given I activate the 'openBanking' feature set
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-brp-expired' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
     Scenario: DAD journey - BRP fails with with ci (score 1) goes to alternative document check - no Open Banking
       Given I activate the 'openBankingDisabled' feature set
       When I submit an 'appTriage' event

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -1,7 +1,6 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 @TrafficGeneration
 Feature: P2 Web document journey
-  #  PYIC-9059 this test will need an equivalent version once it is possible to get an identity via Open Banking
   Scenario Outline: <journey-type> - successful web journey - attains P2 with <cri> - no Open Banking
     Given I activate the 'openBankingDisabled' feature set
     When I start a new '<journey-type>' journey
@@ -51,6 +50,55 @@ Feature: P2 Web document journey
       | medium-confidence      | drivingLicence | kenneth-driving-permit-valid |
       | medium-confidence      | ukPassport     | kenneth-passport-valid       |
 
+  Scenario Outline: <journey-type> - successful web journey - attains P2 with <cri>
+    Given I activate the 'openBanking' feature set
+    When I start a new '<journey-type>' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+    When I submit a 'neither' event
+    Then I get a 'pyi-triage-buffer' page response
+    When I submit an 'anotherWay' event
+    Then I get a 'select-photo-id' page response
+    When I submit an '<cri>' event
+    Then I get a 'prove-identity-online' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
+    When I submit a 'next' event
+    Then I get a 'prove-identity-online-banking' page response
+    When I submit a 'next' event
+    Then I get a '<cri>' CRI response
+    When I submit '<details>' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get an 'openBanking' CRI response
+    When I submit 'kenneth' details to the CRI stub
+    Then I get a 'page-ipv-success' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a 'P2' identity
+    And I have a stored identity record with a 'P2' max vot
+
+    Examples:
+      | journey-type           | cri            | details                      |
+      | high-medium-confidence | drivingLicence | kenneth-driving-permit-valid |
+      | high-medium-confidence | ukPassport     | kenneth-passport-valid       |
+      | medium-confidence      | drivingLicence | kenneth-driving-permit-valid |
+      | medium-confidence      | ukPassport     | kenneth-passport-valid       |
+
   Rule: P2 VTR only - User starts P2 web journey - no Open Banking
     Background: Start P2 journey and ineligible for the app
       Given I activate the 'openBankingDisabled' feature set
@@ -71,7 +119,6 @@ Feature: P2 Web document journey
       When I submit an 'anotherWay' event
       Then I get a 'page-multiple-doc-check' page response
 
-    #  PYIC-9059 this test will need an equivalent version under the rule below once it is possible to get an identity via Open Banking
     Scenario: Successful web journey with driving licence CRI - dva - no Open Banking
       When I submit an 'drivingLicence' event
       Then I get a 'drivingLicence' CRI response
@@ -119,7 +166,6 @@ Feature: P2 Web document journey
         | dva                  | kenneth-driving-permit-dva-valid |
         | dvla                 | kenneth-driving-permit-valid     |
 
-    #  PYIC-9059 this test will need an equivalent version under the rule below once it is possible to get an identity via Open Banking
     Scenario: P2 fallback for users who fail KBV and F2F but can successfully prove their identity - no Open Banking
       When I submit an 'ukPassport' event
       Then I get a 'ukPassport' CRI response
@@ -184,7 +230,6 @@ Feature: P2 Web document journey
       Then I am issued a 'P2' identity
       And I have a stored identity record with a 'P2' max vot
 
-    #  PYIC-9059 this test will need an equivalent version under the rule below once it is possible to get an identity via Open Banking
     Scenario Outline: Allows use of <alternative-doc-cri> when user drops out of <initial-cri> CRI - no Open Banking
       When I submit a '<initial-cri>' event
       Then I get a '<initial-cri>' CRI response
@@ -320,6 +365,31 @@ Feature: P2 Web document journey
       When I submit an 'anotherWay' event
       Then I get a 'select-photo-id' page response
 
+    Scenario: Successful web journey with driving licence CRI - dva
+      When I submit an 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-dva-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
     Scenario Outline: Unsuccessful web journey with driving licence CRI - <driving-licence-type> - low fraud score
       When I submit an 'drivingLicence' event
       Then I get a 'prove-identity-online' page response and pageContext
@@ -347,6 +417,116 @@ Feature: P2 Web document journey
       | driving-licence-type | details                          |
       | dva                  | kenneth-driving-permit-dva-valid |
       | dvla                 | kenneth-driving-permit-valid     |
+
+    Scenario: P2 fallback for users who fail KBV and F2F but can successfully prove their identity
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-1' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+      When I submit a 'f2f' event
+      Then I get a 'f2f' CRI response
+      When I get an error from the async CRI stub
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'pyi-f2f-technical' page response
+      Then I get a 'pyi-f2f-technical' page response
+      When I submit a 'next' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context     | Value |
+        | deviceType  | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario Outline: Allows use of <alternative-doc-cri> when user drops out of <initial-cri> CRI
+      When I submit a '<initial-cri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<initial-cri>' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'prove-identity-another-type-photo-id' page response and pageContext
+        | Context    | Value                                          |
+        | invalidDoc | <prove-identity-another-type-photo-id-context> |
+      When I submit a 'otherPhotoId' event
+      Then I get a '<alternative-doc-cri>' CRI response
+      When I submit '<alternative-doc>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | initial-cri    | alternative-doc-cri | alternative-doc              | prove-identity-another-type-photo-id-context |
+        | ukPassport     | drivingLicence      | kenneth-driving-permit-valid | passport                                     |
+        | drivingLicence | ukPassport          | kenneth-passport-valid       | drivingLicence                               |
 
     Scenario: User is able to continue to service from the prove-identity-another-type-photo-id page without an identity
       When I submit a 'ukPassport' event
@@ -451,7 +631,102 @@ Feature: P2 Web document journey
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-  #  PYIC-9059 these tests will need equivalent Open Banking versions once it is possible to get through KBV with Open Banking
+  Rule: Open Banking CRI results
+    Background: Get to Open Banking with a photo ID
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context     | Value |
+        | deviceType  | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'drivingLicence' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-dva-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+
+    Scenario: Successful web journey - user retries Open Banking
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'tryAgain' event
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: User fails to select current account and tries app
+      When I submit 'kenneth-score-0' details to the CRI stub
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value       |
+        | reason  | openBanking |
+      When I submit a 'appTriage' event
+      Then I get an 'identify-device' page response
+
+    Scenario: User fails to select current account and tries Post Office
+      When I submit 'kenneth-score-0' details to the CRI stub
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value       |
+        | reason  | openBanking |
+      When I submit a 'f2f' event
+      Then I get a 'pyi-post-office' page response
+
+    Scenario: User fails Open Banking with breaching CI
+      When I submit 'kenneth-with-breaching-ci' details to the CRI stub
+      Then I get a 'pyi-no-match' page response
+
+    Scenario: Open Banking CRI returns an error - user tries again
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'tryAgain' event
+      Then I get an 'openBanking' CRI response
+
+    Scenario: Open Banking CRI returns an error - user tries app
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'app' event
+      Then I get an 'identify-device' page response
+
+    Scenario: Open Banking CRI returns an error - user tries Post Office
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'postOffice' event
+      Then I get a 'pyi-post-office' page response
+
+    Scenario: Open Banking CRI returns an error - user returns to RP
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
   Rule: P2 VTR only - User drops out of KBV CRI via thin file or failed checks - no Open Banking
     Background: Navigate to KBV CRI
       Given I activate the 'openBankingDisabled' feature set
@@ -480,6 +755,140 @@ Feature: P2 Web document journey
       When I submit 'kenneth-score-2' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+
+    Scenario: KBV score zero - user is able to receive identity via DCMAW
+      When I submit 'kenneth-score-0' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value   |
+        | reason  | dropout |
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context     | Value |
+        | deviceType  | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+    Scenario: KBV score zero - user is able to receive identity via F2F
+      When I submit 'kenneth-score-0' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value   |
+        | reason  | dropout |
+      When I submit an 'f2f' event
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: KBV score zero - user is able to receive identity via F2F after dropping out of DCMAW
+      When I submit 'kenneth-score-0' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response and pageContext
+        | Context | Value   |
+        | reason  | dropout |
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context     | Value |
+        | deviceType  | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'pyi-post-office' page response
+      When I submit an 'next' event
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+  Rule: P2 VTR only - User drops out of KBV CRI via thin file or failed checks
+    Background: Navigate to KBV CRI
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context     | Value |
+        | deviceType  | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
       Then I get a 'personal-independence-payment' page response
       When I submit a 'end' event
       Then I get a 'page-pre-experian-kbv-transition' page response

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -81,8 +81,68 @@ Feature: Return exit codes
     And I don't have a stored identity in EVCS
     And I get 'non-ci-breaching' return code
 
-  #  PYIC-9059 this test will need an equivalent version once it is possible to get to KBVs via Open Banking
   Scenario: KBV score zero and failure to complete journey - non-ci-breaching code returned
+    Given I activate the 'openBanking' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+    When I submit a 'neither' event
+    Then I get a 'pyi-triage-buffer' page response
+    When I submit an 'anotherWay' event
+    Then I get a 'select-photo-id' page response
+    When I submit an 'drivingLicence' event
+    Then I get a 'prove-identity-online' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
+    When I submit a 'next' event
+    Then I get a 'prove-identity-online-banking' page response
+    When I submit a 'next' event
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get an 'openBanking' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'photo-id-banking-another-way' page response
+    When I submit an 'answerSecurityQuestions' event
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'experianKbv' CRI response
+    When I submit 'kenneth-score-0' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+    Then I get a 'photo-id-web-find-another-way' page response and pageContext
+      | Context | Value   |
+      | reason  | dropout |
+    When I submit a 'f2f' event
+    Then I get a 'f2f' CRI response
+    When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+    Then I get a 'pyi-another-way' page response
+    When I submit a 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a 'P0' identity
+    And I don't have a stored identity in EVCS
+    And I get 'non-ci-breaching' return code
+
+  Scenario: KBV score zero and failure to complete journey - non-ci-breaching code returned - no Open Banking
     Given I activate the 'openBankingDisabled' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response
@@ -217,8 +277,105 @@ Feature: Return exit codes
     And I have a stored identity record with a 'P3' max vot
     And I get 'always-required' return code
 
-  #  PYIC-9059 this test will need an equivalent version once it is possible to get to KBVs via Open Banking
   Scenario: Breaching CI codes generate return codes, including mitigated CIs - CI codes returned
+    Given I activate the 'openBanking' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+    When I submit a 'neither' event
+    Then I get a 'pyi-triage-buffer' page response
+    When I submit an 'anotherWay' event
+    Then I get a 'select-photo-id' page response
+    When I submit an 'ukPassport' event
+    Then I get a 'prove-identity-online' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
+    When I submit a 'next' event
+    Then I get a 'prove-identity-online-banking' page response
+    When I submit a 'next' event
+    Then I get a 'ukPassport' CRI response
+    When I submit 'kenneth-passport-valid' details to the CRI stub
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":2} |
+    Then I get an 'openBanking' CRI response
+    When I call the CRI stub and get an 'access_denied' OAuth error
+    Then I get a 'photo-id-banking-another-way' page response
+    When I submit an 'answerSecurityQuestions' event
+    Then I get a 'personal-independence-payment' page response
+    When I submit a 'end' event
+    Then I get a 'page-pre-experian-kbv-transition' page response
+    When I submit a 'next' event
+    Then I get a 'experianKbv' CRI response
+    When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+      | Attribute          | Values                                          |
+      | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+    Then I get a 'photo-id-web-find-another-way' page response
+    When I submit an 'f2f' event
+    Then I get a 'f2f' CRI response
+    When I call the CRI stub with attributes and get an 'access_denied' OAuth error
+      | Attribute          | Values                                      |
+      | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+    Then I get a 'pyi-another-way' page response
+    When I submit an 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a 'P0' identity
+    And I don't have a stored identity in EVCS
+    And I get 'non-breaching,needs-enhanced-verification' return codes
+
+    # New journey with the same user id
+    When I start a new 'medium-confidence' journey
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'smartphone' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | mam   |
+    When I submit an 'iphone' event
+    Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+      | Context    | Value  |
+      | smartphone | iphone |
+      | isAppOnly  | false  |
+    When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-ENHANCED-VERIFICATION' CI
+    # And the user returns from the app to core-front
+    And I pass on the DCMAW callback
+    Then I get a 'check-mobile-app-result' page response
+    When I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'page-dcmaw-success' page response
+    When I submit a 'next' event
+    Then I get an 'address' CRI response
+    When I submit 'kenneth-current' details to the CRI stub
+    Then I get a 'fraud' CRI response
+    When I submit 'kenneth-score-0-breaching' details with attributes to the CRI stub
+      | Attribute          | Values                   |
+      | evidence_requested | {"identityFraudScore":1} |
+    Then I get a 'pyi-no-match' page response
+    When I submit an 'next' event
+    Then I get an OAuth response
+    When I use the OAuth response to get my identity
+    Then I am issued a 'P0' identity
+    And I don't have a stored identity in EVCS
+    And I get 'non-breaching,breaching,needs-enhanced-verification' return codes
+
+  Scenario: Breaching CI codes generate return codes, including mitigated CIs - CI codes returned - no Open Banking
     Given I activate the 'openBankingDisabled' feature set
     When I start a new 'medium-confidence' journey
     Then I get a 'live-in-uk' page response

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -50,7 +50,44 @@ Feature: Stored Identity - P2 journeys
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
 
-    #  PYIC-9059 this test will need an equivalent version once it is possible to get to complete a journey via Open Banking
+    Scenario: Successful stored identity storage - P2 web journey
+      Given I activate the 'openBanking' feature set
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
     Scenario: Successful stored identity storage - P2 web journey - no Open Banking
       Given I activate the 'openBankingDisabled' feature set
       When I submit an 'appTriage' event

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -1,8 +1,126 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: TICF failed/error journeys
   # These tests check what happens if a user gets to KBVs and then needs enhanced verification
-  #  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to get to KBVs via Open Banking
   Rule: Via enhanced-verification journey
+    Background: Start TICF enhanced verification journey
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+
+    Scenario: TICF failed enhanced-verification journey - PYI_NO_MATCH
+      When I submit a 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
+    # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+      And the TICF VC has properties
+        | cis  |                              |
+        | type | RiskAssessment               |
+
+    Scenario: TICF failed enhanced-verification journey - PYI_ANOTHER_WAY
+      When I submit a 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'pyi-post-office' page response
+      When I submit a 'end' event
+      Then I get a 'pyi-another-way' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+      And the TICF VC has properties
+        | cis  |                              |
+        | type | RiskAssessment               |
+
+    Scenario: TICF failed enhanced-verification journey - PYI_TECHNICAL
+      When I submit an 'f2f' event
+      Then I get a 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'temporarily_unavailable' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'pyi-technical' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+      And the TICF VC has properties
+        | cis  |                              |
+        | type | RiskAssessment               |
+
+  Rule: Via enhanced-verification journey - no Open Banking
     Background: Start TICF enhanced verification journey
       Given I activate the 'openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -20,7 +20,6 @@ Feature: Handling unexpected CRI errors
       When I submit an 'anotherWay' event
       Then I get a 'page-multiple-doc-check' page response
 
-    #  PYIC-9059 this test will need an equivalent duplicate version once it is possible to get complete a journey via Open Banking
     Scenario Outline: Unexpected error from <cri> - try CRI again
       When I submit a '<cri>' event
       Then I get a '<cri>' CRI response
@@ -149,7 +148,6 @@ Feature: Handling unexpected CRI errors
         | ukPassport     |
         | drivingLicence |
 
-    #  PYIC-9059 this test will need an equivalent duplicate version once it is possible to get complete a journey via Open Banking
     Scenario Outline: CI from <ci_cri> then unexpected error twice from <mitigating_cri> before success
       When I submit a '<ci_cri>' event
       Then I get a '<ci_cri>' CRI response
@@ -196,7 +194,6 @@ Feature: Handling unexpected CRI errors
         | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
         | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
 
-    #  PYIC-9059 this test will need an equivalent duplicate version once it is possible to get complete a journey via Open Banking
     Scenario Outline: CI from <ci_cri> then separate session unexpected error twice from <mitigating_cri> before success
       When I submit a '<ci_cri>' event
       Then I get a '<ci_cri>' CRI response
@@ -293,14 +290,48 @@ Feature: Handling unexpected CRI errors
       When I submit an 'anotherWay' event
       Then I get a 'select-photo-id' page response
 
+    Scenario Outline: Unexpected error from <cri> - try CRI again
+      When I submit a '<cri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<cri>' CRI response
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'tryAgain' event
+      Then I get a '<cri>' CRI response
+      When I submit '<details>' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | cri            | details                      |
+        | ukPassport     | kenneth-passport-valid       |
+        | drivingLicence | kenneth-driving-permit-valid |
+
     Scenario Outline: Unexpected error from <cri> - try app route
       When I submit a '<cri>' event
       Then I get a 'prove-identity-online' page response and pageContext
         | Context | Value |
         | photoId | true  |
-      When I submit an 'next' event
+      When I submit a 'next' event
       Then I get a 'prove-identity-online-banking' page response
-      When I submit an 'next' event
+      When I submit a 'next' event
       Then I get a '<cri>' CRI response
       And I call the CRI stub and get a 'server_error' OAuth error
       Then I get a 'sorry-technical-problem' page response
@@ -349,9 +380,9 @@ Feature: Handling unexpected CRI errors
       Then I get a 'prove-identity-online' page response and pageContext
         | Context | Value |
         | photoId | true  |
-      When I submit an 'next' event
+      When I submit a 'next' event
       Then I get a 'prove-identity-online-banking' page response
-      When I submit an 'next' event
+      When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I call the CRI stub and get a 'server_error' OAuth error
       Then I get a 'sorry-technical-problem' page response
@@ -388,9 +419,9 @@ Feature: Handling unexpected CRI errors
       Then I get a 'prove-identity-online' page response and pageContext
         | Context | Value |
         | photoId | true  |
-      When I submit an 'next' event
+      When I submit a 'next' event
       Then I get a 'prove-identity-online-banking' page response
-      When I submit an 'next' event
+      When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I call the CRI stub and get a 'server_error' OAuth error
       Then I get a 'sorry-technical-problem' page response
@@ -405,14 +436,114 @@ Feature: Handling unexpected CRI errors
         | ukPassport     |
         | drivingLicence |
 
+    Scenario Outline: CI from <ci_cri> then unexpected error twice from <mitigating_cri> before success
+      When I submit a '<ci_cri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<ci_cri>' CRI response
+      When I submit '<ci_details>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigating_cri>' CRI response
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response and pageContext
+        | Context | Value                   |
+        | reason  | dlOrPassportMitigation  |
+      When I submit a 'tryAgain' event
+      Then I get a '<mitigating_cri>' CRI response
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response and pageContext
+        | Context | Value                   |
+        | reason  | dlOrPassportMitigation  |
+      When I submit a 'tryAgain' event
+      Then I get a '<mitigating_cri>' CRI response
+      When I submit '<mitigating_details>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | ci_cri            | ci_details                                 | noMatchPage                              | mitigating_cri | mitigating_details           |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence | kenneth-driving-permit-valid |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     | kenneth-passport-valid       |
+
+    Scenario Outline: CI from <ci_cri> then separate session unexpected error twice from <mitigating_cri> before success
+      When I submit a '<ci_cri>' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a '<ci_cri>' CRI response
+      When I submit '<ci_details>' details to the CRI stub
+      Then I get a '<noMatchPage>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigating_cri>' CRI response
+
+      # User drops out of previous CRI without mitigating and starts a new journey
+      Given I start a new 'medium-confidence' journey
+      Then I get a '<separateSessionNoMatch>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigationStart>' page response
+      When I submit a 'next' event
+      Then I get a '<mitigating_cri>' CRI response
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response and pageContext
+        | Context | Value                   |
+        | reason  | dlOrPassportMitigation  |
+      When I submit a 'tryAgain' event
+      Then I get a '<mitigating_cri>' CRI response
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response and pageContext
+        | Context | Value                   |
+        | reason  | dlOrPassportMitigation  |
+      When I submit a 'tryAgain' event
+      Then I get a '<mitigating_cri>' CRI response
+      When I submit '<mitigating_details>' details to the CRI stub that mitigate the 'NEEDS-ALTERNATE-DOC' CI
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+      Examples:
+        | ci_cri            | ci_details                                 | noMatchPage                              | separateSessionNoMatch       | mitigationStart                   | mitigating_cri | mitigating_details           |
+        | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | pyi-passport-no-match        | pyi-continue-with-driving-licence | drivingLicence | kenneth-driving-permit-valid |
+        | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | pyi-driving-licence-no-match | pyi-continue-with-passport        | ukPassport     | kenneth-passport-valid       |
+
     Scenario Outline: CI from <ci_cri> then unexpected error from <mitigating_cri> and return to RP
       When I submit a '<ci_cri>' event
       Then I get a 'prove-identity-online' page response and pageContext
         | Context | Value |
         | photoId | true  |
-      When I submit an 'next' event
+      When I submit a 'next' event
       Then I get a 'prove-identity-online-banking' page response
-      When I submit an 'next' event
+      When I submit a 'next' event
       Then I get a '<ci_cri>' CRI response
       When I submit '<ci_details>' details to the CRI stub
       Then I get a '<noMatchPage>' page response
@@ -433,8 +564,131 @@ Feature: Handling unexpected CRI errors
         | ukPassport        | kenneth-passport-needs-alternate-doc       | pyi-passport-no-match-another-way        | drivingLicence |
         | drivingLicence    | kenneth-driving-permit-needs-alternate-doc | pyi-driving-licence-no-match-another-way | ukPassport     |
 
-  #  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to get to KBVs via Open Banking
   Rule: Experian KBV
+    Background: Route to sorry-technical-problem Experian KBV CRI error page
+      Given I activate the 'openBanking' feature set
+      And I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context     | Value |
+        | deviceType  | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'sorry-technical-problem' page response and pageContext
+        | Context | Value       |
+        | reason  | kbvCriError |
+
+    Scenario: Unexpected error from Experian KBV CRI - try CRI again
+      When I submit a 'tryAgain' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Unexpected error from Experian KBV CRI - try app route
+      When I submit a 'app' event
+      Then I get a 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":1} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+    Scenario: Unexpected error from Experian KBV CRI - try post office route
+      When I submit a 'postOffice' event
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-passport-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Unexpected error from Experian KBV CRI - return to RP
+      When I submit an 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+  Rule: Experian KBV - no Open Banking
     Background: Route to sorry-technical-problem Experian KBV CRI error page
       Given I activate the 'openBankingDisabled' feature set
       And I start a new 'medium-confidence' journey
@@ -628,7 +882,6 @@ Feature: Handling unexpected CRI errors
       Then I am issued a 'P2' identity
       And I have a stored identity record with a 'P3' max vot
 
-    #  PYIC-9059 this test will need an equivalent duplicate version once it is possible to get complete a journey via Open Banking
     Scenario: Unexpected error from F2F CRI - try web route
       When I submit a 'webRoute' event
       Then I get a 'page-multiple-doc-check' page response
@@ -745,6 +998,33 @@ Feature: Handling unexpected CRI errors
       Then I am issued a 'P2' identity
       And I have a stored identity record with a 'P3' max vot
 
+    Scenario: Unexpected error from F2F CRI - try web route
+      When I submit a 'webRoute' event
+      Then I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
     Scenario: Unexpected error from F2F CRI - return to RP
       When I submit an 'returnToRp' event
       Then I get an OAuth response
@@ -859,8 +1139,159 @@ Feature: Handling unexpected CRI errors
       Then I am issued a 'P1' identity
       And I have a stored identity record with a 'P2' max vot
 
-  #  PYIC-9059 these tests will need equivalent duplicate versions once it is possible to get to KBVs via Open Banking
   Rule: F2F CRI mitigation via Experian KBV
+    Background: Route to sorry-technical-problem F2F mitigation error page
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When I submit a 'preferNoApp' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' eventThen I get a 'select-photo-id' page response
+      When I submit an 'ukPassport' event
+      Then I get a 'prove-identity-online' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
+      Then I get a 'ukPassport' CRI response
+      When I submit 'kenneth-passport-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'end' event
+      Then I get a 'page-pre-experian-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'experianKbv' CRI response
+      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'photo-id-web-find-another-way' page response
+
+    Scenario: Same session mitigation via F2F - return to RP
+      When I submit a 'f2f' event
+      Then I get a 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'sorry-technical-problem' page response and pageContext
+        | Context | Value         |
+        | reason  | kbvMitigation |
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Same session mitigation via F2F - switch to app after error
+      When I submit a 'f2f' event
+      Then I get a 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'sorry-technical-problem' page response and pageContext
+        | Context | Value         |
+        | reason  | kbvMitigation |
+      When I submit a 'app' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Separate session F2F enhanced verification mitigation - user fails KBV - mitigate via F2F
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-identity-document-start' page response
+      And I submit an 'end' event
+      Then I get a 'page-ipv-identity-postoffice-start' page response
+      When I submit a 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'f2f' CRI response
+      When I call the CRI stub with attributes and get a 'server_error' OAuth error
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'sorry-technical-problem' page response and pageContext
+        | Context | Value         |
+        | reason  | kbvMitigation |
+      When I submit a 'app' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub that mitigate the 'NEEDS-ENHANCED-VERIFICATION' CI
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+  Rule: F2F CRI mitigation via Experian KBV - no Open Banking
     Background: Route to sorry-technical-problem F2F mitigation error page
       Given I activate the 'openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -220,7 +220,7 @@ states:
         targetJourney: FAILED
         targetState: FAILED
       failWithNoCiFromApp:
-        targetState: MULTIPLE_DOC_CHECK_PAGE
+        targetState: SELECT_PHOTO_ID
         journeyContextToUnset: appOnly
         checkMitigation:
           enhanced-verification:
@@ -229,6 +229,17 @@ states:
               f2f:
                 targetJourney: INELIGIBLE
                 targetState: INELIGIBLE
+        checkIfDisabled:
+          openBanking:
+            targetState: MULTIPLE_DOC_CHECK_PAGE
+            journeyContextToUnset: appOnly
+            checkMitigation:
+              enhanced-verification:
+                targetState: MITIGATION_01_PYI_POST_OFFICE
+                checkIfDisabled:
+                  f2f:
+                    targetJourney: INELIGIBLE
+                    targetState: INELIGIBLE
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
         journeyContextToUnset: appOnly

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -146,7 +146,10 @@ states:
         targetState: STRATEGIC_APP_TRIAGE
         checkIfDisabled:
           dcmawAsync:
-            targetState: MULTIPLE_DOC_CHECK_PAGE
+            targetState: SELECT_PHOTO_ID
+            checkIfDisabled:
+              openBanking:
+                targetState: MULTIPLE_DOC_CHECK_PAGE
       end:
         targetState: PROVE_IDENTITY_ONLINE_NO_PHOTO_ID
         checkIfDisabled:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -484,11 +484,55 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetJourney: FAILED
-        targetState: FAILED
+        targetState: PROCESS_NEW_IDENTITY
+      access-denied:
+        targetState: OPEN_BANKING_PHOTO_ID_ANOTHER_WAY
+      fail-with-no-ci:
+        targetState: OPEN_BANKING_PHOTO_ID_WEB_ANOTHER_WAY
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED
+      error:
+        targetState: OPEN_BANKING_PHOTO_ID_SORRY_CRI_TECHNICAL_ERROR
+
+  OPEN_BANKING_PHOTO_ID_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: photo-id-banking-another-way
+    events:
+      tryAgain:
+        targetState: OPEN_BANKING_CRI_PHOTO_ID
+      answerSecurityQuestions:
+        targetState: KBV_PHOTO_ID
+        targetEntryEvent: next
+
+  OPEN_BANKING_PHOTO_ID_WEB_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: photo-id-web-find-another-way
+      pageContext:
+        reason: openBanking
+    events:
+      appTriage:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+      f2f:
+        targetState: PYI_POST_OFFICE
+
+  OPEN_BANKING_PHOTO_ID_SORRY_CRI_TECHNICAL_ERROR:
+    response:
+      type: page
+      pageId: sorry-technical-problem
+    events:
+      tryAgain:
+        targetState: OPEN_BANKING_CRI_PHOTO_ID
+      app:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+      postOffice:
+        targetState: PYI_POST_OFFICE
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   OPEN_BANKING_CRI_NO_PHOTO_ID:
     response:

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -321,10 +321,10 @@ core:
           authorizeUrl: https://open-banking-cri.stubs.account.gov.uk/authorize
           tokenUrl: https://open-banking-cri.stubs.account.gov.uk/token
           credentialUrl: https://open-banking-cri.stubs.account.gov.uk/credentials/issue
-          clientId: ipv-core-build
+          clientId: ipv-core-local
           signingKey: '{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"RBXnILIdExUEWUJMlYeD6agE8u9gGgA3InKrd5TKhhY\",\"y\":\"kKtt9v_xq9oqvv5_E8AHcV77IYQfyNwaTQyTYxdO_UM\"}' # pragma: allowlist secret
           componentId: https://open-banking-cri.stubs.account.gov.uk
-          clientCallbackUrl: https://identity.staging.account.gov.uk/credential-issuer/callback?id=openBanking
+          clientCallbackUrl: http://localhost:4501/credential-issuer/callback/openBanking
           requiresApiKey: false
           requiresAdditionalEvidence: false
           jwksUrl: https://open-banking-cri.stubs.account.gov.uk/.well-known/jwks.json


### PR DESCRIPTION
## Proposed changes
### What changed

Add routing for after the Open Banking CRI for photo ID journeys

### Why did it change

New routes

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9059](https://govukverify.atlassian.net/browse/PYIC-9059)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated

[PYIC-9059]: https://govukverify.atlassian.net/browse/PYIC-9059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ