### PR TITLE
BAU Correct cross-browser mitigation API tests setup

### DIFF
--- a/api-tests/features/app-cross-browser/p1-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p1-cross-browser.feature
@@ -170,12 +170,9 @@ Feature: P1 V2 App Cross Browser Scenario
   Rule: Cross-browser during separate-session enhanced verification mitigation
     Background: Start separate-session enhanced verification mitigation
       Given I activate the 'drivingLicenceAuthCheck' feature set
-      And the subject already has the following credentials
-        | CRI         | scenario                            |
-        | ukPassport  | kenneth-passport-valid              |
-        | address     | kenneth-current                     |
-        | fraud       | kenneth-score-2                     |
-        | experianKbv | kenneth-needs-enhanced-verification |
+      And the subject has the following CIs
+        | Code                        |
+        | NEEDS-ENHANCED-VERIFICATION |
 
       # Separate session mitigation
       When I start a new 'low-confidence' journey

--- a/api-tests/features/app-cross-browser/p2-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p2-cross-browser.feature
@@ -260,12 +260,9 @@ Feature: P2 V2 App Cross Browser Scenario
   Rule: Cross-browser during separate-session enhanced verification mitigation
     Background: Start separate-session enhanced verification mitigation
       Given I activate the 'drivingLicenceAuthCheck' feature set
-      And the subject already has the following credentials
-        | CRI         | scenario                            |
-        | ukPassport  | kenneth-passport-valid              |
-        | address     | kenneth-current                     |
-        | fraud       | kenneth-score-2                     |
-        | experianKbv | kenneth-needs-enhanced-verification |
+      And the subject has the following CIs
+        | Code                        |
+        | NEEDS-ENHANCED-VERIFICATION |
 
       # Separate session mitigation
       When I start a new 'medium-confidence' journey


### PR DESCRIPTION
## Proposed changes
### What changed

The cross-browser mitigation test backgrounds in p1 and p2 no longer pre-store VCs as CURRENT. Instead they set up the CI directly using 'the subject has the following CIs'.

### Why did it change

The tests model a user who got a CI during a fresh proving journey and dropped out before proving their identity. That user wouldn't have CURRENT VCs in EVCS - the identity was never successfully proven, so nothing would have been stored. Pre-storing VCs as CURRENT made the test setup unrealistic and could mask routing bugs where the presence of an existing identity changes behaviour.

### Issue tracking
Spotted while investigating [PYIC-8941](https://govukverify.atlassian.net/browse/PYIC-8941)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-8941]: https://govukverify.atlassian.net/browse/PYIC-8941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ