### PR TITLE
PYIC-9204: Fix NullPointerException trying to look up unknown client config

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -314,22 +314,29 @@ public class InitialiseIpvSessionHandler
     }
 
     private Optional<ErrorResponse> validateSessionParams(Map<String, String> sessionParams) {
-        boolean isInvalid = false;
-
-        if (StringUtils.isBlank(sessionParams.get(CLIENT_ID_PARAM_KEY))) {
-            LOGGER.warn(LogHelper.buildLogMessage("Missing client_id query parameter"));
-            isInvalid = true;
+        if (sessionParams == null) {
+            LOGGER.warn(LogHelper.buildLogMessage("Session parameters map is null"));
+            return Optional.of(ErrorResponse.INVALID_SESSION_REQUEST);
         }
-        LogHelper.attachClientIdToLogs(sessionParams.get(CLIENT_ID_PARAM_KEY));
+
+        String clientId = sessionParams.get(CLIENT_ID_PARAM_KEY);
+        if (StringUtils.isBlank(clientId)) {
+            LOGGER.warn(LogHelper.buildLogMessage("Missing client_id query parameter"));
+            return Optional.of(ErrorResponse.INVALID_SESSION_REQUEST);
+        }
+
+        LogHelper.attachClientIdToLogs(clientId);
 
         if (StringUtils.isBlank(sessionParams.get(REQUEST_PARAM_KEY))) {
             LOGGER.warn(LogHelper.buildLogMessage("Missing request query parameter"));
-            isInvalid = true;
-        }
-
-        if (isInvalid) {
             return Optional.of(ErrorResponse.INVALID_SESSION_REQUEST);
         }
+
+        if (configService.getConfiguration().getClientConfig(clientId) == null) {
+            LOGGER.warn(LogHelper.buildLogMessage("Unknown client_id query parameter provided"));
+            return Optional.of(ErrorResponse.INVALID_SESSION_REQUEST);
+        }
+
         return Optional.empty();
     }
 }

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -38,6 +38,8 @@ import uk.gov.di.ipv.core.initialiseipvsession.exception.RecoverableJarValidatio
 import uk.gov.di.ipv.core.initialiseipvsession.validation.JarValidator;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
+import uk.gov.di.ipv.core.library.config.domain.ClientConfig;
+import uk.gov.di.ipv.core.library.config.domain.Config;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.exceptions.HttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.core.library.fixtures.TestFixtures;
@@ -76,6 +78,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -117,6 +120,9 @@ class InitialiseIpvSessionHandlerTest {
     @Mock private ConfigService mockConfigService;
     @Mock private JarValidator mockJarValidator;
     @Mock private AuditService mockAuditService;
+    @Mock private Config mockConfig;
+    @Mock private ClientConfig mockClientConfig;
+
     @InjectMocks private InitialiseIpvSessionHandler initialiseIpvSessionHandler;
 
     @Captor private ArgumentCaptor<ErrorObject> errorObjectArgumentCaptor;
@@ -155,7 +161,11 @@ class InitialiseIpvSessionHandlerTest {
         clientOAuthSessionItem.setEvcsAccessToken(TEST_EVCS_ACCESS_TOKEN);
         clientOAuthSessionItem.setReproveIdentity(false);
 
-        when(mockConfigService.getComponentId()).thenReturn("https://core-component.example");
+        lenient()
+                .when(mockConfigService.getComponentId())
+                .thenReturn("https://core-component.example");
+        lenient().when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
+        lenient().when(mockConfig.getClientConfig(anyString())).thenReturn(mockClientConfig);
     }
 
     @AfterEach
@@ -520,6 +530,31 @@ class InitialiseIpvSessionHandlerTest {
         // Act
         APIGatewayProxyResponseEvent response =
                 initialiseIpvSessionHandler.handleRequest(missingRequestEvent, mockContext);
+
+        // Assert
+        Map<String, Object> responseBody =
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatusCode.BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorResponse.INVALID_SESSION_REQUEST.getCode(), responseBody.get("code"));
+        assertEquals(
+                ErrorResponse.INVALID_SESSION_REQUEST.getMessage(), responseBody.get("message"));
+    }
+
+    @Test
+    void shouldReturn400IfUnknownClientId() throws JsonProcessingException {
+        // Arrange
+        when(mockConfig.getClientConfig("unknown-client")).thenReturn(null);
+
+        APIGatewayProxyRequestEvent unknownClientEvent = new APIGatewayProxyRequestEvent();
+        Map<String, Object> sessionParams =
+                Map.of("clientId", "unknown-client", "request", signedEncryptedJwt.serialize());
+        unknownClientEvent.setBody(OBJECT_MAPPER.writeValueAsString(sessionParams));
+        unknownClientEvent.setHeaders(Map.of("ip-address", TEST_IP_ADDRESS));
+
+        // Act
+        APIGatewayProxyResponseEvent response =
+                initialiseIpvSessionHandler.handleRequest(unknownClientEvent, mockContext);
 
         // Assert
         Map<String, Object> responseBody =


### PR DESCRIPTION
## Proposed changes
### What changed

- Fix NullPointerException trying to look up unknown client config

<img width="427" height="498" alt="Screenshot 2026-07-28 at 11 22 29" src="https://github.com/user-attachments/assets/01d27d15-d9bf-42ff-b9de-96e67dfd3898" />


### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9204](https://govukverify.atlassian.net/browse/PYIC-9204)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9204]: https://govukverify.atlassian.net/browse/PYIC-9204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ