### PR TITLE
BAU: Remove  '# pragma: allowlist secret' from .env.template.

### DIFF
--- a/api-tests/.env.template
+++ b/api-tests/.env.template
@@ -20,4 +20,4 @@
 # MANAGEMENT_TICF_API_KEY=
 
 # Required for signing JAR passed to initialise-ipv-session lambda, found in stubs-common-infra  ORCHESTRATOR_SIGNING_JWK
-#JAR_SIGNING_KEY='' # pragma: allowlist secret
+#JAR_SIGNING_KEY=''


### PR DESCRIPTION
## Proposed changes
### What changed

- removed # pragma: allowlist secret from JAR_SIGNING_KEY in api-tests/.env.template file

### Why did it change

- This could allow to detect secrets to omit this key.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- BAU

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>
