### PR TITLE
PYIC-9058: Differentiate photo ID and non photo ID journeys

### DIFF
--- a/api-tests/features/app-cross-browser/p2-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p2-cross-browser.feature
@@ -102,7 +102,9 @@ Feature: P2 V2 App Cross Browser Scenario
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -205,7 +207,9 @@ Feature: P2 V2 App Cross Browser Scenario
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -107,7 +107,9 @@ Feature: Audit Events
       | Context | Value |
       | photoId | true  |
     When I submit a 'next' event
-    Then I get a 'prove-identity-online-banking' page response
+    Then I get a 'prove-identity-online-banking' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
     When I submit a 'next' event
     Then I get a 'drivingLicence' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -370,7 +372,9 @@ Feature: Audit Events
       | Context | Value |
       | photoId | true  |
     When I submit an 'next' event
-    Then I get a 'prove-identity-online-banking' page response
+    Then I get a 'prove-identity-online-banking' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
     When I submit an 'next' event
     Then I get a 'drivingLicence' CRI response
     When I submit 'kenneth-driving-permit-needs-alternate-doc' details to the CRI stub
@@ -762,7 +766,9 @@ Feature: Audit Events
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub

--- a/api-tests/features/cimit/p2-alternate-doc.feature
+++ b/api-tests/features/cimit/p2-alternate-doc.feature
@@ -26,7 +26,9 @@ Feature: P2 CIMIT - Alternate doc
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<initialCri>' CRI response
       When I submit '<initialInvalidDoc>' details to the CRI stub
@@ -60,7 +62,9 @@ Feature: P2 CIMIT - Alternate doc
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<initialCri>' CRI response
       When I submit '<initialInvalidDoc>' details to the CRI stub
@@ -102,7 +106,9 @@ Feature: P2 CIMIT - Alternate doc
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<initial-cri>' CRI response
       When I submit '<initial-invalid-doc>' details to the CRI stub
@@ -142,7 +148,9 @@ Feature: P2 CIMIT - Alternate doc
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-needs-alternate-doc' details to the CRI stub
@@ -387,7 +395,9 @@ Feature: P2 CIMIT - Alternate doc
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<initialCri>' CRI response
       When I submit '<initialInvalidDoc>' details to the CRI stub

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-dcmaw.feature
@@ -24,7 +24,9 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       | Context | Value |
       | photoId | true  |
     When I submit a 'next' event
-    Then I get a 'prove-identity-online-banking' page response
+    Then I get a 'prove-identity-online-banking' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
     When I submit a 'next' event
     Then I get a 'drivingLicence' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -170,7 +172,9 @@ Feature:  Mitigating CIs with enhanced verification using the DCMAW CRI
       | Context | Value |
       | photoId | true  |
     When I submit a 'next' event
-    Then I get a 'prove-identity-online-banking' page response
+    Then I get a 'prove-identity-online-banking' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
     When I submit a 'next' event
     Then I get a 'drivingLicence' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub

--- a/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
+++ b/api-tests/features/cimit/p2-enhanced-verification-mitigation-f2f.feature
@@ -24,7 +24,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -274,7 +276,9 @@ Feature: Mitigating CIs with enhanced verification using the F2F CRI
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -34,7 +34,9 @@ Feature: Disabled CRI journeys
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -119,7 +121,9 @@ Feature: Disabled CRI journeys
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -321,7 +325,9 @@ Feature: Disabled CRI journeys
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I submit an 'access-denied' event
@@ -489,7 +495,9 @@ Feature: Disabled CRI journeys
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       Then I get a 'ukPassport' CRI response

--- a/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
+++ b/api-tests/features/dl-auth-source-checks/p2-dl-auth-source-check.feature
@@ -330,7 +330,9 @@ Feature: P2 Journeys with DL authoritative source check
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -392,7 +394,9 @@ Feature: P2 Journeys with DL authoritative source check
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -443,7 +447,9 @@ Feature: P2 Journeys with DL authoritative source check
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub

--- a/api-tests/features/dl-auth-source-checks/p2-enhanced-verification-mitigation.feature
+++ b/api-tests/features/dl-auth-source-checks/p2-enhanced-verification-mitigation.feature
@@ -24,7 +24,9 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -472,7 +474,9 @@ Feature:  Mitigating CIs with enhanced verification using the async DCMAW CRI an
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub

--- a/api-tests/features/dwp-kbv/p2-alternate-doc-mitigation.feature
+++ b/api-tests/features/dwp-kbv/p2-alternate-doc-mitigation.feature
@@ -26,7 +26,9 @@ Feature: P2 CIMIT - Alternate doc - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<initialCri>' CRI response
       When I submit '<initialInvalidDoc>' details to the CRI stub
@@ -70,7 +72,9 @@ Feature: P2 CIMIT - Alternate doc - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<initialCri>' CRI response
       When I submit '<initialInvalidDoc>' details to the CRI stub
@@ -122,7 +126,9 @@ Feature: P2 CIMIT - Alternate doc - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<initialCri>' CRI response
       When I submit '<initialInvalidDoc>' details to the CRI stub
@@ -166,7 +172,9 @@ Feature: P2 CIMIT - Alternate doc - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<initialCri>' CRI response
       When I submit '<initialInvalidDoc>' details to the CRI stub

--- a/api-tests/features/dwp-kbv/p2-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p2-web-journey.feature
@@ -26,7 +26,9 @@ Feature: P2 Web document journey - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I submit '<details>' details to the CRI stub
@@ -66,7 +68,9 @@ Feature: P2 Web document journey - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I submit '<details>' details to the CRI stub
@@ -106,7 +110,9 @@ Feature: P2 Web document journey - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -160,7 +166,9 @@ Feature: P2 Web document journey - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -218,7 +226,9 @@ Feature: P2 Web document journey - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I submit '<details>' details to the CRI stub
@@ -266,7 +276,9 @@ Feature: P2 Web document journey - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I submit '<details>' details to the CRI stub
@@ -313,7 +325,9 @@ Feature: P2 Web document journey - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -348,7 +362,9 @@ Feature: P2 Web document journey - DWP KBV
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub

--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -414,7 +414,9 @@ Feature: P2 Fraud mitigation
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I submit '<details>' details to the CRI stub
@@ -442,7 +444,9 @@ Feature: P2 Fraud mitigation
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I submit '<details>' details to the CRI stub

--- a/api-tests/features/m1c-journeys.feature
+++ b/api-tests/features/m1c-journeys.feature
@@ -56,7 +56,9 @@ Feature: M1C Unavailable Journeys
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -395,7 +395,9 @@ Feature: P2 App journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -500,7 +502,9 @@ Feature: P2 App journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -73,7 +73,9 @@ Feature: P2 Web document journey
       | Context | Value |
       | photoId | true  |
     When I submit a 'next' event
-    Then I get a 'prove-identity-online-banking' page response
+    Then I get a 'prove-identity-online-banking' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
     When I submit a 'next' event
     Then I get a '<cri>' CRI response
     When I submit '<details>' details to the CRI stub
@@ -371,7 +373,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-dva-valid' details to the CRI stub
@@ -396,7 +400,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit '<details>' details to the CRI stub
@@ -424,7 +430,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -498,7 +506,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<initial-cri>' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error
@@ -534,7 +544,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error
@@ -553,7 +565,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I call the CRI stub and get an 'access_denied' OAuth error
@@ -591,7 +605,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I submit '<details>' details to the CRI stub
@@ -614,7 +630,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -655,7 +673,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-dva-valid' details to the CRI stub
@@ -875,7 +895,9 @@ Feature: P2 Web document journey
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -104,7 +104,9 @@ Feature: Return exit codes
       | Context | Value |
       | photoId | true  |
     When I submit a 'next' event
-    Then I get a 'prove-identity-online-banking' page response
+    Then I get a 'prove-identity-online-banking' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
     When I submit a 'next' event
     Then I get a 'drivingLicence' CRI response
     When I submit 'kenneth-driving-permit-valid' details to the CRI stub
@@ -300,7 +302,9 @@ Feature: Return exit codes
       | Context | Value |
       | photoId | true  |
     When I submit a 'next' event
-    Then I get a 'prove-identity-online-banking' page response
+    Then I get a 'prove-identity-online-banking' page response and pageContext
+      | Context | Value |
+      | photoId | true  |
     When I submit a 'next' event
     Then I get a 'ukPassport' CRI response
     When I submit 'kenneth-passport-valid' details to the CRI stub

--- a/api-tests/features/stored-identity/m1c-journeys.feature
+++ b/api-tests/features/stored-identity/m1c-journeys.feature
@@ -79,7 +79,9 @@ Feature: Stored Identity - M1C Outcomes
         | Context | Value |
         | photoId | true  |
       When I submit an 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit an 'next' event
       Then I get a 'drivingLicence' CRI response
       When I submit 'kenneth-driving-permit-valid' details to the CRI stub

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -69,7 +69,9 @@ Feature: Stored Identity - P2 journeys
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -25,7 +25,9 @@ Feature: TICF failed/error journeys
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub

--- a/api-tests/features/unexpected-cri-error.feature
+++ b/api-tests/features/unexpected-cri-error.feature
@@ -296,7 +296,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I call the CRI stub and get a 'server_error' OAuth error
@@ -330,7 +332,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       And I call the CRI stub and get a 'server_error' OAuth error
@@ -381,7 +385,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I call the CRI stub and get a 'server_error' OAuth error
@@ -420,7 +426,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<cri>' CRI response
       When I call the CRI stub and get a 'server_error' OAuth error
@@ -442,7 +450,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<ci_cri>' CRI response
       When I submit '<ci_details>' details to the CRI stub
@@ -488,7 +498,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<ci_cri>' CRI response
       When I submit '<ci_details>' details to the CRI stub
@@ -542,7 +554,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a '<ci_cri>' CRI response
       When I submit '<ci_details>' details to the CRI stub
@@ -588,7 +602,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -1006,7 +1022,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub
@@ -1167,7 +1185,9 @@ Feature: Handling unexpected CRI errors
         | Context | Value |
         | photoId | true  |
       When I submit a 'next' event
-      Then I get a 'prove-identity-online-banking' page response
+      Then I get a 'prove-identity-online-banking' page response and pageContext
+        | Context | Value |
+        | photoId | true  |
       When I submit a 'next' event
       Then I get a 'ukPassport' CRI response
       When I submit 'kenneth-passport-valid' details to the CRI stub

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -20,6 +20,7 @@ public class PageContextValidator extends AbstractPageContextValidator {
                     Map.entry("prove-identity-no-other-photo-id", Set.of(INVALID_DOC)),
                     Map.entry("prove-identity-no-photo-id", Set.of(NINO_ONLY)),
                     Map.entry("prove-identity-online", Set.of(PHOTO_ID)),
+                    Map.entry("prove-identity-online-banking", Set.of(PHOTO_ID)),
                     Map.entry("pyi-no-match", Set.of(REASON)),
                     Map.entry("pyi-technical", Set.of(IS_UNRECOVERABLE)),
                     Map.entry("pyi-triage-desktop-download-app", Set.of(SMARTPHONE, IS_APP_ONLY)),

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -327,6 +327,8 @@ states:
     response:
       type: page
       pageId: prove-identity-online-banking
+      pageContext:
+        photoId: true
     events:
       next:
         targetState: WEB_DL_OR_PASSPORT
@@ -356,6 +358,8 @@ states:
     response:
       type: page
       pageId: prove-identity-online-banking
+      pageContext:
+        photoId: true
     events:
       next:
         targetState: WEB_DL_OR_PASSPORT


### PR DESCRIPTION
## Proposed changes
### What changed

Use correct page contexts on `prove-identity-online-banking`

### Why did it change

All routes used the photo ID version

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9058](https://govukverify.atlassian.net/browse/PYIC-9058)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated


[PYIC-9058]: https://govukverify.atlassian.net/browse/PYIC-9058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ