### PR TITLE
PYIC-9223 Stop calling invalidate at journey start

### DIFF
--- a/api-tests/features/stored-identity.feature
+++ b/api-tests/features/stored-identity.feature
@@ -37,6 +37,8 @@ Feature: Stored Identity
       Then I get a 'page-update-name' page response and pageContext
         | Context     | Value            |
         | journeyType | repeatFraudCheck |
+      When I submit a 'update-name' event
+      Then I get an 'identify-device' page response
       And I have a stored identity record with a 'P2' max vot that is 'invalid'
 
     Scenario: Update address invalidates stored identity
@@ -53,4 +55,6 @@ Feature: Stored Identity
       Then I get a 'page-update-name' page response and pageContext
         | Context     | Value            |
         | journeyType | repeatFraudCheck |
+      When I submit a 'update-name' event
+      Then I get an 'identify-device' page response
       And I have a stored identity record with a 'P2' max vot that is 'invalid'

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -290,12 +290,9 @@ public class CheckExistingIdentityHandler
             }
 
             if (configService.enabled(SIS_VERIFICATION)) {
-                // Call this before we invalidate the stored identity!
                 sisService.compareStoredIdentityWithStoredVcs(
                         clientOAuthSessionItem, auditEventUser);
             }
-
-            evcsService.invalidateStoredIdentityRecord(clientOAuthSessionItem.getUserId());
 
             return getJourneyResponse(
                             ipvSessionItem,
@@ -309,7 +306,7 @@ public class CheckExistingIdentityHandler
                     .toObjectMap();
         } catch (AccountInterventionException e) {
             return JOURNEY_ACCOUNT_INTERVENTION.toObjectMap();
-        } catch (HttpResponseExceptionWithErrorBody | EvcsServiceException e) {
+        } catch (HttpResponseExceptionWithErrorBody e) {
             return new JourneyErrorResponse(
                             JOURNEY_ERROR_PATH, e.getResponseCode(), e.getErrorResponse())
                     .toObjectMap();

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -303,7 +303,7 @@ class CheckExistingIdentityHandlerTest {
             assertEquals(JOURNEY_IPV_GPG45_MEDIUM, journeyResponse);
 
             verify(auditService, never()).sendAuditEvent(auditEventArgumentCaptor.capture());
-            verify(mockEvcsService, times(1)).invalidateStoredIdentityRecord(TEST_USER_ID);
+            verify(mockEvcsService, never()).invalidateStoredIdentityRecord(TEST_USER_ID);
         }
 
         @Test


### PR DESCRIPTION
## Proposed changes
### What changed

- Removed the unconditional stored-identity invalidate call from CheckExistingIdentity, which ran at the start of every journey. Invalidation still happens in reset-identity when a user commits to an update.
- Updated API test scenarios to expect invalidation after the update is committed rather than at journey start.

### Why did it change

EVCS hit DynamoDB conflict errors seemingly caused by users starting parallel reuse journeys, where invalidating at journey start produced a rapid /invalidate→/identity sequence. We only need to invalidate when a user actually opts to update their details, which reset-identity already does - so the blanket call is unnecessary and removing it avoids the conflicting sequence. The up-front call was groundwork for SIS Phase 3, which will instead trigger invalidation from a new JAR claim.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9223](https://govukverify.atlassian.net/browse/PYIC-9223)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9223]: https://govukverify.atlassian.net/browse/PYIC-9223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ