### PR TITLE
Pyic 9171 open banking no photo

### DIFF
--- a/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
+++ b/api-tests/data/audit-events/strategic-app-cross-browser-journey.json
@@ -38,13 +38,6 @@
     }
   },
   {
-    "event_name": "IPV_APP_MISSING_CONTEXT",
-    "component_id": "https://identity.local.account.gov.uk",
-    "restricted": {
-      "device_information": {}
-    }
-  },
-  {
     "event_name": "IPV_ASYNC_CRI_VC_RECEIVED",
     "component_id": "https://identity.local.account.gov.uk",
     "user": {
@@ -123,6 +116,13 @@
         }
       ],
       "docExpiryDate": "2030-01-01"
+    }
+  },
+  {
+    "event_name": "IPV_APP_MISSING_CONTEXT",
+    "component_id": "https://identity.local.account.gov.uk",
+    "restricted": {
+      "device_information": {}
     }
   },
   {

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -314,7 +314,7 @@ Feature: Audit Events
 
     # Return journey
     When I start new 'medium-confidence' journeys until I get a 'pyi-f2f-technical' page response
-    When I submit a 'end' event
+    And I submit a 'end' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity
     Then I am issued a 'P0' identity without a TICF VC
@@ -638,6 +638,8 @@ Feature: Audit Events
       | smartphone | iphone |
       | isAppOnly  | false  |
     When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'success' VC
+    # Wait for the VC to be processed so the audit events are in a reliable order
+    And I wait for 5 seconds for the async credential to be processed
     # And the user returns from the app to core-front
     And I pass on the DCMAW callback in a separate session
     Then I get a 'problem-different-browser' page response

--- a/api-tests/features/disabled-cri-journeys.feature
+++ b/api-tests/features/disabled-cri-journeys.feature
@@ -12,14 +12,23 @@ Feature: Disabled CRI journeys
         | Context  | Value  |
         | ninoOnly | true   |
 
-    Scenario: A P2 journey takes the user down the web route instead
-      Given I activate the 'dcmawAsyncDisabled' feature set
+    Scenario: A P2 journey takes the user down the web route instead - no Open Banking
+      Given I activate the 'dcmawAsyncDisabled,openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
       When I submit a 'uk' event
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'appTriage' event
       Then I get a 'page-multiple-doc-check' page response
+
+    Scenario: A P2 journey takes the user down the web route instead
+      Given I activate the 'dcmawAsyncDisabled,openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get a 'select-photo-id' page response
 
     Scenario: Choosing DCMAW after escaping from KBV CRIs leads to technical failure
       Given I activate the 'dcmawAsyncDisabled,openBanking' feature set

--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -74,17 +74,13 @@ Feature: P2 Fraud mitigation
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'end' event
       Then I get a 'prove-identity-online' page response
-      When I submit an 'anotherWay' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
-      When I submit an 'next' event
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
       Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
       Then I get a 'nino' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub
         | Attribute          | Values                                      |
@@ -97,7 +93,7 @@ Feature: P2 Fraud mitigation
       When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
+      Then I get an 'openBanking' CRI response
 
     Scenario: Non-breaching, failing fraud CI fails journey
       When I submit 'kenneth-score-0-non-breaching' details with attributes to the CRI stub
@@ -302,17 +298,13 @@ Feature: P2 Fraud mitigation
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'end' event
       Then I get a 'prove-identity-online' page response
-      When I submit an 'anotherWay' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
+      When I submit an 'next' event
+      Then I get a 'prove-identity-online-banking' page response
       When I submit an 'next' event
       Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
       Then I get a 'nino' CRI response
       When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
         | Attribute          | Values                                      |

--- a/api-tests/features/p2-app-journey.feature
+++ b/api-tests/features/p2-app-journey.feature
@@ -171,7 +171,8 @@ Feature: P2 App journey
         | smartphone | android |
         | isAppOnly  | false   |
 
-    Scenario: MAM Fail DCMAW with no CI - route to alternative IPV method
+    Scenario: MAM Fail DCMAW with no CI - route to alternative IPV method - no Open Banking
+      Given I activate the 'openBankingDisabled' feature set
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -191,6 +192,28 @@ Feature: P2 App journey
       Then the poll returns a '201'
       When I submit the returned journey event
       Then I get a 'page-multiple-doc-check' page response
+
+    Scenario: MAM Fail DCMAW with no CI - route to alternative IPV method
+      Given I activate the 'openBanking' feature set
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'select-photo-id' page response
 
     Scenario: MAM journey abandoned without a VC - no Open Banking
       Given I activate the 'openBankingDisabled' feature set
@@ -234,7 +257,8 @@ Feature: P2 App journey
       When I submit the returned journey event
       Then I get a 'select-photo-id' page response
 
-    Scenario: MAM journey cross-browser scenario unsuccessful VC without CI
+    Scenario: MAM journey cross-browser scenario unsuccessful VC without CI - no Open Banking
+      Given I activate the 'openBankingDisabled' feature set
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
@@ -254,6 +278,28 @@ Feature: P2 App journey
       Then the poll returns a '201'
       When I submit the returned journey event
       Then I get a 'page-multiple-doc-check' page response
+
+    Scenario: MAM journey cross-browser scenario unsuccessful VC without CI
+      Given I activate the 'openBanking' feature set
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'select-photo-id' page response
 
     Scenario: MAM journey no compatible smartphone - no Open Banking
       Given I activate the 'openBankingDisabled' feature set
@@ -461,7 +507,8 @@ Feature: P2 App journey
       Then I am issued a 'P2' identity
       And I have a stored identity record with a 'P2' max vot
 
-    Scenario: DAD journey credential fails with with no ci and continues to other methods
+    Scenario: DAD journey credential fails with with no ci and continues to other methods - no Open Banking
+      Given I activate the 'openBankingDisabled' feature set
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
       When I submit a 'computer-or-tablet' event
@@ -478,6 +525,25 @@ Feature: P2 App journey
       Then the poll returns a '201'
       When I submit the returned journey event
       Then I get an 'page-multiple-doc-check' page response
+
+    Scenario: DAD journey credential fails with with no ci and continues to other methods
+      Given I activate the 'openBanking' feature set
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'select-photo-id' page response
 
     Scenario: DAD journey - BRP fails with with ci (score 1) goes to alternative document check
       Given I activate the 'openBanking' feature set

--- a/api-tests/features/p2-f2f-journey.feature
+++ b/api-tests/features/p2-f2f-journey.feature
@@ -521,17 +521,18 @@ Feature: P2 F2F journey
       When I submit a 'end' event
       Then I get an OAuth response
 
-    Scenario: F2F PYI escape route
-      Given I start a new 'medium-confidence' journey
-      Then I get a 'live-in-uk' page response
-      When I submit a 'uk' event
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-online' page response
-      When I submit an 'anotherWay' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
+  Scenario: F2F PYI escape route
+    Given I activate the 'openBanking' feature set
+    When I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'end' event
+    Then I get a 'prove-identity-online' page response
+    When I submit an 'anotherWay' event
+    Then I get a 'page-ipv-identity-postoffice-start' page response
+    When I submit an 'end' event
+    Then I get a 'pyi-escape' page response
 
   Rule: F2F evidence requested strength score
     Background: User has pending F2F verification

--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -1,5 +1,214 @@
 @Build @QualityGateIntegrationTest @QualityGateRegressionTest
 Feature: P2 no photo id journey
+  Rule: Open Banking CRI results
+    Background: Start P2 no photo id journey
+      Given I activate the 'openBanking' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'end' event
+      Then I get a 'prove-identity-online' page response
+      When I submit an 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit an 'next' event
+      Then I get a 'claimedIdentity' CRI response
+      When I submit 'kenneth-current' details with attributes to the CRI stub
+        | Attribute | Values         |
+        | context   | "bank_account" |
+      Then I get a 'nino' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get an 'openBanking' CRI response
+
+    Scenario: Successful web journey - user retries Open Banking
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'no-photo-id-banking-another-way' page response
+      When I submit an 'onlineBanking' event
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: User switches to F2F
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'no-photo-id-banking-another-way' page response
+      When I submit an 'postOffice' event
+      Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: User fails to select current account and tries app
+      When I submit 'kenneth-score-0' details to the CRI stub
+      Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
+        | Context | Value       |
+        | reason  | openBanking |
+      When I submit a 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+    Scenario: User fails to select current account and tries Post Office
+      When I submit 'kenneth-score-0' details to the CRI stub
+      Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
+        | Context | Value       |
+        | reason  | openBanking |
+      When I submit a 'f2f' event
+      Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                      |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: User fails to select current account and returns to RP
+      When I submit 'kenneth-score-0' details to the CRI stub
+      Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
+        | Context | Value       |
+        | reason  | openBanking |
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: User fails Open Banking with breaching CI
+      When I submit 'kenneth-with-breaching-ci' details to the CRI stub
+      Then I get a 'pyi-no-match' page response and pageContext
+        | Context | Value       |
+        | reason  | openBanking |
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Open Banking CRI returns an error - user tries again
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'tryAgain' event
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Open Banking CRI returns an error - user tries app
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'app' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+    Scenario: Open Banking CRI returns an error - user tries Post Office
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'postOffice' event
+      Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":3} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
+    Scenario: Open Banking CRI returns an error - user returns to RP
+      When I call the CRI stub and get a 'server_error' OAuth error
+      Then I get a 'sorry-technical-problem' page response
+      When I submit a 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
   Rule: Experian KBV
     Background: Start P2 no photo id with Experian KBV
       Given I activate the 'openBankingDisabled' feature set
@@ -179,7 +388,7 @@ Feature: P2 no photo id journey
         | Context | Value       |
         | reason  | bankAccount |
 
-  Rule: Abandon
+  Rule: Abandon NINO
     Background: Abandon P2 no photo id journey
       Given I activate the 'openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey
@@ -355,188 +564,7 @@ Feature: P2 no photo id journey
       Then I get a 'f2f' CRI response
 
   # Duplicate tests with Open Banking enabled
-  Rule: Experian KBV
-    Background: Start P2 no photo id with Experian KBV
-      Given I activate the 'openBanking' feature set
-      When I start a new 'medium-confidence' journey
-      Then I get a 'live-in-uk' page response
-      When I submit a 'uk' event
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-online' page response
-      When I submit an 'anotherWay' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
-      When I submit an 'next' event
-      Then I get a 'claimedIdentity' CRI response
-
-    Scenario: P2 no photo id journey - Experian - Happy path
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
-      Then I get a 'nino' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                      |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'end' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'experianKbv' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'page-ipv-success' page response
-      When I submit a 'next' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I am issued a 'P2' identity
-      And I have a stored identity record with a 'P2' max vot
-
-    Scenario: P2 no photo id journey - Experian - BAV dropout:
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I call the CRI stub and get an 'access_denied' OAuth error
-      Then I get a 'no-photo-id-abandon-find-another-way' page response
-
-    Scenario: P2 no photo id journey - Experian - Breaching BAV CI
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth-with-breaching-ci' details to the CRI stub
-      Then I get a 'pyi-no-match' page response and pageContext
-        | Context | Value       |
-        | reason  | bankAccount |
-
-    Scenario: P2 no photo id journey - Experian - NINO dropout:
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
-      Then I get a 'nino' CRI response
-      When I call the CRI stub with attributes and get an 'access_denied' OAuth error
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get a 'no-photo-id-abandon-find-another-way' page response
-
-    Scenario: P2 no photo id journey - Experian - Breaching NINO CI
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
-      Then I get a 'nino' CRI response
-      When I submit 'kenneth-with-breaching-ci' details with attributes to the CRI stub
-        | Attribute          | Values                                      |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get a 'pyi-no-match' page response and pageContext
-        | Context | Value |
-        | reason  | nino  |
-
-    Scenario: P2 no photo id journey - Experian - Drops out via thin file or failed checks
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
-      Then I get a 'nino' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                      |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'end' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'experianKbv' CRI response
-      When I submit 'kenneth-score-0' details with attributes to the CRI stub
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
-        | Context | Value   |
-        | reason  | dropout |
-
-    Scenario: P2 no photo id journey - Experian - Breaching KBV CI
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
-      Then I get a 'nino' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                      |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'end' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'experianKbv' CRI response
-      When I submit 'kenneth-with-breaching-ci' details with attributes to the CRI stub
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'pyi-no-match' page response
-
-    Scenario: P2 no photo id journey - Experian - KBV CI mitigation:
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
-      Then I get a 'nino' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                      |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'end' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'experianKbv' CRI response
-      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'no-photo-id-web-find-another-way' page response
-
-    Scenario: P2 no photo id journey - Experian - Breaching BAV CI
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth-with-breaching-ci' details to the CRI stub
-      Then I get a 'pyi-no-match' page response and pageContext
-        | Context | Value       |
-        | reason  | bankAccount |
-
-  Rule: Abandon
+  Rule: Abandon NINO
     Background: Abandon P2 no photo id journey
       Given I activate the 'openBanking' feature set
       When I start a new 'medium-confidence' journey
@@ -545,50 +573,22 @@ Feature: P2 no photo id journey
       Then I get a 'page-ipv-identity-document-start' page response
       When I submit an 'end' event
       Then I get a 'prove-identity-online' page response
-      When I submit an 'anotherWay' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
+      When I submit an 'next' event
+      Then I get a 'prove-identity-online-banking' page response
       When I submit an 'next' event
       Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
       Then I get a 'nino' CRI response
       When I call the CRI stub with attributes and get an 'access_denied' OAuth error
-        | Attribute          | Values                                          |
+        | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get a 'no-photo-id-abandon-find-another-way' page response
+      # PYIC-9224: Currently TBD where this event should go with open banking
+      Then I get a 'pyi-no-match' page response
 
-    Scenario: P2 no photo id journey - Abandon - Strategic app
-      Given I activate the 'strategicApp' feature set
-      When I submit an 'mobileApp' event
-      Then I get an 'identify-device' page response
-
-    Scenario: P2 no photo id journey - Abandon - Passport
-      When I submit an 'passport' event
-      Then I get a 'ukPassport' CRI response
-
-    Scenario: P2 no photo id journey - Abandon - Driving licence
-      When I submit an 'drivingLicence' event
-      Then I get a 'drivingLicence' CRI response
-
-    Scenario: P2 no photo id journey - Abandon - F2F
-      When I submit an 'postOffice' event
-      Then I get a 'claimedIdentity' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'f2f' CRI response
-
-    Scenario: P2 no photo id journey - Abandon - Return to RP
-      When I submit an 'relyingParty' event
+    Scenario: P2 no photo id journey - Abandon - Failure
+      When I submit a 'next' event
       Then I get an OAuth response
 
   Rule: Escape
@@ -603,118 +603,12 @@ Feature: P2 no photo id journey
       When I submit an 'anotherWay' event
       Then I get a 'page-ipv-identity-postoffice-start' page response
       When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
-      When I submit an 'end' event
-      Then I get a 'no-photo-id-exit-find-another-way' page response
+      Then I get a 'pyi-escape' page response
 
-    Scenario: P2 no photo id journey - Escape - Use photo id
+    Scenario: P2 no photo id journey - Escape - Try again
       When I submit an 'next' event
       Then I get a 'page-ipv-identity-document-start' page response
-
-    Scenario: P2 no photo id journey - Escape - Return to no photo id
-      When I submit an 'bankAccount' event
-      Then I get a 'prove-identity-no-photo-id' page response
 
     Scenario: P2 no photo id journey - Escape - Return to RP
       When I submit an 'end' event
       Then I get an OAuth response
-
-  Rule: KBV mitigation
-    Background: Start P2 no photo id KBV mitigation journey
-      Given I activate the 'openBanking' feature set
-      When I start a new 'medium-confidence' journey
-      Then I get a 'live-in-uk' page response
-      When I submit a 'uk' event
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-online' page response
-      When I submit an 'anotherWay' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
-      When I submit an 'next' event
-      Then I get a 'claimedIdentity' CRI response
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
-      Then I get a 'nino' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                      |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'end' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'experianKbv' CRI response
-      When I submit 'kenneth-needs-enhanced-verification' details with attributes to the CRI stub
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'no-photo-id-web-find-another-way' page response
-
-    Scenario: P2 no photo id journey - KBV mitigation - Strategic app
-      Given I activate the 'strategicApp' feature set
-      When I submit an 'appTriage' event
-      Then I get an 'identify-device' page response
-
-    Scenario: P2 no photo id journey - KBV mitigation - F2F
-      When I submit an 'f2f' event
-      Then I get a 'f2f' CRI response
-
-  Rule: KBV dropout
-    Background: Start P2 no photo id KBV mitigation journey
-      Given I activate the 'openBanking' feature set
-      When I start a new 'medium-confidence' journey
-      Then I get a 'live-in-uk' page response
-      When I submit a 'uk' event
-      Then I get a 'page-ipv-identity-document-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-online' page response
-      When I submit an 'anotherWay' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
-      When I submit an 'next' event
-      Then I get a 'claimedIdentity' CRI response
-      When I submit 'kenneth-current' details with attributes to the CRI stub
-        | Attribute | Values         |
-        | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
-      Then I get a 'nino' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                      |
-        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get an 'address' CRI response
-      When I submit 'kenneth-current' details to the CRI stub
-      Then I get a 'fraud' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                   |
-        | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'end' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'experianKbv' CRI response
-      When I submit 'kenneth-score-0' details with attributes to the CRI stub
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
-        | Context | Value   |
-        | reason  | dropout |
-
-    Scenario: P2 no photo id journey - KBV dropout - Strategic app
-      Given I activate the 'strategicApp' feature set
-      When I submit an 'appTriage' event
-      Then I get an 'identify-device' page response
-
-    Scenario: P2 no photo id journey - KBV dropout - F2F
-      When I submit an 'f2f' event
-      Then I get a 'f2f' CRI response

--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -584,7 +584,7 @@ Feature: P2 no photo id journey
       When I call the CRI stub with attributes and get an 'access_denied' OAuth error
         | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      # PYIC-9224: Currently TBD where this event should go with open banking
+      # PYIC-9215: Currently TBD where this event should go with open banking
       Then I get a 'pyi-no-match' page response
 
     Scenario: P2 no photo id journey - Abandon - Failure

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -739,30 +739,94 @@ Feature: P2 Web document journey
         | reason  | openBanking |
       When I submit a 'f2f' event
       Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
     Scenario: User fails Open Banking with breaching CI
       When I submit 'kenneth-with-breaching-ci' details to the CRI stub
       Then I get a 'pyi-no-match' page response and pageContext
         | Context | Value       |
         | reason  | openBanking |
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
 
     Scenario: Open Banking CRI returns an error - user tries again
       When I call the CRI stub and get a 'server_error' OAuth error
       Then I get a 'sorry-technical-problem' page response
       When I submit a 'tryAgain' event
       Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
     Scenario: Open Banking CRI returns an error - user tries app
       When I call the CRI stub and get a 'server_error' OAuth error
       Then I get a 'sorry-technical-problem' page response
       When I submit a 'app' event
       Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
 
     Scenario: Open Banking CRI returns an error - user tries Post Office
       When I call the CRI stub and get a 'server_error' OAuth error
       Then I get a 'sorry-technical-problem' page response
       When I submit a 'postOffice' event
       Then I get a 'pyi-post-office' page response
+      When I submit a 'next' event
+      Then I get a 'f2f' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the async CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":0} |
+      Then I get a 'page-face-to-face-handoff' page response
+
+      # Return journey
+      When I start new 'medium-confidence' journeys until I get a 'page-ipv-reuse' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
 
     Scenario: Open Banking CRI returns an error - user returns to RP
       When I call the CRI stub and get a 'server_error' OAuth error

--- a/api-tests/features/p2-web-journey.feature
+++ b/api-tests/features/p2-web-journey.feature
@@ -700,6 +700,25 @@ Feature: P2 Web document journey
       Then I am issued a 'P2' identity
       And I have a stored identity record with a 'P2' max vot
 
+    Scenario: User switches to KBV
+      When I call the CRI stub and get an 'access_denied' OAuth error
+      Then I get a 'photo-id-banking-another-way' page response
+      When I submit an 'answerSecurityQuestions' event
+      Then I get a 'personal-independence-payment' page response
+      When I submit a 'next' event
+      Then I get a 'page-pre-dwp-kbv-transition' page response
+      When I submit a 'next' event
+      Then I get a 'dwpKbv' CRI response
+      When I submit 'kenneth-score-2' details with attributes to the CRI stub
+        | Attribute          | Values                                          |
+        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P2' max vot
+
     Scenario: User fails to select current account and tries app
       When I submit 'kenneth-score-0' details to the CRI stub
       Then I get a 'photo-id-web-find-another-way' page response and pageContext

--- a/api-tests/features/return-codes.feature
+++ b/api-tests/features/return-codes.feature
@@ -71,9 +71,7 @@ Feature: Return exit codes
     When I submit a 'anotherWay' event
     Then I get a 'page-ipv-identity-postoffice-start' page response
     When I submit an 'end' event
-    Then I get a 'prove-identity-no-photo-id' page response
-    When I submit a 'end' event
-    Then I get a 'no-photo-id-exit-find-another-way' page response
+    Then I get a 'pyi-escape' page response
     When I submit a 'end' event
     Then I get an OAuth response
     When I use the OAuth response to get my identity

--- a/api-tests/features/stored-identity/p2-journeys.feature
+++ b/api-tests/features/stored-identity/p2-journeys.feature
@@ -262,17 +262,13 @@ Feature: Stored Identity - P2 journeys
       Given I activate the 'openBanking' feature set
       When I submit an 'end' event
       Then I get a 'prove-identity-online' page response
-      When I submit a 'anotherWay' event
-      Then I get a 'page-ipv-identity-postoffice-start' page response
-      When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
-      When I submit an 'next' event
+      When I submit a 'next' event
+      Then I get a 'prove-identity-online-banking' page response
+      When I submit a 'next' event
       Then I get a 'claimedIdentity' CRI response
       When I submit 'kenneth-current' details with attributes to the CRI stub
         | Attribute | Values         |
         | context   | "bank_account" |
-      Then I get a 'bav' CRI response
-      When I submit 'kenneth' details to the CRI stub
       Then I get a 'nino' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub
         | Attribute          | Values                                      |
@@ -283,14 +279,8 @@ Feature: Stored Identity - P2 journeys
       When I submit 'kenneth-score-2' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
-      Then I get a 'personal-independence-payment' page response
-      When I submit a 'end' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
-      When I submit a 'next' event
-      Then I get a 'experianKbv' CRI response
-      When I submit 'kenneth-score-2' details with attributes to the CRI stub
-        | Attribute          | Values                                          |
-        | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
+      Then I get an 'openBanking' CRI response
+      When I submit 'kenneth' details to the CRI stub
       Then I get a 'page-ipv-success' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/ticf/ticf-failed-error-journeys.feature
+++ b/api-tests/features/ticf/ticf-failed-error-journeys.feature
@@ -264,9 +264,7 @@ Feature: TICF failed/error journeys
       When I submit a 'anotherWay' event
       Then I get a 'page-ipv-identity-postoffice-start' page response
       When I submit an 'end' event
-      Then I get a 'prove-identity-no-photo-id' page response
-      When I submit an 'end' event
-      Then I get a 'no-photo-id-exit-find-another-way' page response
+      Then I get a 'pyi-escape' page response
       When I submit an 'end' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity

--- a/api-tests/src/clients/local-audit-client.ts
+++ b/api-tests/src/clients/local-audit-client.ts
@@ -16,5 +16,15 @@ export const getAuditEvents = async (
     );
   }
 
-  return (await response.json()) as AuditEvent[];
+  const events = (await response.json()) as AuditEvent[];
+
+  const deduplicated = events.filter(
+    (event, index) =>
+      events.findIndex((e) => JSON.stringify(e) === JSON.stringify(event)) ===
+      index,
+  );
+
+  return deduplicated.sort(
+    (a, b) => a.event_timestamp_ms - b.event_timestamp_ms,
+  );
 };

--- a/api-tests/src/utils/audit-events.ts
+++ b/api-tests/src/utils/audit-events.ts
@@ -18,34 +18,47 @@ export const getAuditEventsForJourneyType = async (journeyName: string) => {
   ) as AuditEvent[];
 };
 
+const countEventNames = (events: AuditEvent[]): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const event of events) {
+    counts.set(event.event_name, (counts.get(event.event_name) ?? 0) + 1);
+  }
+  return counts;
+};
+
 const diffAuditEventNames = (
   actualEvents: AuditEvent[],
   expectedEvents: AuditEvent[],
 ): string => {
-  const actualNames = actualEvents.map((e) => e.event_name);
-  const expectedNames = expectedEvents.map((e) => e.event_name);
-  const missingFromActual = expectedNames.filter(
-    (n) => !actualNames.includes(n),
-  );
-  const unexpectedInActual = actualNames.filter(
-    (n) => !expectedNames.includes(n),
-  );
-  return [
-    missingFromActual.length ? `Missing: [${missingFromActual}]` : "",
-    unexpectedInActual.length ? `Unexpected: [${unexpectedInActual}]` : "",
-  ]
-    .filter(Boolean)
-    .join(", ");
+  const actualCounts = countEventNames(actualEvents);
+  const expectedCounts = countEventNames(expectedEvents);
+
+  const differences: string[] = [];
+
+  const allNames = new Set([...actualCounts.keys(), ...expectedCounts.keys()]);
+  for (const name of allNames) {
+    const actualCount = actualCounts.get(name) ?? 0;
+    const expectedCount = expectedCounts.get(name) ?? 0;
+    if (actualCount !== expectedCount) {
+      differences.push(
+        `${name}: expected ${expectedCount}, got ${actualCount}`,
+      );
+    }
+  }
+
+  return differences.length ? `Differences: [${differences.join("; ")}]` : "";
 };
 
 export const compareAuditEvents = (
   actualAuditEvents: AuditEvent[],
   expectedAuditEvent: AuditEvent[],
 ): ObjectPartialEqualityResult => {
+  const eventNamesSummary = `\nExpected event names: [${expectedAuditEvent.map((e) => e.event_name).join(", ")}]\nActual event names: [${actualAuditEvents.map((e) => e.event_name).join(", ")}]`;
+
   if (actualAuditEvents.length !== expectedAuditEvent.length) {
     return {
       isPartiallyEqual: false,
-      errorMessage: `Expected (${expectedAuditEvent.length}) and actual (${actualAuditEvents.length}) events are not the same length. ${diffAuditEventNames(actualAuditEvents, expectedAuditEvent)}`,
+      errorMessage: `Expected (${expectedAuditEvent.length}) and actual (${actualAuditEvents.length}) events are not the same length. ${diffAuditEventNames(actualAuditEvents, expectedAuditEvent)}.${eventNamesSummary}`,
     };
   }
 
@@ -56,6 +69,8 @@ export const compareAuditEvents = (
     );
 
     if (!comparisonResult.isPartiallyEqual) {
+      comparisonResult.errorMessage =
+        comparisonResult.errorMessage + eventNamesSummary;
       return comparisonResult;
     }
   }

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -531,7 +531,7 @@ states:
       tryAgain:
         targetState: OPEN_BANKING_CRI_PHOTO_ID
       app:
-        targetState: STRATEGIC_APP_TRIAGE
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
         targetEntryEvent: appTriage
       postOffice:
         targetState: PYI_POST_OFFICE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -378,10 +378,13 @@ states:
       next:
         targetState: CRI_CLAIMED_IDENTITY_J4
       end:
-        targetState: BANK_ACCOUNT_START_PAGE
+        targetState: PYI_ESCAPE
         checkIfDisabled:
-          bav:
-            targetState: PYI_ESCAPE
+          openBanking:
+            targetState: BANK_ACCOUNT_START_PAGE
+            checkIfDisabled:
+              bav:
+                targetState: PYI_ESCAPE
 
   F2F_PYI_POST_OFFICE:
     response:
@@ -545,11 +548,58 @@ states:
     parent: CRI_STATE
     events:
       next:
-        targetJourney: FAILED
-        targetState: FAILED
+        targetState: PROCESS_NEW_IDENTITY
+      access-denied:
+        targetState: OPEN_BANKING_NO_PHOTO_ID_ANOTHER_WAY
+      fail-with-no-ci:
+        targetState: OPEN_BANKING_NO_PHOTO_ID_WEB_ANOTHER_WAY
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_OPEN_BANKING
+      error:
+        targetState: OPEN_BANKING_NO_PHOTO_ID_SORRY_CRI_TECHNICAL_ERROR
+
+  OPEN_BANKING_NO_PHOTO_ID_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: no-photo-id-banking-another-way
+    events:
+      onlineBanking:
+        targetState: OPEN_BANKING_CRI_NO_PHOTO_ID
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+      postOffice:
+        targetState: PYI_POST_OFFICE
+
+  OPEN_BANKING_NO_PHOTO_ID_WEB_ANOTHER_WAY:
+    response:
+      type: page
+      pageId: no-photo-id-web-find-another-way
+      pageContext:
+        reason: openBanking
+    events:
+      appTriage:
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetEntryEvent: appTriage
+      f2f:
+        targetState: PYI_POST_OFFICE
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+
+  OPEN_BANKING_NO_PHOTO_ID_SORRY_CRI_TECHNICAL_ERROR:
+    response:
+      type: page
+      pageId: sorry-technical-problem
+    events:
+      tryAgain:
+        targetState: OPEN_BANKING_CRI_NO_PHOTO_ID
+      app:
+        targetState: STRATEGIC_APP_TRIAGE_PYI_ESCAPE
+        targetEntryEvent: appTriage
+      postOffice:
+        targetState: PYI_POST_OFFICE
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
 
   PYI_ESCAPE:
     response:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -769,7 +769,7 @@ states:
       next:
         targetState: ADDRESS_AND_FRAUD_NO_PHOTO_ID_OPEN_BANKING
       access-denied:
-        # PYIC-9224: Currently TBD where this event should go with open banking
+        # PYIC-9215: Currently TBD where this event should go with open banking
         targetJourney: FAILED
         targetState: FAILED
       fail-with-ci:


### PR DESCRIPTION
## Proposed changes
### What changed

Added Open Banking no-photo-id post CRI routing

### Why did it change

New routing

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9171](https://govukverify.atlassian.net/browse/PYIC-9171)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated

[PYIC-9171]: https://govukverify.atlassian.net/browse/PYIC-9171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ