### PR TITLE
PYIC-9207: Change compose.yaml.template to indicate EVCS_ACCESS_TOKEN_SIGNING_JWK location.

### DIFF
--- a/local-running/compose.yaml.template
+++ b/local-running/compose.yaml.template
@@ -27,7 +27,7 @@ services:
       ORCHESTRATOR_REDIRECT_URL: http://localhost:4500/callback
       EVCS_ACCESS_TOKEN_ENDPOINT: https://token-generator.reuse.stubs.account.gov.uk/generate
       EVCS_ACCESS_TOKEN_TTL: 60
-      EVCS_ACCESS_TOKEN_SIGNING_JWK: '{"kty":"EC","kid":"evcs-token-local-running-FI4xysvMVdRtkt6xmO5gqcaTF4Tf9NKD1zdg3T8y69M","use":"sig","d":"OXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthU","crv":"P-256","x":"E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM","y":"KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"}' # pragma: allowlist secret
+      EVCS_ACCESS_TOKEN_SIGNING_JWK: <Extract from ipv-stubs-common-infra>
       JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5000
     ports:
       - "4500:4500"


### PR DESCRIPTION
## Proposed changes
### What changed

- Changed compose.yaml.template to indicate EVCS_ACCESS_TOKEN_SIGNING_JWK location.

### Why did it change

- EVCS_ACCESS_TOKEN_SIGNING_JWK has been rotated.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9207](https://govukverify.atlassian.net/browse/PYIC-9207)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9207]: https://govukverify.atlassian.net/browse/PYIC-9207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ