### PR TITLE
BAU: Update data-vocab package

### DIFF
--- a/api-tests/package-lock.json
+++ b/api-tests/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@cucumber/cucumber": "13.2.0",
-        "@govuk-one-login/data-vocab": "2.0.0",
+        "@govuk-one-login/data-vocab": "2.0.3",
         "@types/eslint__js": "9.14.0",
         "dotenv": "17.4.2",
         "eslint": "10.0.3",
@@ -427,9 +427,9 @@
       }
     },
     "node_modules/@govuk-one-login/data-vocab": {
-      "version": "2.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/2.0.0/c5ecfde3f00491bc70585a070a27154d47303390",
-      "integrity": "sha512-nsZOZAgR5R9vvD5LHiA5AOpov3eLsDHaljP+vzD3mBpa3YvlI31RvdRZAfM7Gv/h6eaIRH97gt7+va1hyqm31g==",
+      "version": "2.0.3",
+      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/2.0.3/df51da4cfdecd6c334f1672f60d3f3b0842bdf27",
+      "integrity": "sha512-kuNCUpz9ZJ6lSSnl9uXa5SrSO94/0jLqYdjutGjQ0DmDgbWpJb8B0lM9HotWJXuQy5mRthu8RcaJ6h8d5pYERA==",
       "dev": true
     },
     "node_modules/@hapi/address": {
@@ -1026,9 +1026,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/api-tests/package.json
+++ b/api-tests/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "13.2.0",
-    "@govuk-one-login/data-vocab": "2.0.0",
+    "@govuk-one-login/data-vocab": "2.0.3",
     "@types/eslint__js": "9.14.0",
     "dotenv": "17.4.2",
     "eslint": "10.0.3",


### PR DESCRIPTION
## Proposed changes
### What changed

Update data-vocab package

### Why did it change

So that we can switch from github to npm when downloading the package

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9193](https://govukverify.atlassian.net/browse/PYIC-9193)



[PYIC-9193]: https://govukverify.atlassian.net/browse/PYIC-9193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ