### PR TITLE
PYIC-9193: Use standard npm for all node packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,6 @@
 
 version: 2
 registries:
-  github-npm:
-    type: npm-registry
-    url: https://npm.pkg.github.com
-    username: ${{ secrets.DEPENDABOT_GITHUB_USERNAME }}
-    password: ${{ secrets.DEPENDABOT_GITHUB_TOKEN }}
-    scope: "@govuk-one-login"
   github-maven:
     type: maven-repository
     url: https://maven.pkg.github.com

--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -108,13 +108,6 @@ jobs:
           cache: npm
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Setup .npmrc
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cp .npmrc.template .npmrc && \
-          sed -i s/GITHUB_PAT_WITH_READ:PACKAGES/"$GITHUB_TOKEN"/ .npmrc
-
       - name: Install dependencies
         run: npm ci --ignore-scripts # the .npmrc should already stop scripts, but no harm in having this too
 

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ local-running/core.local.secrets.yaml
 
 api-tests/reports/*
 !api-tests/reports/.gitkeep
-api-tests/.npmrc
 api-tests/.env*
 !api-tests/.env.template
 !api-tests/.env.dev.template

--- a/api-tests/.npmrc
+++ b/api-tests/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/api-tests/.npmrc.template
+++ b/api-tests/.npmrc.template
@@ -1,3 +1,0 @@
-ignore-scripts=true
-@govuk-one-login:registry=https://npm.pkg.github.com
-//npm.pkg.github.com:_authToken=GITHUB_PAT_WITH_READ:PACKAGES

--- a/api-tests/README.md
+++ b/api-tests/README.md
@@ -10,8 +10,6 @@
 
 ## Installation
 
-- [Create a GitHub personal access token][create-pat] with package:read scope
-- Copy `.npmrc.template` to `.npmrc` and replace `GITHUB_PAT_WITH_READ:PACKAGES` with your personal access token
 - Run `npm install`
 
 ## Running the tests

--- a/api-tests/secure-pipeline/api-tests.Dockerfile
+++ b/api-tests/secure-pipeline/api-tests.Dockerfile
@@ -13,10 +13,7 @@ WORKDIR /api-tests
 
 ARG GITHUB_PAT
 
-RUN cp .npmrc.template .npmrc && \
-    sed -i s/GITHUB_PAT_WITH_READ:PACKAGES/${GITHUB_PAT}/ .npmrc && \
-    npm ci && \
-    rm .npmrc && \
+RUN npm ci && \
     cp .env.template .env
 
 ENTRYPOINT ["/run-tests.sh"]


### PR DESCRIPTION
## Proposed changes
### What changed

Stop dependabot and devs trying to access npm packages on GitHub

### Why did it change

It's causing errors in dependabot, and all of the packages are now on the main npm

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9193](https://govukverify.atlassian.net/browse/PYIC-9193)

## Checklists

- [x] READMEs and documentation up-to-date

[PYIC-9193]: https://govukverify.atlassian.net/browse/PYIC-9193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ