### PR TITLE
PYIC-9193: Update package-lock for data-vocab

### DIFF
--- a/api-tests/package-lock.json
+++ b/api-tests/package-lock.json
@@ -428,7 +428,7 @@
     },
     "node_modules/@govuk-one-login/data-vocab": {
       "version": "2.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@govuk-one-login/data-vocab/2.0.3/df51da4cfdecd6c334f1672f60d3f3b0842bdf27",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/data-vocab/-/data-vocab-2.0.3.tgz",
       "integrity": "sha512-kuNCUpz9ZJ6lSSnl9uXa5SrSO94/0jLqYdjutGjQ0DmDgbWpJb8B0lM9HotWJXuQy5mRthu8RcaJ6h8d5pYERA==",
       "dev": true
     },


### PR DESCRIPTION
## Proposed changes
### What changed

Update data-vocab in package-lock

### Why did it change

So npm looks for the package in the default repo

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9193](https://govukverify.atlassian.net/browse/PYIC-9193)


[PYIC-9193]: https://govukverify.atlassian.net/browse/PYIC-9193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ