### PR TITLE
PYIC-9171: Use correct event name

### DIFF
--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -120,7 +120,7 @@ Feature: P2 no photo id journey
       Then I get a 'no-photo-id-web-find-another-way' page response and pageContext
         | Context | Value       |
         | reason  | openBanking |
-      When I submit a 'returnToRp' event
+      When I submit an 'end' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity
       Then I am issued a 'P0' identity

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -583,7 +583,7 @@ states:
         targetEntryEvent: appTriage
       f2f:
         targetState: PYI_POST_OFFICE
-      returnToRp:
+      end:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
   OPEN_BANKING_NO_PHOTO_ID_SORRY_CRI_TECHNICAL_ERROR:


### PR DESCRIPTION
## Proposed changes
### What changed

Event name on one step of the journey map

### Why did it change

It was wrong

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9171](https://govukverify.atlassian.net/browse/PYIC-9171)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated

[PYIC-9171]: https://govukverify.atlassian.net/browse/PYIC-9171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ