### PR TITLE
PYIC-9068: New CIs mitigation routes.

### DIFF
--- a/api-tests/features/fraud-mitigation/p1-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p1-mitigation.feature
@@ -41,13 +41,41 @@ Feature: P1 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-    Scenario: Breaching fraud CI goes to mitigation route
+    Scenario Outline: Breaching fraud CI goes to mitigation route - Happy path DAD journey - <device>
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an '<device>' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | <device> |
+        | isAppOnly  | true     |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P1' identity
+      And I have a stored identity record with a 'P3' max vot
+
+      Examples:
+        | device  |
+        | iphone  |
+        | android |
 
     Scenario: Breaching fraud CI goes back to RP
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
@@ -60,7 +88,7 @@ Feature: P1 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-    Scenario: Breaching fraud CI goes to mitigation route
+    Scenario: Breaching fraud CI goes to mitigation route - user start new journey
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
@@ -133,13 +161,28 @@ Feature: P1 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-    Scenario: Breaching fraud CI goes to mitigation route
+    Scenario: Breaching fraud CI goes to mitigation route - Happy path MAM journey - <device>
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'retry-prove-identity-passport' page response
       When I submit a 'retryPassport' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | true   |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P1' identity
+      And I have a stored identity record with a 'P3' max vot
 
     Scenario: Breaching fraud CI goes back to RP
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
@@ -166,18 +209,49 @@ Feature: P1 Fraud mitigation
         | Attribute | Values         |
         | context   | "hmrc_check" |
       Then I get a 'nino' CRI response
+
+      # First non breaching CI
       When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
         | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
+
+      # Second CI
       When I submit 'kenneth-score-2-liveness-likeness-p1-when-combined-with-non-breaching' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+
+      # Mitigation journey
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+
+      # Mitigate second CI
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS-P1-WHEN-COMBINED-WITH-NON-BREACHING' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P1' identity
+      And I have a stored identity record with a 'P3' max vot
 
   Rule: Web document journey
     Background: Start P1 web document journey
@@ -233,6 +307,29 @@ Feature: P1 Fraud mitigation
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P1' identity
+      And I have a stored identity record with a 'P3' max vot
 
       Examples:
         | cri            | details                      |
@@ -274,3 +371,85 @@ Feature: P1 Fraud mitigation
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P1' identity
+      And I have a stored identity record with a 'P3' max vot
+
+  Rule: Fraud CI mitigation failed by using driving licence
+    Scenario: User failed to mitigate Fraud CI by using driving licence in app:
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response and pageContext
+        | Context   | Value |
+        | allowNino | true  |
+      When I submit a 'drivingLicence' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+      When I submit a 'abandon' event
+      Then I get a 'need-biometric-passport' page response
+      When I submit a 'useApp' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      # User passed DL check but doesn't have sufficient score to achieve P2
+      Then I get an 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS

--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -104,7 +104,6 @@ Feature: P2 Fraud mitigation
         | smartphone | <device> |
         | isAppOnly  | true     |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
-      # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
       When I poll for async DCMAW credential receipt
@@ -199,7 +198,6 @@ Feature: P2 Fraud mitigation
         | smartphone | <device> |
         | isAppOnly  | true     |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
-      # And the user returns from the app to core-front
       And I pass on the DCMAW callback
       Then I get a 'check-mobile-app-result' page response
       When I poll for async DCMAW credential receipt
@@ -492,7 +490,7 @@ Feature: P2 Fraud mitigation
       When I submit 'kenneth' details to the CRI stub
       Then I get a 'nino' CRI response
 
-      # First CI
+      # First non breaching CI
       When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
         | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |

--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -1,5 +1,6 @@
 @Build @QualityGateIntegrationTest @QualityGateNewFeatureTest @DomAll
 Feature: P2 Fraud mitigation
+
   Background: Enable fraud mitigation
     Given I activate the 'mitigations9020' feature set
 
@@ -65,7 +66,7 @@ Feature: P2 Fraud mitigation
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
         | Context    | Value    |
         | smartphone | <device> |
-        | isAppOnly  | true    |
+        | isAppOnly  | true     |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
@@ -99,9 +100,9 @@ Feature: P2 Fraud mitigation
         | deviceType | mam   |
       When I submit an '<device>' event
       Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
-        | Context    | Value  |
+        | Context    | Value    |
         | smartphone | <device> |
-        | isAppOnly  | true  |
+        | isAppOnly  | true     |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -194,9 +195,9 @@ Feature: P2 Fraud mitigation
         | deviceType | mam   |
       When I submit an '<device>' event
       Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
-        | Context    | Value  |
+        | Context    | Value    |
         | smartphone | <device> |
-        | isAppOnly  | true  |
+        | isAppOnly  | true     |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
       # And the user returns from the app to core-front
       And I pass on the DCMAW callback
@@ -235,7 +236,7 @@ Feature: P2 Fraud mitigation
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
         | Context    | Value    |
         | smartphone | <device> |
-        | isAppOnly  | true    |
+        | isAppOnly  | true     |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
@@ -347,9 +348,9 @@ Feature: P2 Fraud mitigation
       Then I get a 'passport-biometric-chip' page response
       When I submit a 'next' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
-        | Context    | Value    |
+        | Context    | Value  |
         | smartphone | iphone |
-        | isAppOnly  | true    |
+        | isAppOnly  | true   |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
@@ -360,7 +361,6 @@ Feature: P2 Fraud mitigation
       When I use the OAuth response to get my identity
       Then I am issued a 'P2' identity
       And I have a stored identity record with a 'P3' max vot
-
 
     Scenario: Breaching fraud CI goes back to RP
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
@@ -456,7 +456,7 @@ Feature: P2 Fraud mitigation
         | deviceType | dad   |
       When I submit an 'android' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
-        | Context    | Value    |
+        | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
       # Mitigate second CI
@@ -519,7 +519,7 @@ Feature: P2 Fraud mitigation
         | deviceType | dad   |
       When I submit an 'android' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
-        | Context    | Value    |
+        | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
 
@@ -600,7 +600,7 @@ Feature: P2 Fraud mitigation
         | deviceType | dad   |
       When I submit an 'android' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
-        | Context    | Value    |
+        | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
@@ -700,7 +700,7 @@ Feature: P2 Fraud mitigation
         | deviceType | dad   |
       When I submit an 'android' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
-        | Context    | Value    |
+        | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
@@ -763,7 +763,7 @@ Feature: P2 Fraud mitigation
         | deviceType | dad   |
       When I submit an 'android' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
-        | Context    | Value    |
+        | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
@@ -823,7 +823,7 @@ Feature: P2 Fraud mitigation
         | deviceType | dad   |
       When I submit an 'android' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
-        | Context    | Value    |
+        | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
       When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
@@ -837,7 +837,7 @@ Feature: P2 Fraud mitigation
       Then I am issued a 'P2' identity
       And I have a stored identity record with a 'P3' max vot
 
-  Rule: Abandoned Journeys
+  Rule: Abandoned fraud mitigation and retry
     Background: Start P2 photo id journey
       When I start a new 'medium-confidence' journey
       Then I get a 'live-in-uk' page response
@@ -848,8 +848,7 @@ Feature: P2 Fraud mitigation
       When I submit an 'appTriage' event
       Then I get a 'pyi-triage-select-device' page response
 
-    @Dom
-    Scenario: DAD abandoned journey - user retried mitigate via app
+    Scenario: DAD abandoned journey - user retried
       When I submit a 'computer-or-tablet' event
       Then I get a 'pyi-triage-select-smartphone' page response and pageContext
         | Context    | Value |
@@ -901,15 +900,14 @@ Feature: P2 Fraud mitigation
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
-#      TODO: Fix previous VC response (reset lambda?)
-#      Then I get a 'page-ipv-success' page response
-#      When I submit a 'next' event
-#      Then I get an OAuth response
-#      When I use the OAuth response to get my identity
-#      Then I am issued a 'P2' identity
-#      And I have a stored identity record with a 'P3' max vot
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
 
-    Scenario:  MAM abandoned journey - user retried mitigate via app
+    Scenario: MAM abandoned journey - user retried
       When I submit a 'smartphone' event
       Then I get a 'pyi-triage-select-smartphone' page response and pageContext
         | Context    | Value |
@@ -946,37 +944,36 @@ Feature: P2 Fraud mitigation
         | smartphone | iphone |
         | isAppOnly  | true   |
 
-#      TODO: Resolve this issue
       # User abandon journey
-#      When the async DCMAW CRI produces an 'access_denied' error response
-#      And I pass on the DCMAW callback
-#      Then I get a 'check-mobile-app-result' page response
-#      When I poll for async DCMAW credential receipt
-#      Then the poll returns a '201'
-#
-#      When I submit the returned journey event
-#      Then I get a 'app-passport-prove-identity' page response
-#
-#      # User retried to mitigate via app
-#      When I submit a 'useApp' event
-#      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
-#        | Context    | Value  |
-#        | smartphone | iphone |
-#        | isAppOnly  | true   |
-#      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
-#      And I pass on the DCMAW callback
-#      Then I get a 'check-mobile-app-result' page response
-#      When I poll for async DCMAW credential receipt
-#      Then the poll returns a '201'
-#      When I submit the returned journey event
-#      Then I get a 'page-ipv-success' page response
-#      When I submit a 'next' event
-#      Then I get an OAuth response
-#      When I use the OAuth response to get my identity
-#      Then I am issued a 'P2' identity
-#      And I have a stored identity record with a 'P3' max vot
+      When the async DCMAW CRI produces an 'access_denied' error response
+      And I fetch user OAuthState
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'app-passport-prove-identity' page response
 
-  Rule: Alternative routes:
+      # User retried to mitigate via app
+      When I submit a 'useApp' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | true   |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+  Rule: Failed DCMAW async and alternative routes
     Background:
       Given I activate the 'openBankingDisabled' feature set
       When I start a new 'medium-confidence' journey
@@ -1051,9 +1048,9 @@ Feature: P2 Fraud mitigation
         | deviceType | mam   |
       When I submit an '<device>' event
       Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
-        | Context    | Value  |
+        | Context    | Value    |
         | smartphone | <device> |
-        | isAppOnly  | true  |
+        | isAppOnly  | true     |
       When I submit an 'preferNoApp' event
       Then I get a 'app-passport-prove-identity' page response
       When I submit an 'useApp' event
@@ -1074,30 +1071,7 @@ Feature: P2 Fraud mitigation
         | iphone  |
         | android |
 
-    Scenario: User fail Fraud CI Mitigation with CI:
-      When I submit a 'smartphone' event
-      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
-        | Context    | Value |
-        | deviceType | mam   |
-      When I submit an 'android' event
-      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
-        | Context    | Value   |
-        | smartphone | android |
-        | isAppOnly  | true    |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'ALWAYS-REQUIRED' CI
-      And I pass on the DCMAW callback
-      Then I get an 'check-mobile-app-result' page response
-      When I poll for async DCMAW credential receipt
-      Then the poll returns a '201'
-      When I submit the returned journey event
-      Then I get an 'pyi-no-match' page response
-      When I submit a 'next' event
-      Then I get an OAuth response
-      When I use the OAuth response to get my identity
-      Then I am issued a 'P0' identity
-      And I don't have a stored identity in EVCS
-
-    Scenario: User fail Fraud CI Mitigation with no CI:
+    Scenario: User failed to mitigate Fraud CI:
       When I submit a 'smartphone' event
       Then I get a 'pyi-triage-select-smartphone' page response and pageContext
         | Context    | Value |
@@ -1120,7 +1094,30 @@ Feature: P2 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-    Scenario: User fail Fraud CI Mitigation by using driving licence:
+    Scenario: User failed to mitigate Fraud CI with new CI:
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'ALWAYS-REQUIRED' CI
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: User failed to mitigate Fraud CI by using driving licence in app:
       When I submit a 'smartphone' event
       Then I get a 'pyi-triage-select-smartphone' page response and pageContext
         | Context    | Value |
@@ -1136,6 +1133,7 @@ Feature: P2 Fraud mitigation
       When I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
+      # User passed DL check but doesn't have sufficient score to achieve P2
       Then I get an 'pyi-no-match' page response
       When I submit a 'next' event
       Then I get an OAuth response

--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -1,4 +1,4 @@
-@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
+@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest @DomAll
 Feature: P2 Fraud mitigation
   Background: Enable fraud mitigation
     Given I activate the 'mitigations9020' feature set
@@ -46,13 +46,80 @@ Feature: P2 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-    Scenario: Breaching fraud CI goes to mitigation route - no Open Banking
+    Scenario Outline: Breaching fraud CI - no Open Banking - Happy path DAD journey - <device>
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an '<device>' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | <device> |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+      Examples:
+        | device  |
+        | iphone  |
+        | android |
+
+    Scenario Outline: Breaching fraud CI - no Open Banking - Happy path MAM journey - <device>
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an '<device>' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | <device> |
+        | isAppOnly  | true  |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+      Examples:
+        | device  |
+        | iphone  |
+        | android |
 
     Scenario: Breaching fraud CI goes back to RP - no Open Banking
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
@@ -110,13 +177,80 @@ Feature: P2 Fraud mitigation
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
 
-    Scenario: Breaching fraud CI goes to mitigation route
+    Scenario Outline: Breaching fraud CI - Happy path MAM journey - <device>
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an '<device>' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | <device> |
+        | isAppOnly  | true  |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      # And the user returns from the app to core-front
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+      Examples:
+        | device  |
+        | iphone  |
+        | android |
+
+    Scenario Outline: Breaching fraud CI - Happy path DAD journey - <device>
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an '<device>' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | <device> |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+      Examples:
+        | device  |
+        | iphone  |
+        | android |
 
     Scenario: Breaching fraud CI goes back to RP
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
@@ -211,6 +345,22 @@ Feature: P2 Fraud mitigation
       Then I get a 'retry-prove-identity-passport' page response
       When I submit a 'retryPassport' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | iphone |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
 
     Scenario: Breaching fraud CI goes back to RP
       When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
@@ -281,18 +431,45 @@ Feature: P2 Fraud mitigation
       Then I get a 'bav' CRI response
       When I submit 'kenneth' details to the CRI stub
       Then I get a 'nino' CRI response
+      # First CI
       When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
         | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
+      # Second CI
       When I submit 'kenneth-score-2-liveness-likeness-p2-when-combined-with-non-breaching' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
+      # Mitigation journey
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      # Mitigate second CI
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS-P2-WHEN-COMBINED-WITH-NON-BREACHING' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
 
     Scenario: Combined breaching fraud CI goes to mitigation route
       Given I activate the 'openBanking' feature set
@@ -314,18 +491,49 @@ Feature: P2 Fraud mitigation
       Then I get a 'bav' CRI response
       When I submit 'kenneth' details to the CRI stub
       Then I get a 'nino' CRI response
+
+      # First CI
       When I submit 'kenneth-score-2-non-breaching' details with attributes to the CRI stub
         | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
       Then I get an 'address' CRI response
       When I submit 'kenneth-current' details to the CRI stub
       Then I get a 'fraud' CRI response
+
+      # Second CI
       When I submit 'kenneth-score-2-liveness-likeness-p2-when-combined-with-non-breaching' details with attributes to the CRI stub
         | Attribute          | Values                   |
         | evidence_requested | {"identityFraudScore":2} |
+
+      # Mitigation journey
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | android |
+        | isAppOnly  | true    |
+
+      # Mitigate second CI
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS-P2-WHEN-COMBINED-WITH-NON-BREACHING' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
 
   Rule: Web document journey - no Open Banking
     Background: Start P2 web document journey
@@ -382,6 +590,29 @@ Feature: P2 Fraud mitigation
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
 
       Examples:
         | cri            | details                      |
@@ -459,6 +690,29 @@ Feature: P2 Fraud mitigation
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
 
       Examples:
         | cri            | details                      |
@@ -499,6 +753,29 @@ Feature: P2 Fraud mitigation
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
 
   Rule: F2F journey
     Background: Start P2 F2F journey
@@ -536,3 +813,332 @@ Feature: P2 Fraud mitigation
       Then I get a 'retry-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+  Rule: Abandoned Journeys
+    Background: Start P2 photo id journey
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+
+    @Dom
+    Scenario: DAD abandoned journey - user retried mitigate via app
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-passport' page response
+      When I submit a 'retryPassport' event
+      Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | true   |
+
+      # User abandon journey
+      When the async DCMAW CRI produces an 'access_denied' error response
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'need-smartphone-prove-identity-app' page response
+
+      # User retried to mitigate via app
+      When I submit a 'useApp' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | true   |
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+      And I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+#      TODO: Fix previous VC response (reset lambda?)
+#      Then I get a 'page-ipv-success' page response
+#      When I submit a 'next' event
+#      Then I get an OAuth response
+#      When I use the OAuth response to get my identity
+#      Then I am issued a 'P2' identity
+#      And I have a stored identity record with a 'P3' max vot
+
+    Scenario:  MAM abandoned journey - user retried mitigate via app
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | false  |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      And I pass on the DCMAW callback
+      Then I get a 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details with attributes to the CRI stub
+        | Attribute | Values          |
+        | context   | "check_details" |
+      Then I get a 'page-dcmaw-success' page response
+      When I submit a 'next' event
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-passport' page response
+      When I submit a 'retryPassport' event
+      Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | true   |
+
+#      TODO: Resolve this issue
+      # User abandon journey
+#      When the async DCMAW CRI produces an 'access_denied' error response
+#      And I pass on the DCMAW callback
+#      Then I get a 'check-mobile-app-result' page response
+#      When I poll for async DCMAW credential receipt
+#      Then the poll returns a '201'
+#
+#      When I submit the returned journey event
+#      Then I get a 'app-passport-prove-identity' page response
+#
+#      # User retried to mitigate via app
+#      When I submit a 'useApp' event
+#      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+#        | Context    | Value  |
+#        | smartphone | iphone |
+#        | isAppOnly  | true   |
+#      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+#      And I pass on the DCMAW callback
+#      Then I get a 'check-mobile-app-result' page response
+#      When I poll for async DCMAW credential receipt
+#      Then the poll returns a '201'
+#      When I submit the returned journey event
+#      Then I get a 'page-ipv-success' page response
+#      When I submit a 'next' event
+#      Then I get an OAuth response
+#      When I use the OAuth response to get my identity
+#      Then I am issued a 'P2' identity
+#      And I have a stored identity record with a 'P3' max vot
+
+  Rule: Alternative routes:
+    Background:
+      Given I activate the 'openBankingDisabled' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'drivingLicence' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+      When I submit a 'abandon' event
+      Then I get a 'need-biometric-passport' page response
+      When I submit a 'useApp' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+
+    Scenario Outline: DAD journeys - user drop off from download page
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an '<device>' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | <device> |
+        | isAppOnly  | true     |
+      When I submit an 'preferNoApp' event
+      Then I get a 'need-smartphone-prove-identity-app' page response
+      When I submit an 'useApp' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | <device> |
+        | isAppOnly  | true     |
+      When I submit an 'anotherWay' event
+      Then I get a 'need-smartphone-prove-identity-app' page response
+      When I submit an 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+      Examples:
+        | device  |
+        | iphone  |
+        | android |
+
+    Scenario Outline: MAM journeys - user drop off from download page
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an '<device>' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | <device> |
+        | isAppOnly  | true  |
+      When I submit an 'preferNoApp' event
+      Then I get a 'app-passport-prove-identity' page response
+      When I submit an 'useApp' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value    |
+        | smartphone | <device> |
+        | isAppOnly  | true     |
+      When I submit an 'anotherWay' event
+      Then I get a 'app-passport-prove-identity' page response
+      When I submit an 'returnToRp' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+      Examples:
+        | device  |
+        | iphone  |
+        | android |
+
+    Scenario: User fail Fraud CI Mitigation with CI:
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'ALWAYS-REQUIRED' CI
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: User fail Fraud CI Mitigation with no CI:
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: User fail Fraud CI Mitigation by using driving licence:
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS

--- a/api-tests/src/steps/cri-steps.ts
+++ b/api-tests/src/steps/cri-steps.ts
@@ -604,6 +604,13 @@ When(
   },
 );
 
+When("I fetch user OAuthState", async function (this: World): Promise<void> {
+  this.oauthState = await getOAuthState(this.userId);
+  if (!this.oauthState) {
+    throw new Error("Oauth state must not be undefined");
+  }
+});
+
 When(
   /^I pass on the DCMAW callback( in a separate session)?$/,
   async function (

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -578,13 +578,7 @@ nestedJourneyStates:
       pageId: need-smartphone-prove-identity-app
     events:
       useApp:
-        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
-        targetEntryEvent: identify-device
-        checkJourneyContext:
-          dadIphone:
-            targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
-          dadAndroid:
-            targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
+        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_RETRY
       returnToRp:
         exitEventToEmit: returnToRp
 
@@ -594,12 +588,29 @@ nestedJourneyStates:
       pageId: app-passport-prove-identity
     events:
       useApp:
+        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_RETRY
+      returnToRp:
+        exitEventToEmit: returnToRp
+
+  MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_RETRY:
+    response:
+      type: process
+      lambda: reset-identity
+      lambdaInput:
+        resetType: PENDING_DCMAW_ASYNC
+    events:
+      next:
         targetState: STRATEGIC_APP_IDENTIFY_DEVICE
         targetEntryEvent: identify-device
         checkJourneyContext:
           mamIphone:
-            targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
+            targetState: MOBILE_IPHONE_START_SESSION
           mamAndroid:
-            targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
-      returnToRp:
-        exitEventToEmit: returnToRp
+            targetState: MOBILE_ANDROID_START_SESSION
+          dadIphone:
+            targetState: DAD_IPHONE_START_SESSION
+          dadAndroid:
+            targetState: DAD_ANDROID_START_SESSION
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -19,6 +19,8 @@ entryEvents:
   dl-auth-source-check:
     targetState: STRATEGIC_APP_HANDLE_RESULT
     targetEntryEvent: dl-auth-source-check
+  liveness-likeness-return:
+    targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
 
 nestedJourneyStates:
   # PYIC-8896 Remove this state once there is no danger of anyone still being in it.
@@ -91,6 +93,9 @@ nestedJourneyStates:
           appOnly:
             targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
             journeyContextToSet: dadIphone
+        checkMitigation:
+          liveness-likeness:
+            targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -155,6 +160,9 @@ nestedJourneyStates:
         targetEntryEvent: dl-auth-source-check
       preferNoApp:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkMitigation:
+          liveness-likeness:
+            targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
         checkJourneyContext:
           internationalAddress:
             targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NEED_APP
@@ -241,6 +249,9 @@ nestedJourneyStates:
         targetEntryEvent: dl-auth-source-check
       preferNoApp:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkMitigation:
+          liveness-likeness:
+            targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
         checkJourneyContext:
           internationalAddress:
             targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NEED_APP
@@ -281,6 +292,9 @@ nestedJourneyStates:
           appOnly:
             targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
             journeyContextToSet: dadAndroid
+        checkMitigation:
+          liveness-likeness:
+            targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -314,6 +328,9 @@ nestedJourneyStates:
           appOnly:
             targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
             journeyContextToSet: mamIphone
+        checkMitigation:
+          liveness-likeness:
+            targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -353,6 +370,9 @@ nestedJourneyStates:
         targetEntryEvent: check-mobile-app-result
       preferNoApp:
         targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkMitigation:
+          liveness-likeness:
+            targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
         checkJourneyContext:
           internationalAddress:
             targetState: MOBILE_IPHONE_DOWNLOAD_PAGE_NEED_APP
@@ -386,6 +406,9 @@ nestedJourneyStates:
           appOnly:
             targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
             journeyContextToSet: mamAndroid
+        checkMitigation:
+          liveness-likeness:
+            targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -425,6 +448,9 @@ nestedJourneyStates:
         targetEntryEvent: check-mobile-app-result
       preferNoApp:
         targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
+        checkMitigation:
+          liveness-likeness:
+            targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
         checkJourneyContext:
           internationalAddress:
             targetState: MOBILE_ANDROID_DOWNLOAD_PAGE_NEED_APP
@@ -526,6 +552,49 @@ nestedJourneyStates:
         targetState: DAD_ANDROID_START_SESSION
       noDevice:
         targetState: DAD_SELECT_SMARTPHONE_EXIT_BUFFER
+        checkMitigation:
+          liveness-likeness:
+            targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
         checkJourneyContext:
           internationalAddress:
             targetState: DAD_SELECT_SMARTPHONE_NEED_APP
+
+  MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP:
+    response:
+      type: page
+      pageId: need-smartphone-prove-identity-app
+    events:
+      useApp:
+        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
+        targetEntryEvent: identify-device
+        checkJourneyContext:
+          mamIphone:
+            targetState: MOBILE_IPHONE_START_SESSION
+          mamAndroid:
+            targetState: MOBILE_ANDROID_START_SESSION
+          dadIphone:
+            targetState: DAD_IPHONE_START_SESSION
+          dadAndroid:
+            targetState: DAD_ANDROID_START_SESSION
+      returnToRp:
+        exitEventToEmit: returnToRp
+
+  MITIGATION_APP_PASSPORT_PROVE_IDENTITY:
+    response:
+      type: page
+      pageId: app-passport-prove-identity
+    events:
+      useApp:
+        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
+        targetEntryEvent: identify-device
+        checkJourneyContext:
+          mamIphone:
+            targetState: MOBILE_IPHONE_START_SESSION
+          mamAndroid:
+            targetState: MOBILE_ANDROID_START_SESSION
+          dadIphone:
+            targetState: DAD_IPHONE_START_SESSION
+          dadAndroid:
+            targetState: DAD_ANDROID_START_SESSION
+      returnToRp:
+        exitEventToEmit: returnToRp

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -19,7 +19,7 @@ entryEvents:
   dl-auth-source-check:
     targetState: STRATEGIC_APP_HANDLE_RESULT
     targetEntryEvent: dl-auth-source-check
-  liveness-likeness-return:
+  liveness-likeness-another-way:
     targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
 
 nestedJourneyStates:

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -20,6 +20,15 @@ entryEvents:
     targetState: STRATEGIC_APP_HANDLE_RESULT
     targetEntryEvent: dl-auth-source-check
   liveness-likeness-another-way:
+    checkJourneyContext:
+      mamIphone:
+        targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
+      mamAndroid:
+        targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
+      dadIphone:
+        targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
+      dadAndroid:
+        targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
     targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
 
 nestedJourneyStates:
@@ -96,6 +105,7 @@ nestedJourneyStates:
         checkMitigation:
           liveness-likeness:
             targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
+            journeyContextToSet: dadIphone
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -295,6 +305,7 @@ nestedJourneyStates:
         checkMitigation:
           liveness-likeness:
             targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
+            journeyContextToSet: dadAndroid
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -331,6 +342,7 @@ nestedJourneyStates:
         checkMitigation:
           liveness-likeness:
             targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
+            journeyContextToSet: mamIphone
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -409,6 +421,7 @@ nestedJourneyStates:
         checkMitigation:
           liveness-likeness:
             targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
+            journeyContextToSet: mamAndroid
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR
@@ -568,14 +581,10 @@ nestedJourneyStates:
         targetState: STRATEGIC_APP_IDENTIFY_DEVICE
         targetEntryEvent: identify-device
         checkJourneyContext:
-          mamIphone:
-            targetState: MOBILE_IPHONE_START_SESSION
-          mamAndroid:
-            targetState: MOBILE_ANDROID_START_SESSION
           dadIphone:
-            targetState: DAD_IPHONE_START_SESSION
+            targetState: DESKTOP_APP_ONLY_IPHONE_DOWNLOAD_PAGE
           dadAndroid:
-            targetState: DAD_ANDROID_START_SESSION
+            targetState: DESKTOP_APP_ONLY_ANDROID_DOWNLOAD_PAGE
       returnToRp:
         exitEventToEmit: returnToRp
 
@@ -589,12 +598,8 @@ nestedJourneyStates:
         targetEntryEvent: identify-device
         checkJourneyContext:
           mamIphone:
-            targetState: MOBILE_IPHONE_START_SESSION
+            targetState: MOBILE_APP_ONLY_IPHONE_DOWNLOAD_PAGE
           mamAndroid:
-            targetState: MOBILE_ANDROID_START_SESSION
-          dadIphone:
-            targetState: DAD_IPHONE_START_SESSION
-          dadAndroid:
-            targetState: DAD_ANDROID_START_SESSION
+            targetState: MOBILE_APP_ONLY_ANDROID_DOWNLOAD_PAGE
       returnToRp:
         exitEventToEmit: returnToRp

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -30,6 +30,7 @@ entryEvents:
       dadAndroid:
         targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
     targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
+    journeyContextToUnset: mamIphone,mamAndroid,dadIphone,dadAndroid
 
 nestedJourneyStates:
   # PYIC-8896 Remove this state once there is no danger of anyone still being in it.

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -24,12 +24,7 @@ states:
             auditContext:
               mitigationType: enhanced-verification
           liveness-likeness:
-            targetJourney: TECHNICAL_ERROR # Should never happen
-            targetState: ERROR
-            checkFeatureFlag:
-              mitigations9020Enabled:
-                targetState: MITIGATION_STRATEGIC_APP_TRIAGE
-                targetEntryEvent: liveness-likeness-return
+            targetState: MITIGATE_CI_VIA_APP
 
   KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
     events:
@@ -775,8 +770,8 @@ states:
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
       anotherWay:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
+        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+        targetEntryEvent: liveness-likeness-another-way
       incompleteDlAuthCheckInvalidDl:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -24,7 +24,12 @@ states:
             auditContext:
               mitigationType: enhanced-verification
           liveness-likeness:
-            targetState: MITIGATE_CI_VIA_APP
+            targetJourney: TECHNICAL_ERROR # Should never happen
+            targetState: ERROR
+            checkFeatureFlag:
+              mitigations9020Enabled:
+                targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+                targetEntryEvent: liveness-likeness-return
 
   KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
     events:
@@ -733,9 +738,7 @@ states:
       pageId: passport-biometric-chip
     events:
       next:
-        # PYIC-9068 Implement mitigation route
-        targetJourney: FAILED
-        targetState: FAILED
+        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP
       abandon:
         targetState: MITIGATION_NEED_BIOMETRIC_PASSPORT
 
@@ -747,10 +750,45 @@ states:
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
       useApp:
-        # PYIC-9068 Implement mitigation route
+        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP
+
+  MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP:
+    response:
+      type: process
+      lambda: reset-identity
+      lambdaInput:
+        resetType: PENDING_DCMAW_ASYNC
+    events:
+      next:
+        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+        journeyContextToUnset: internationalAddress
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  MITIGATION_STRATEGIC_APP_TRIAGE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetState: PROCESS_NEW_IDENTITY
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+      anotherWay:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+      incompleteDlAuthCheckInvalidDl:
         targetJourney: FAILED
         targetState: FAILED
-
+      failedDlAuthCheckInvalidDl:
+        targetJourney: FAILED
+        targetState: FAILED
+      failWithCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED
+      failWithNoCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -1153,10 +1153,8 @@ states:
       type: page
       pageId: passport-biometric-chip
     events:
-      next:
-        # PYIC-9068 Implement mitigation route
-        targetJourney: FAILED
-        targetState: FAILED
+      appTriage:
+        targetState: MITIGATION_FRAUD_STRATEGIC_APP_TRIAGE
       abandon:
         targetState: MITIGATION_NEED_BIOMETRIC_PASSPORT
 
@@ -1165,12 +1163,18 @@ states:
       type: page
       pageId: need-biometric-passport
     events:
+      useApp:
+        targetState: MITIGATION_FRAUD_STRATEGIC_APP_TRIAGE
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
-      useApp:
-        # PYIC-9068 Implement mitigation route
-        targetJourney: FAILED
-        targetState: FAILED
+
+  MITIGATION_FRAUD_STRATEGIC_APP_TRIAGE:
+    nestedJourney: STRATEGIC_APP_TRIAGE
+    exitEvents:
+      next:
+        targetState: PROCESS_NEW_IDENTITY
+
+
 
   # End of journey steps
 

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -24,7 +24,12 @@ states:
             auditContext:
               mitigationType: enhanced-verification
           liveness-likeness:
-            targetState: MITIGATE_CI_VIA_APP
+            targetJourney: TECHNICAL_ERROR # Should never happen
+            targetState: ERROR
+            checkFeatureFlag:
+              mitigations9020Enabled:
+                targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+                targetEntryEvent: liveness-likeness-return
 
   KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
     events:
@@ -1153,8 +1158,8 @@ states:
       type: page
       pageId: passport-biometric-chip
     events:
-      appTriage:
-        targetState: MITIGATION_FRAUD_STRATEGIC_APP_TRIAGE
+      next:
+        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP
       abandon:
         targetState: MITIGATION_NEED_BIOMETRIC_PASSPORT
 
@@ -1164,20 +1169,49 @@ states:
       pageId: need-biometric-passport
     events:
       useApp:
-        targetState: MITIGATION_FRAUD_STRATEGIC_APP_TRIAGE
+        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
-  MITIGATION_FRAUD_STRATEGIC_APP_TRIAGE:
+  MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP:
+    response:
+      type: process
+      lambda: reset-identity
+      lambdaInput:
+        resetType: PENDING_DCMAW_ASYNC
+    events:
+      next:
+        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+        journeyContextToUnset: internationalAddress
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  MITIGATION_STRATEGIC_APP_TRIAGE:
     nestedJourney: STRATEGIC_APP_TRIAGE
     exitEvents:
       next:
         targetState: PROCESS_NEW_IDENTITY
-
-
+      returnToRp:
+        targetState: PROCESS_INCOMPLETE_IDENTITY
+      anotherWay:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE
+      incompleteDlAuthCheckInvalidDl:
+        targetJourney: FAILED
+        targetState: FAILED
+      failedDlAuthCheckInvalidDl:
+        targetJourney: FAILED
+        targetState: FAILED
+      failWithCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED
+      failWithNoCiFromApp:
+        targetJourney: FAILED
+        targetState: FAILED
 
   # End of journey steps
-
   PROCESS_NEW_IDENTITY:
     response:
       type: process

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -24,12 +24,7 @@ states:
             auditContext:
               mitigationType: enhanced-verification
           liveness-likeness:
-            targetJourney: TECHNICAL_ERROR # Should never happen
-            targetState: ERROR
-            checkFeatureFlag:
-              mitigations9020Enabled:
-                targetState: MITIGATION_STRATEGIC_APP_TRIAGE
-                targetEntryEvent: liveness-likeness-return
+            targetState: MITIGATE_CI_VIA_APP
 
   KBV_MITIGATION_VIA_APP_SKIP_ADDRESS_FRAUD:
     events:
@@ -1196,8 +1191,8 @@ states:
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
       anotherWay:
-        targetJourney: INELIGIBLE
-        targetState: INELIGIBLE
+        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+        targetEntryEvent: liveness-likeness-another-way
       incompleteDlAuthCheckInvalidDl:
         targetJourney: FAILED
         targetState: FAILED

--- a/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
+++ b/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
@@ -42,6 +42,7 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_IS
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.IPV_SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.NAME_ONLY_CHANGE;
+import static uk.gov.di.ipv.core.library.enums.IdentityResetType.PENDING_DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.PENDING_DCMAW_ASYNC_ALL;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.REINSTATE;
@@ -160,7 +161,9 @@ public class ResetIdentityHandler implements RequestHandler<ProcessRequest, Map<
                                         input.getDeviceInformation())));
             }
 
-            if (resetType.equals(PENDING_DCMAW_ASYNC_ALL) || resetType.equals(NAME_ONLY_CHANGE)) {
+            if (resetType.equals(PENDING_DCMAW_ASYNC_ALL)
+                    || resetType.equals(NAME_ONLY_CHANGE)
+                    || resetType.equals(PENDING_DCMAW_ASYNC)) {
                 resetPendingIdentity(clientOAuthSessionItem, DCMAW_ASYNC);
             }
 

--- a/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
+++ b/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
@@ -55,6 +55,7 @@ import static uk.gov.di.ipv.core.library.domain.ErrorResponse.MISSING_IPV_SESSIO
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.UNKNOWN_RESET_TYPE;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.ALL;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.NAME_ONLY_CHANGE;
+import static uk.gov.di.ipv.core.library.enums.IdentityResetType.PENDING_DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.PENDING_DCMAW_ASYNC_ALL;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.PENDING_F2F_ALL;
 import static uk.gov.di.ipv.core.library.enums.IdentityResetType.REINSTATE;
@@ -269,7 +270,7 @@ class ResetIdentityHandlerTest {
     }
 
     @Test
-    void handleRequestShouldCleanupVcsAndReturnNextForPendingDcmaw() throws Exception {
+    void handleRequestShouldCleanupVcsAndReturnNextForPendingDcmawAsyncAll() throws Exception {
         // Arrange
         when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -300,7 +301,7 @@ class ResetIdentityHandlerTest {
     }
 
     @Test
-    void handleRequestShouldCleanupVcsAndReturnNextForPendingDcmawV2() throws Exception {
+    void handleRequestShouldCleanupVcsAndReturnNextForPendingDcmawAsyncAllV2() throws Exception {
         // Arrange
         when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
         when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
@@ -329,6 +330,69 @@ class ResetIdentityHandlerTest {
         verify(mockEvcsService)
                 .abandonPendingIdentityV2(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
 
+        assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
+    }
+
+    // Can be removed with EVCS_API_UPDATES feature flag removal ticket
+    @Test
+    void handleRequestShouldCleanupAsyncDcmawVcAndPendingRecordAndReturnNextForPendingDcmawAsync()
+            throws Exception {
+        // Arrange
+        when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        var event =
+                ProcessRequest.processRequestBuilder()
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .featureSet(TEST_FEATURE_SET)
+                        .lambdaInput(Map.of("resetType", PENDING_DCMAW_ASYNC.name()))
+                        .build();
+
+        // Act
+        var journeyResponse =
+                OBJECT_MAPPER.convertValue(
+                        resetIdentityHandler.handleRequest(event, mockContext),
+                        JourneyResponse.class);
+
+        // Assert
+        verifyVotSetToP0();
+        verify(mockSessionCredentialsService)
+                .deleteSessionCredentialsForResetType(
+                        ipvSessionItem.getIpvSessionId(), PENDING_DCMAW_ASYNC);
+        verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, DCMAW_ASYNC);
+        verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+        assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
+    }
+
+    @Test
+    void handleRequestShouldCleanupAsyncDcmawVcAndPendingRecordAndReturnNextForPendingDcmawAsyncV2()
+            throws Exception {
+        // Arrange
+        when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
+        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
+                .thenReturn(clientOAuthSessionItem);
+        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
+        var event =
+                ProcessRequest.processRequestBuilder()
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .featureSet(TEST_FEATURE_SET)
+                        .lambdaInput(Map.of("resetType", PENDING_DCMAW_ASYNC.name()))
+                        .build();
+
+        // Act
+        var journeyResponse =
+                OBJECT_MAPPER.convertValue(
+                        resetIdentityHandler.handleRequest(event, mockContext),
+                        JourneyResponse.class);
+
+        // Assert
+        verifyVotSetToP0();
+        verify(mockSessionCredentialsService)
+                .deleteSessionCredentialsForResetType(
+                        ipvSessionItem.getIpvSessionId(), PENDING_DCMAW_ASYNC);
+        verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, DCMAW_ASYNC);
+        verify(mockEvcsService)
+                .abandonPendingIdentityV2(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
         assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
     }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/IdentityResetType.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/IdentityResetType.java
@@ -7,6 +7,8 @@ public enum IdentityResetType {
     DCMAW,
     /** Deletes only DCMAW_ASYNC VC from session. */
     DCMAW_ASYNC,
+    /** Deletes DCMAW_ASYNC VC from session and pending record. */
+    PENDING_DCMAW_ASYNC,
     /** Deletes all session + pending VCs except address. */
     NAME_ONLY_CHANGE,
     /** Deletes address + fraud VCs from session. */

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -169,7 +169,9 @@ public class EvcsService {
                                         new EvcsUpdateUserVCsDto(
                                                 getVcSignature(vc.vc()), ABANDONED, null))
                         .toList();
-        if (!vcsToUpdates.isEmpty()) evcsClient.updateUserVCs(userId, vcsToUpdates);
+        if (!vcsToUpdates.isEmpty()) {
+            evcsClient.updateUserVCs(userId, vcsToUpdates);
+        }
     }
 
     public void abandonPendingIdentityV2(

--- a/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
+++ b/libs/verifiable-credentials/src/main/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsService.java
@@ -120,7 +120,7 @@ public class SessionCredentialsService {
                                 sessionCredentialItems.stream()
                                         .filter(item -> DCMAW.getId().equals(item.getCriId()))
                                         .toList();
-                        case DCMAW_ASYNC ->
+                        case DCMAW_ASYNC, PENDING_DCMAW_ASYNC ->
                                 sessionCredentialItems.stream()
                                         .filter(item -> DCMAW_ASYNC.getId().equals(item.getCriId()))
                                         .toList();

--- a/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
+++ b/libs/verifiable-credentials/src/test/java/uk/gov/di/ipv/core/library/verifiablecredential/service/SessionCredentialsServiceTest.java
@@ -378,9 +378,10 @@ class SessionCredentialsServiceTest {
             verify(mockDataStore).delete(List.of(sessionDcmawCredentialItem));
         }
 
-        @Test
-        void deleteSessionCredentialsForResetTypeDcmawAsyncShouldDeleteDcmawAsyncVcs()
-                throws Exception {
+        @ParameterizedTest
+        @EnumSource(names = {"DCMAW_ASYNC", "PENDING_DCMAW_ASYNC"})
+        void deleteSessionCredentialsForResetTypeDcmawAsyncShouldDeleteDcmawAsyncVcs(
+                IdentityResetType resetType) throws Exception {
             var addressVc =
                     generateVerifiableCredential("userId", ADDRESS, vcClaimFailedWithCis(null));
             var fraudVc =
@@ -401,8 +402,7 @@ class SessionCredentialsServiceTest {
                                     sessionAddressCredentialItem,
                                     sessionDcmawCredentialItem));
 
-            sessionCredentialService.deleteSessionCredentialsForResetType(
-                    SESSION_ID, IdentityResetType.DCMAW_ASYNC);
+            sessionCredentialService.deleteSessionCredentialsForResetType(SESSION_ID, resetType);
 
             verify(mockDataStore).getItems(SESSION_ID);
             verify(mockDataStore).delete(List.of(sessionDcmawCredentialItem));


### PR DESCRIPTION
## Proposed changes
### What changed

- Added fraud mitigation journeys and test coverage
- Added new PENDING_DCMAW_ASYNC imput to reset-identity lambda

### Why did it change

- To increase journeys competition score
- We need to reset pending VCs before app journey to wipe out previous async VC before the mitigation via app. Otherwise the spinner will hold previous state, but at the same time we want to persist address and fraud and other VCs. 

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9068](https://govukverify.atlassian.net/browse/PYIC-9068)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9068]: https://govukverify.atlassian.net/browse/PYIC-9068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ