### PR TITLE
Revert "Revert "PYIC-9068: Fix new CI mitigation journeys - back button and cross-browser scenarios.""

### DIFF
--- a/api-tests/features/app-cross-browser/p1-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p1-cross-browser.feature
@@ -363,3 +363,126 @@ Feature: P1 V2 App Cross Browser Scenario
       When I use the OAuth response to get my identity
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
+
+  Rule: Cross-browser during separate-session liveness-likeness mitigation
+    Background:
+      Given I activate the 'mitigations9020' feature set
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response and pageContext
+        | Context   | Value |
+        | allowNino | true  |
+      When I submit a 'drivingLicence' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+
+    Scenario: Separate session DCMAW liveness-likeness mitigation - successful
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+        # This simulates the user clicking continue on the problem-different-browser
+        # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+        # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+        # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P1' identity
+      And I have a stored identity record with a 'P3' max vot
+
+    Scenario: Separate session DCMAW liveness-likeness mitigation - user fails DCMAW with no ci
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+      # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+      # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'low-confidence' journey
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Separate session DCMAW liveness-likeness mitigation - user fails DCMAW with CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+      # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+      # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'low-confidence' journey
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Separate session DCMAW liveness-likeness mitigation - DL auth check
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+      # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+      # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'low-confidence' journey
+      # User should not use DL in the app
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS

--- a/api-tests/features/app-cross-browser/p2-cross-browser.feature
+++ b/api-tests/features/app-cross-browser/p2-cross-browser.feature
@@ -606,3 +606,128 @@ Feature: P2 V2 App Cross Browser Scenario
       When I use the OAuth response to get my identity
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
+
+  Rule: Cross-browser during separate-session liveness-likeness mitigation
+    Background:
+      Given I activate the 'openBankingDisabled' feature set
+      And I activate the 'mitigations9020' feature set
+      When I start a new 'medium-confidence' journey
+      Then I get a 'live-in-uk' page response
+      When I submit a 'uk' event
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response
+      When I submit a 'drivingLicence' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+      When I submit a 'next' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'iphone' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value  |
+        | smartphone | iphone |
+        | isAppOnly  | true  |
+
+    Scenario: Separate session DCMAW liveness-likeness mitigation - successful
+      When the async DCMAW CRI produces a 'kenneth-passport-valid' VC that mitigates the 'NEEDS-LIVENESS-LIKENESS' CI
+        # And the user returns from the app to core-front
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+        # This simulates the user clicking continue on the problem-different-browser
+        # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+        # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+        # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'medium-confidence' journey
+      Then I get a 'page-ipv-success' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P2' identity
+      And I have a stored identity record with a 'P3' max vot
+
+    Scenario: Separate session DCMAW liveness-likeness mitigation - user fails DCMAW with no ci
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+      # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+      # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'medium-confidence' journey
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+
+    Scenario: Separate session DCMAW liveness-likeness mitigation - user fails DCMAW with CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+      # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+      # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'medium-confidence' journey
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: Separate session DCMAW liveness-likeness mitigation - DL auth check
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      And I pass on the DCMAW callback in a separate session
+      Then I get a 'problem-different-browser' page response
+      # This simulates the user clicking continue on the problem-different-browser
+      # page which sends a 'build-client-oauth-response' event to the journey engine
+      When I submit a 'build-client-oauth-response' event in a separate session
+      Then I get an OAuth response with error code 'access_denied'
+      # Wait for the VC to be received before continuing. In the usual case the VC will be received well before the user
+      # has managed to log back in to the site.
+      When I poll for async DCMAW credential receipt
+      And I start a new 'medium-confidence' journey
+      # User should not use DL in the app
+      Then I get a 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS

--- a/api-tests/features/fraud-mitigation/p1-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p1-mitigation.feature
@@ -453,3 +453,116 @@ Feature: P1 Fraud mitigation
       When I use the OAuth response to get my identity
       Then I am issued a 'P0' identity
       And I don't have a stored identity in EVCS
+
+  Rule: Failed DCMAW async and alternative routes
+    Background:
+      When I start a new 'low-confidence' journey
+      Then I get a 'page-ipv-identity-document-start' page response
+      When I submit an 'appTriage' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'pyi-triage-buffer' page response
+      When I submit an 'anotherWay' event
+      Then I get a 'page-multiple-doc-check' page response and pageContext
+        | Context   | Value |
+        | allowNino | true  |
+      When I submit a 'drivingLicence' event
+      Then I get a 'drivingLicence' CRI response
+      When I submit 'kenneth-driving-permit-valid' details to the CRI stub
+      Then I get an 'address' CRI response
+      When I submit 'kenneth-current' details to the CRI stub
+      Then I get a 'fraud' CRI response
+      When I submit 'kenneth-breaching-liveness-likeness-ci' details with attributes to the CRI stub
+        | Attribute          | Values                   |
+        | evidence_requested | {"identityFraudScore":2} |
+      Then I get a 'retry-prove-identity-app' page response
+      When I submit a 'useApp' event
+      Then I get a 'passport-biometric-chip' page response
+      When I submit a 'abandon' event
+      Then I get a 'need-biometric-passport' page response
+      When I submit a 'useApp' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+
+    Scenario: User navigates back on select device page
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit an 'back' event
+      Then I get a 'need-biometric-passport' page response
+      When I submit a 'useApp' event
+      Then I get an 'identify-device' page response
+
+    Scenario: User failed to mitigate Fraud CI:
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-passport-fail-no-ci' VC
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: User failed to mitigate Fraud CI with new CI:
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      Then I get an 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS
+
+    Scenario: User failed to mitigate Fraud CI by using driving licence in app:
+      When I submit a 'smartphone' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | mam   |
+      When I submit an 'android' event
+      Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
+        | Context    | Value   |
+        | smartphone | android |
+        | isAppOnly  | true    |
+      When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
+      And I pass on the DCMAW callback
+      Then I get an 'check-mobile-app-result' page response
+      When I poll for async DCMAW credential receipt
+      Then the poll returns a '201'
+      When I submit the returned journey event
+      # User passed DL check but doesn't have sufficient score to achieve P2
+      Then I get an 'pyi-no-match' page response
+      When I submit a 'next' event
+      Then I get an OAuth response
+      When I use the OAuth response to get my identity
+      Then I am issued a 'P0' identity
+      And I don't have a stored identity in EVCS

--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -1,4 +1,4 @@
-@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest @DomAll
+@Build @QualityGateIntegrationTest @QualityGateNewFeatureTest
 Feature: P2 Fraud mitigation
 
   Background: Enable fraud mitigation
@@ -999,9 +999,14 @@ Feature: P2 Fraud mitigation
       When I submit a 'useApp' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event
-      Then I get a 'pyi-triage-select-device' page response
 
-    Scenario Outline: DAD journeys - user drop off from download page
+    Scenario Outline: DAD journeys - user goes back and drop off from download page
+      Then I get a 'pyi-triage-select-device' page response
+      When I submit an 'back' event
+      Then I get a 'need-biometric-passport' page response
+      When I submit a 'useApp' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
       When I submit a 'computer-or-tablet' event
       Then I get a 'pyi-triage-select-smartphone' page response and pageContext
         | Context    | Value |
@@ -1032,6 +1037,7 @@ Feature: P2 Fraud mitigation
         | android |
 
     Scenario Outline: MAM journeys - user drop off from download page
+      Then I get a 'pyi-triage-select-device' page response
       When I submit a 'smartphone' event
       Then I get a 'pyi-triage-select-smartphone' page response and pageContext
         | Context    | Value |
@@ -1094,7 +1100,7 @@ Feature: P2 Fraud mitigation
         | Context    | Value   |
         | smartphone | android |
         | isAppOnly  | true    |
-      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'ALWAYS-REQUIRED' CI
+      When the async DCMAW CRI produces a 'kennethD' 'ukChippedPassport' 'fail' VC with a 'BREACHING' CI
       And I pass on the DCMAW callback
       Then I get an 'check-mobile-app-result' page response
       When I poll for async DCMAW credential receipt

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2519,6 +2519,8 @@ Resources:
             TableName: !Ref ClientOAuthSessionsTable
         - DynamoDBWritePolicy:
             TableName: !Ref ClientOAuthSessionsTable
+        - DynamoDBReadPolicy:
+            TableName: !Ref SessionCredentialsTable
         - DynamoDBWritePolicy:
             TableName: !Ref SessionCredentialsTable
         - SSMParameterReadPolicy:

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -49,6 +49,7 @@ import uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
 import uk.gov.di.ipv.core.library.helpers.RequestHelper;
 import uk.gov.di.ipv.core.library.helpers.VotHelper;
+import uk.gov.di.ipv.core.library.journeys.Events;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.IpvSessionItem;
 import uk.gov.di.ipv.core.library.service.AuditService;
@@ -72,6 +73,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_NOT_FOUND;
 import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
@@ -491,6 +493,7 @@ public class CheckExistingIdentityHandler
                     var dcmawContinuationResponse =
                             buildDCMAWContinuationResponse(
                                     credentialBundle,
+                                    contraIndicators,
                                     ipAddress,
                                     ipvSessionItem,
                                     targetVot,
@@ -605,8 +608,10 @@ public class CheckExistingIdentityHandler
         return JOURNEY_F2F_FAIL;
     }
 
+    @SuppressWarnings("java:S107") // Methods should not have too many parameters
     private JourneyResponse buildDCMAWContinuationResponse(
             VerifiableCredentialBundle credentialBundle,
+            List<ContraIndicator> contraIndicators,
             String ipAddress,
             IpvSessionItem ipvSessionItem,
             Vot lowestGpg45ConfidenceRequested,
@@ -641,8 +646,33 @@ public class CheckExistingIdentityHandler
                 deviceInformation,
                 new AuditExtensionPreviousIpvSessionId(previousIpvSessionItem.getIpvSessionId()));
 
-        sessionCredentialsService.persistCredentials(
-                credentialBundle.credentials, auditEventUser.getSessionId(), true);
+        if (isLivenessLikenessMitigation(contraIndicators, lowestGpg45ConfidenceRequested)) {
+            // In the Fraud Mitigation journey, we reset only the DCMAW ASYNC VC from the session
+            // and pending record from criResponse.
+            // As app is the final step, and there is no address or fraud CRI after,
+            // we need to access the VCs from the previous session in the process-candidate-identity
+            // Lambda.
+            // We also want to use the VC extracted from EVCS for the DCMAW ASYNC VC rather than the
+            // one
+            // from the previous session
+            var previousSessionVcs =
+                    sessionCredentialsService.getCredentials(
+                            previousIpvSessionItem.getIpvSessionId(),
+                            clientOAuthSessionItem.getUserId(),
+                            true);
+            var newSessionVcs =
+                    Stream.concat(
+                                    credentialBundle.credentials.stream()
+                                            .filter(vc -> vc.getCri().equals(DCMAW_ASYNC)),
+                                    previousSessionVcs.stream()
+                                            .filter(vc -> !vc.getCri().equals(DCMAW_ASYNC)))
+                            .toList();
+            sessionCredentialsService.persistCredentials(
+                    newSessionVcs, auditEventUser.getSessionId(), true);
+        } else {
+            sessionCredentialsService.persistCredentials(
+                    credentialBundle.credentials, auditEventUser.getSessionId(), true);
+        }
 
         var forcedJourney =
                 criCheckingService.checkVcResponse(
@@ -674,6 +704,13 @@ public class CheckExistingIdentityHandler
             case P2 -> JOURNEY_DCMAW_ASYNC_VC_RECEIVED_MEDIUM;
             default -> buildErrorResponse(ErrorResponse.INVALID_VTR_CLAIM);
         };
+    }
+
+    private boolean isLivenessLikenessMitigation(List<ContraIndicator> contraIndicators, Vot vot) {
+        var mitigationEvent =
+                cimitUtilityService.getMitigationEventIfBreachingOrActive(contraIndicators, vot);
+        return mitigationEvent.isPresent()
+                && mitigationEvent.get().equals(Events.LIVENESS_LIKENESS);
     }
 
     private JourneyResponse buildReuseResponse(

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -56,6 +56,7 @@ import uk.gov.di.ipv.core.library.exceptions.VerifiableCredentialException;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45Scores;
 import uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile;
 import uk.gov.di.ipv.core.library.helpers.SecureTokenHelper;
+import uk.gov.di.ipv.core.library.journeys.Events;
 import uk.gov.di.ipv.core.library.journeys.JourneyUris;
 import uk.gov.di.ipv.core.library.persistence.item.ClientOAuthSessionItem;
 import uk.gov.di.ipv.core.library.persistence.item.CriOAuthSessionItem;
@@ -87,6 +88,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -120,6 +122,7 @@ import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.PENDING_RETURN;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcAddressM1a;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawAsyncDrivingPermitDva;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawAsyncDrivingPermitDvaFailedChecks;
+import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawAsyncPassport;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawDrivingPermitDvaExpired;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawDrivingPermitDvaExpiredFailNoCi;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcDcmawDrivingPermitDvaM1b;
@@ -419,6 +422,277 @@ class CheckExistingIdentityHandlerTest {
 
             // Assert
             assertEquals(expectedJourney, journeyResponse);
+            verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+            verify(mockSessionCredentialService).persistCredentials(vcs, TEST_SESSION_ID, true);
+            verify(auditService).sendAuditEvent(auditEventArgumentCaptor.capture());
+            assertEquals(
+                    AuditEventTypes.IPV_APP_SESSION_RECOVERED,
+                    auditEventArgumentCaptor.getValue().getEventName());
+            assertEquals(
+                    TEST_PREVIOUS_IPV_SESSION_ID,
+                    ((AuditExtensionPreviousIpvSessionId)
+                                    auditEventArgumentCaptor.getValue().getExtensions())
+                            .getPreviousIpvSessionId());
+            assertEquals(Vot.P0, ipvSessionItem.getVot());
+        }
+
+        @ParameterizedTest
+        @MethodSource("lowAndMediumConfidenceVtrs")
+        void
+                shouldPersistPendingReturnVcInTheSessionWithPreviousSessionVcsAndReturnDcmawAsyncVcReceivedForDcmawAsyncComplete(
+                        List<String> vtr, JourneyResponse expectedJourney)
+                        throws IpvSessionNotFoundException,
+                                VerifiableCredentialException,
+                                EvcsServiceException,
+                                CredentialParseException,
+                                HttpResponseExceptionWithErrorBody {
+            // Arrange
+            when(criResponseService.getCriResponseItem(TEST_USER_ID, DCMAW_ASYNC))
+                    .thenReturn(
+                            CriResponseItem.builder()
+                                    .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                    .build());
+            when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                    .thenReturn(
+                            List.of(
+                                    CriResponseItem.builder()
+                                            .credentialIssuer(DCMAW_ASYNC.getId())
+                                            .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                            .build()));
+            when(criOAuthSessionService.getCriOauthSessionItem(TEST_CRI_OAUTH_SESSION_ID))
+                    .thenReturn(
+                            CriOAuthSessionItem.builder()
+                                    .clientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID)
+                                    .build());
+            when(cimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any()))
+                    .thenReturn(Optional.of(Events.LIVENESS_LIKENESS));
+
+            var previousIpvSession = new IpvSessionItem();
+            previousIpvSession.setIpvSessionId(TEST_PREVIOUS_IPV_SESSION_ID);
+            when(ipvSessionService.getIpvSessionByClientOAuthSessionId(
+                            TEST_CLIENT_OAUTH_SESSION_ID))
+                    .thenReturn(previousIpvSession);
+
+            // Previous session had address, fraud, and DCMAW_ASYNC VC
+            var previousSessionDcmawAsyncPassportVc = vcDcmawAsyncPassport();
+            var previousSessionAddressVc = vcAddressM1a();
+            var previousSessionFraudVc = vcExperianFraudM1a();
+            var previousSessionVcs =
+                    List.of(
+                            previousSessionAddressVc,
+                            previousSessionFraudVc,
+                            previousSessionDcmawAsyncPassportVc);
+
+            when(mockSessionCredentialService.getCredentials(
+                            TEST_PREVIOUS_IPV_SESSION_ID, TEST_USER_ID, true))
+                    .thenReturn(previousSessionVcs);
+
+            // DCMAW_ASYNC VC from EVCS
+            var evcsDcmawAsyncPassportVc = vcDcmawAsyncDrivingPermitDva();
+            var evcsVcs = List.of(evcsDcmawAsyncPassportVc);
+
+            when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+                    .thenReturn(
+                            new AsyncCriStatus(
+                                    DCMAW_ASYNC,
+                                    AsyncCriStatus.STATUS_PENDING,
+                                    false,
+                                    true,
+                                    false));
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
+                            TEST_USER_ID, EVCS_TEST_TOKEN, false, CURRENT, PENDING_RETURN))
+                    .thenReturn(Map.of(PENDING_RETURN, evcsVcs));
+            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+            clientOAuthSessionItem.setVtr(vtr);
+
+            // Act
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            // Assert
+            assertEquals(expectedJourney, journeyResponse);
+            var vcsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(mockSessionCredentialService)
+                    .persistCredentials(vcsCaptor.capture(), eq(TEST_SESSION_ID), eq(true));
+
+            var persistedVcs = (List<VerifiableCredential>) vcsCaptor.getValue();
+            assertEquals(3, persistedVcs.size());
+            assertTrue(persistedVcs.stream().anyMatch(vc -> vc.equals(evcsDcmawAsyncPassportVc)));
+            assertTrue(persistedVcs.contains(previousSessionAddressVc));
+            assertTrue(persistedVcs.contains(previousSessionFraudVc));
+            verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+            verify(auditService).sendAuditEvent(auditEventArgumentCaptor.capture());
+            assertEquals(
+                    AuditEventTypes.IPV_APP_SESSION_RECOVERED,
+                    auditEventArgumentCaptor.getValue().getEventName());
+            assertEquals(
+                    TEST_PREVIOUS_IPV_SESSION_ID,
+                    ((AuditExtensionPreviousIpvSessionId)
+                                    auditEventArgumentCaptor.getValue().getExtensions())
+                            .getPreviousIpvSessionId());
+            assertEquals(Vot.P0, ipvSessionItem.getVot());
+        }
+
+        @ParameterizedTest
+        @MethodSource("lowAndMediumConfidenceVtrs")
+        void
+                shouldPersistOnlyPendingReturnVcInTheSessionWhenPreviousSessionVcsIsEmptyAndReturnDcmawAsyncVcReceivedForDcmawAsyncComplete(
+                        List<String> vtr, JourneyResponse expectedJourney)
+                        throws IpvSessionNotFoundException,
+                                HttpResponseExceptionWithErrorBody,
+                                CredentialParseException,
+                                VerifiableCredentialException,
+                                EvcsServiceException {
+            // Arrange
+            when(criResponseService.getCriResponseItem(TEST_USER_ID, DCMAW_ASYNC))
+                    .thenReturn(
+                            CriResponseItem.builder()
+                                    .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                    .build());
+            when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                    .thenReturn(
+                            List.of(
+                                    CriResponseItem.builder()
+                                            .credentialIssuer(DCMAW_ASYNC.getId())
+                                            .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                            .build()));
+            when(criOAuthSessionService.getCriOauthSessionItem(TEST_CRI_OAUTH_SESSION_ID))
+                    .thenReturn(
+                            CriOAuthSessionItem.builder()
+                                    .clientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID)
+                                    .build());
+            when(cimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any()))
+                    .thenReturn(Optional.of(Events.LIVENESS_LIKENESS));
+
+            var previousIpvSession = new IpvSessionItem();
+            previousIpvSession.setIpvSessionId(TEST_PREVIOUS_IPV_SESSION_ID);
+            when(ipvSessionService.getIpvSessionByClientOAuthSessionId(
+                            TEST_CLIENT_OAUTH_SESSION_ID))
+                    .thenReturn(previousIpvSession);
+
+            // Previous session had no VCs
+            when(mockSessionCredentialService.getCredentials(
+                            TEST_PREVIOUS_IPV_SESSION_ID, TEST_USER_ID, true))
+                    .thenReturn(List.of());
+
+            // DCMAW_ASYNC VC from EVCS
+            var dcmawAsyncPassportVc = vcDcmawAsyncPassport();
+            var evcsVcs = List.of(dcmawAsyncPassportVc);
+
+            when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+                    .thenReturn(
+                            new AsyncCriStatus(
+                                    DCMAW_ASYNC,
+                                    AsyncCriStatus.STATUS_PENDING,
+                                    false,
+                                    true,
+                                    false));
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
+                            TEST_USER_ID, EVCS_TEST_TOKEN, false, CURRENT, PENDING_RETURN))
+                    .thenReturn(Map.of(PENDING_RETURN, evcsVcs));
+            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+            clientOAuthSessionItem.setVtr(vtr);
+
+            // Act
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            // Assert
+            verify(mockSessionCredentialService).persistCredentials(evcsVcs, TEST_SESSION_ID, true);
+
+            assertEquals(expectedJourney, journeyResponse);
+            var vcsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(mockSessionCredentialService)
+                    .persistCredentials(vcsCaptor.capture(), eq(TEST_SESSION_ID), eq(true));
+            var persistedVcs = (List<VerifiableCredential>) vcsCaptor.getValue();
+            assertEquals(1, persistedVcs.size());
+            assertSame(persistedVcs.getFirst(), dcmawAsyncPassportVc);
+            verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
+            verify(auditService).sendAuditEvent(auditEventArgumentCaptor.capture());
+            assertEquals(
+                    AuditEventTypes.IPV_APP_SESSION_RECOVERED,
+                    auditEventArgumentCaptor.getValue().getEventName());
+            assertEquals(
+                    TEST_PREVIOUS_IPV_SESSION_ID,
+                    ((AuditExtensionPreviousIpvSessionId)
+                                    auditEventArgumentCaptor.getValue().getExtensions())
+                            .getPreviousIpvSessionId());
+            assertEquals(Vot.P0, ipvSessionItem.getVot());
+        }
+
+        @ParameterizedTest
+        @MethodSource("lowAndMediumConfidenceVtrs")
+        void
+                shouldPersistOnlyPendingReturnVcInTheSessionWhenIsNotLivenessLikenessMitigationAndReturnDcmawAsyncVcReceivedForDcmawAsyncComplete(
+                        List<String> vtr, JourneyResponse expectedJourney)
+                        throws IpvSessionNotFoundException,
+                                HttpResponseExceptionWithErrorBody,
+                                CredentialParseException,
+                                VerifiableCredentialException,
+                                EvcsServiceException {
+            // Arrange
+            when(criResponseService.getCriResponseItem(TEST_USER_ID, DCMAW_ASYNC))
+                    .thenReturn(
+                            CriResponseItem.builder()
+                                    .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                    .build());
+            when(criResponseService.getCriResponseItems(TEST_USER_ID))
+                    .thenReturn(
+                            List.of(
+                                    CriResponseItem.builder()
+                                            .credentialIssuer(DCMAW_ASYNC.getId())
+                                            .oauthState(TEST_CRI_OAUTH_SESSION_ID)
+                                            .build()));
+            when(criOAuthSessionService.getCriOauthSessionItem(TEST_CRI_OAUTH_SESSION_ID))
+                    .thenReturn(
+                            CriOAuthSessionItem.builder()
+                                    .clientOAuthSessionId(TEST_CLIENT_OAUTH_SESSION_ID)
+                                    .build());
+            when(cimitUtilityService.getMitigationEventIfBreachingOrActive(any(), any()))
+                    .thenReturn(Optional.of("different-mitigation-event"));
+
+            var previousIpvSession = new IpvSessionItem();
+            previousIpvSession.setIpvSessionId(TEST_PREVIOUS_IPV_SESSION_ID);
+            when(ipvSessionService.getIpvSessionByClientOAuthSessionId(
+                            TEST_CLIENT_OAUTH_SESSION_ID))
+                    .thenReturn(previousIpvSession);
+            var dcmawAsyncPassportVc = vcDcmawAsyncPassport();
+            var vcs = List.of(dcmawAsyncPassportVc);
+            when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(true)))
+                    .thenReturn(
+                            new AsyncCriStatus(
+                                    DCMAW_ASYNC,
+                                    AsyncCriStatus.STATUS_PENDING,
+                                    false,
+                                    true,
+                                    false));
+            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
+                            TEST_USER_ID, EVCS_TEST_TOKEN, false, CURRENT, PENDING_RETURN))
+                    .thenReturn(Map.of(PENDING_RETURN, vcs));
+            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
+
+            clientOAuthSessionItem.setVtr(vtr);
+
+            // Act
+            JourneyResponse journeyResponse =
+                    toResponseClass(
+                            checkExistingIdentityHandler.handleRequest(event, context),
+                            JourneyResponse.class);
+
+            // Assert
+            assertEquals(expectedJourney, journeyResponse);
+            verify(mockSessionCredentialService, times(0)).getCredentials(any(), any(), any());
+            var vcsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(mockSessionCredentialService)
+                    .persistCredentials(vcsCaptor.capture(), eq(TEST_SESSION_ID), eq(true));
+
+            var persistedVcs = (List<VerifiableCredential>) vcsCaptor.getValue();
+            assertEquals(1, persistedVcs.size());
+            assertSame(persistedVcs.getFirst(), dcmawAsyncPassportVc);
             verify(clientOAuthSessionDetailsService, times(1)).getClientOAuthSession(any());
             verify(mockSessionCredentialService).persistCredentials(vcs, TEST_SESSION_ID, true);
             verify(auditService).sendAuditEvent(auditEventArgumentCaptor.capture());

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p1-identity.yaml
@@ -47,17 +47,27 @@ states:
               f2f:
                 targetJourney: INELIGIBLE
                 targetState: INELIGIBLE
+          liveness-likeness:
+            targetJourney: FAILED
+            targetState: FAILED
 
   DCMAW_ASYNC_DL_AUTH_SOURCE_CHECK:
     events:
       next:
         targetState: STRATEGIC_APP_TRIAGE
         targetEntryEvent: dl-auth-source-check
+        checkMitigation:
+          liveness-likeness:
+            targetJourney: FAILED
+            targetState: FAILED
 
   DCMAW_ASYNC_COMPLETE:
     events:
       next:
         targetState: POST_APP_DOC_CHECK_SUCCESS_PAGE
+        checkMitigation:
+          liveness-likeness:
+            targetState: PROCESS_NEW_IDENTITY
 
   IDENTITY_DOCUMENT_START:
     events:
@@ -307,7 +317,7 @@ states:
             targetState: FAILED
             checkMitigation:
               liveness-likeness:
-                targetState: MITIGATE_CI_VIA_APP
+                targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_NO_PHOTO_ID
 
   PYI_ESCAPE:
     response:
@@ -412,7 +422,7 @@ states:
             targetState: FAILED
             checkMitigation:
               liveness-likeness:
-                targetState: MITIGATE_CI_VIA_PASSPORT
+                targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_PHOTO_ID
       fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_NEW_IDENTITY
 
@@ -447,7 +457,7 @@ states:
             targetState: FAILED
             checkMitigation:
               liveness-likeness:
-                targetState: MITIGATE_CI_VIA_APP
+                targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_NO_PHOTO_ID
       fraud-fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
@@ -500,7 +510,7 @@ states:
             targetState: FAILED
             checkMitigation:
               liveness-likeness:
-                targetState: MITIGATE_CI_VIA_APP
+                targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_NO_PHOTO_ID
       fraud-fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
@@ -733,7 +743,9 @@ states:
       pageId: passport-biometric-chip
     events:
       next:
-        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP
+        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+        journeyContextToUnset: internationalAddress
       abandon:
         targetState: MITIGATION_NEED_BIOMETRIC_PASSPORT
 
@@ -742,12 +754,14 @@ states:
       type: page
       pageId: need-biometric-passport
     events:
+      useApp:
+        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+        journeyContextToUnset: internationalAddress
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
-      useApp:
-        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP
 
-  MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP:
+  MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_NO_PHOTO_ID:
     response:
       type: process
       lambda: reset-identity
@@ -755,9 +769,20 @@ states:
         resetType: PENDING_DCMAW_ASYNC
     events:
       next:
-        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
-        journeyContextToUnset: internationalAddress
+        targetState: MITIGATE_CI_VIA_APP
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_PHOTO_ID:
+    response:
+      type: process
+      lambda: reset-identity
+      lambdaInput:
+        resetType: PENDING_DCMAW_ASYNC
+    events:
+      next:
+        targetState: MITIGATE_CI_VIA_PASSPORT
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -50,6 +50,9 @@ states:
                   f2f:
                     targetJourney: INELIGIBLE
                     targetState: INELIGIBLE
+              liveness-likeness:
+                targetJourney: FAILED
+                targetState: FAILED
         checkMitigation:
           enhanced-verification:
             targetState: MITIGATION_01_PYI_POST_OFFICE
@@ -57,17 +60,27 @@ states:
               f2f:
                 targetJourney: INELIGIBLE
                 targetState: INELIGIBLE
+          liveness-likeness:
+            targetJourney: FAILED
+            targetState: FAILED
 
   DCMAW_ASYNC_DL_AUTH_SOURCE_CHECK:
     events:
       next:
         targetState: STRATEGIC_APP_TRIAGE
         targetEntryEvent: dl-auth-source-check
+        checkMitigation:
+          liveness-likeness:
+            targetJourney: FAILED
+            targetState: FAILED
 
   DCMAW_ASYNC_COMPLETE:
     events:
       next:
         targetState: POST_APP_DOC_CHECK_INTERNATIONAL_SUCCESS_PAGE
+        checkMitigation:
+          liveness-likeness:
+            targetState: PROCESS_NEW_IDENTITY
 
   IDENTITY_DOCUMENT_START:
     events:
@@ -464,7 +477,7 @@ states:
             targetState: FAILED
             checkMitigation:
               liveness-likeness:
-                targetState: MITIGATE_CI_VIA_APP
+                targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_NO_PHOTO_ID
 
   CHECK_FRAUD_AFTER_DL:
     response:
@@ -704,7 +717,7 @@ states:
             targetState: FAILED
             checkMitigation:
               liveness-likeness:
-                targetState: MITIGATE_CI_VIA_PASSPORT
+                targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_PHOTO_ID
       fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_NEW_IDENTITY
 
@@ -739,7 +752,7 @@ states:
             targetState: FAILED
             checkMitigation:
               liveness-likeness:
-                targetState: MITIGATE_CI_VIA_APP
+                targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_NO_PHOTO_ID
       fraud-fail-with-no-ci-fatal:
         targetState: PROCESS_NEW_IDENTITY
 
@@ -793,7 +806,7 @@ states:
             targetState: FAILED
             checkMitigation:
               liveness-likeness:
-                targetState: MITIGATE_CI_VIA_APP
+                targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_NO_PHOTO_ID
       fraud-fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
@@ -860,7 +873,7 @@ states:
             targetState: FAILED
             checkMitigation:
               liveness-likeness:
-                targetState: MITIGATE_CI_VIA_APP
+                targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_NO_PHOTO_ID
       fraud-fail-with-no-ci-fatal:
         targetJourney: FAILED
         targetState: FAILED
@@ -1204,7 +1217,9 @@ states:
       pageId: passport-biometric-chip
     events:
       next:
-        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP
+        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+        journeyContextToUnset: internationalAddress
       abandon:
         targetState: MITIGATION_NEED_BIOMETRIC_PASSPORT
 
@@ -1214,11 +1229,13 @@ states:
       pageId: need-biometric-passport
     events:
       useApp:
-        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP
+        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+        journeyContextToUnset: internationalAddress
       returnToRp:
         targetState: PROCESS_INCOMPLETE_IDENTITY
 
-  MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP:
+  MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_NO_PHOTO_ID:
     response:
       type: process
       lambda: reset-identity
@@ -1226,9 +1243,20 @@ states:
         resetType: PENDING_DCMAW_ASYNC
     events:
       next:
-        targetState: MITIGATION_STRATEGIC_APP_TRIAGE
-        targetEntryEvent: appTriage
-        journeyContextToUnset: internationalAddress
+        targetState: MITIGATE_CI_VIA_APP
+      error:
+        targetJourney: TECHNICAL_ERROR
+        targetState: ERROR
+
+  MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_APP_PHOTO_ID:
+    response:
+      type: process
+      lambda: reset-identity
+      lambdaInput:
+        resetType: PENDING_DCMAW_ASYNC
+    events:
+      next:
+        targetState: MITIGATE_CI_VIA_PASSPORT
       error:
         targetJourney: TECHNICAL_ERROR
         targetState: ERROR

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/Events.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/journeys/Events.java
@@ -16,5 +16,7 @@ public class Events {
     public static final String ALTERNATE_DOC_INVALID_DL_EVENT = "alternate-doc-invalid-dl";
     public static final String ALTERNATE_DOC_INVALID_PASSPORT_EVENT =
             "alternate-doc-invalid-passport";
+    public static final String LIVENESS_LIKENESS = "liveness-likeness";
+
     public static final String FAIL_WITH_CI_EVENT = "fail-with-ci";
 }


### PR DESCRIPTION
Reverts govuk-one-login/ipv-core-back#4196

Reason why it failed in build on Friday is lack of permission to query dynamoDb SessionCrednetialsTable in CheckExistingIdentity lambda. As new mitigation journey need to fetch the previous VCs, this lambda now need permission to do it.