### PR TITLE
PYIC-9194: Bumping apacheHttpCore to 5.4.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ pact = "4.7.3"
 powertools = "2.10.0"
 
 [libraries]
-apacheHttpCore = "org.apache.httpcomponents.core5:httpcore5:5.4"
+apacheHttpCore = "org.apache.httpcomponents.core5:httpcore5:5.4.3"
 aspectj = "org.aspectj:aspectjrt:1.9.21.2"
 assertJ = "org.assertj:assertj-core:3.27.7"
 awsLambdaJavaCore = "com.amazonaws:aws-lambda-java-core:1.4.0"


### PR DESCRIPTION
## Proposed changes
### What changed

- Bumping apacheHttpCore to 5.4.3 fixes 2 alerts

### Why did it change

- Apache HttpComponents Core HTTP/1 header parsing can cause memory-exhaustion denial of service (org.apache.httpcomponents.core5:httpcore5)  
- Apache HttpComponents Core: HPackDecoder Unlimited Header List Size Before SETTINGS ACK (org.apache.httpcomponents.core5:httpcore5-h2)  

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9194](https://govukverify.atlassian.net/browse/PYIC-9194)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9194]: https://govukverify.atlassian.net/browse/PYIC-9194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ