### PR TITLE
PYIC-9068: Adjust behavior of back button on fraud mitigation drop off pages.

### DIFF
--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -881,7 +881,7 @@ Feature: P2 Fraud mitigation
       Then I get a 'need-smartphone-prove-identity-app' page response
 
       # User retried to mitigate via app
-      When I submit a 'useApp' event
+      When I submit a 'back' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
         | Context    | Value  |
         | smartphone | iphone |
@@ -945,7 +945,7 @@ Feature: P2 Fraud mitigation
       Then I get a 'app-passport-prove-identity' page response
 
       # User retried to mitigate via app
-      When I submit a 'useApp' event
+      When I submit a 'back' event
       Then I get a 'pyi-triage-mobile-download-app' page response and pageContext
         | Context    | Value  |
         | smartphone | iphone |

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -582,6 +582,8 @@ nestedJourneyStates:
         targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_RETRY
       returnToRp:
         exitEventToEmit: returnToRp
+      back:
+        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_RETRY
 
   MITIGATION_APP_PASSPORT_PROVE_IDENTITY:
     response:
@@ -592,6 +594,9 @@ nestedJourneyStates:
         targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_RETRY
       returnToRp:
         exitEventToEmit: returnToRp
+      back:
+        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_RETRY
+
 
   MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_RETRY:
     response:


### PR DESCRIPTION
## Proposed changes
### What changed

Added back event to below pages to navigate to reset identity lambda before app download pages:
- need-smartphone-prove-identity-app
- app-passport-prove-identity

### Why did it change

- App abandoned journeys navigates to those pages and giving user option to either try again or return to rp. If user click the back button, then is navigated to download page with completed spinner page from previous try.
To mitigate that and keep it consistent, back button will navigate to reset-identity lambda followed by call dcmaw async lambda and download page.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9068](https://govukverify.atlassian.net/browse/PYIC-9068)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9068]: https://govukverify.atlassian.net/browse/PYIC-9068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ