### PR TITLE
BAU: Increase journey restart timeout to allow for slower queue responses

### DIFF
--- a/api-tests/src/steps/ipv-steps.ts
+++ b/api-tests/src/steps/ipv-steps.ts
@@ -44,7 +44,7 @@ import {
   primeResponseForUser,
 } from "../clients/ais-management-api.js";
 
-const RETRY_DELAY_MILLIS = 2000;
+const RETRY_DELAY_MILLIS = 5000;
 const MAX_ATTEMPTS = 5;
 
 const addressCredential = "https://vocab.account.gov.uk/v1/address";


### PR DESCRIPTION


## Proposed changes
### What changed

Increased journey restart retry period

### Why did it change

Sometimes the queue is too slow and we restart the journey too many times

