### PR TITLE
PYIC-9068: Adjust Fraud mitigation journey according to new requirments.

### DIFF
--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -878,7 +878,7 @@ Feature: P2 Fraud mitigation
       And I poll for async DCMAW credential receipt
       Then the poll returns a '201'
       When I submit the returned journey event
-      Then I get a 'need-smartphone-prove-identity-app' page response
+      Then I get a 'app-passport-prove-identity' page response
 
       # User retried to mitigate via app
       When I submit a 'useApp' event
@@ -1011,20 +1011,35 @@ Feature: P2 Fraud mitigation
       Then I get a 'pyi-triage-select-smartphone' page response and pageContext
         | Context    | Value |
         | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'app-passport-prove-identity' page response
+      When I submit a 'back' event
+      Then I get an 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
+      When I submit a 'neither' event
+      Then I get a 'app-passport-prove-identity' page response
+      When I submit a 'useApp' event
+      Then I get an 'identify-device' page response
+      When I submit an 'appTriage' event
+      When I submit a 'computer-or-tablet' event
+      Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+        | Context    | Value |
+        | deviceType | dad   |
       When I submit an '<device>' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
         | Context    | Value    |
         | smartphone | <device> |
         | isAppOnly  | true     |
       When I submit an 'preferNoApp' event
-      Then I get a 'need-smartphone-prove-identity-app' page response
+      Then I get a 'app-passport-prove-identity' page response
       When I submit an 'useApp' event
       Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
         | Context    | Value    |
         | smartphone | <device> |
         | isAppOnly  | true     |
       When I submit an 'anotherWay' event
-      Then I get a 'need-smartphone-prove-identity-app' page response
+      Then I get a 'app-passport-prove-identity' page response
       When I submit an 'returnToRp' event
       Then I get an OAuth response
       When I use the OAuth response to get my identity

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -26,9 +26,9 @@ entryEvents:
       mamAndroid:
         targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
       dadIphone:
-        targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
+        targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
       dadAndroid:
-        targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
+        targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
     targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
     journeyContextToUnset: mamIphone,mamAndroid,dadIphone,dadAndroid
 
@@ -173,7 +173,7 @@ nestedJourneyStates:
         targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_EXIT_BUFFER
         checkMitigation:
           liveness-likeness:
-            targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
+            targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
         checkJourneyContext:
           internationalAddress:
             targetState: DESKTOP_IPHONE_DOWNLOAD_PAGE_NEED_APP
@@ -262,7 +262,7 @@ nestedJourneyStates:
         targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_EXIT_BUFFER
         checkMitigation:
           liveness-likeness:
-            targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
+            targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
         checkJourneyContext:
           internationalAddress:
             targetState: DESKTOP_ANDROID_DOWNLOAD_PAGE_NEED_APP
@@ -568,7 +568,7 @@ nestedJourneyStates:
         targetState: DAD_SELECT_SMARTPHONE_EXIT_BUFFER
         checkMitigation:
           liveness-likeness:
-            targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
+            targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
         checkJourneyContext:
           internationalAddress:
             targetState: DAD_SELECT_SMARTPHONE_NEED_APP
@@ -579,7 +579,8 @@ nestedJourneyStates:
       pageId: need-smartphone-prove-identity-app
     events:
       useApp:
-        targetState: MITIGATION_RESET_DCMAW_ASYNC_VC_BEFORE_RETRY
+        targetState: STRATEGIC_APP_IDENTIFY_DEVICE
+        targetEntryEvent: identify-device
       returnToRp:
         exitEventToEmit: returnToRp
 


### PR DESCRIPTION
## Proposed changes
### What changed

Drop off page from both MAM and DAD download page now redirect user to app-passport-prove-identity.
This is also true for abandoned journeys. User is also redirected to app-passport-prove-identity and have option to try again in both scenarios - DAD and MAM.

The app-passport-prove-identity page has removed back button which means user can go back only using radio option.

The need-passport-prove-identity-app is drop off page from device identification route and has back button included.


### Why did it change

To adjust behaviour to new UCD requiremtns.
We faced some inconvenient issues related to the back button. We shifted some pages to make sure back button is included where it should be and excluded where it shouldn't.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9068](https://govukverify.atlassian.net/browse/PYIC-9068)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9068]: https://govukverify.atlassian.net/browse/PYIC-9068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ