### PR TITLE
PYIC-9208: validate VTR claim during session initialisation

### DIFF
--- a/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
+++ b/lambdas/initialise-ipv-session/src/main/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandler.java
@@ -34,6 +34,7 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionsIpvJourneyStart;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
+import uk.gov.di.ipv.core.library.enums.Vot;
 import uk.gov.di.ipv.core.library.helpers.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.core.library.helpers.EmbeddedMetricHelper;
 import uk.gov.di.ipv.core.library.helpers.LogHelper;
@@ -148,6 +149,20 @@ public class InitialiseIpvSessionHandler
                 LOGGER.error(LogHelper.buildLogMessage(ErrorResponse.MISSING_VTR.getMessage()));
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         HttpStatusCode.BAD_REQUEST, ErrorResponse.MISSING_VTR);
+            }
+
+            if (!isListEmpty(vtr)) {
+                for (String vtrItem : vtr) {
+                    if (Vot.parse(vtrItem).isEmpty()) {
+                        LOGGER.error(
+                                LogHelper.buildLogMessage(
+                                        String.format(
+                                                "Invalid VTR value provided in authorize request: %s",
+                                                vtrItem)));
+                        return ApiGatewayResponseGenerator.proxyJsonResponse(
+                                HttpStatusCode.BAD_REQUEST, ErrorResponse.INVALID_VTR_CLAIM);
+                    }
+                }
             }
 
             String clientOAuthSessionId = SecureTokenHelper.getInstance().generate();

--- a/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
+++ b/lambdas/initialise-ipv-session/src/test/java/uk/gov/di/ipv/core/initialiseipvsession/InitialiseIpvSessionHandlerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
@@ -410,6 +411,35 @@ class InitialiseIpvSessionHandlerTest {
         assertEquals(HttpStatusCode.BAD_REQUEST, response.getStatusCode());
         assertEquals(ErrorResponse.MISSING_VTR.getCode(), responseBody.get("code"));
         assertEquals(ErrorResponse.MISSING_VTR.getMessage(), responseBody.get("message"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Cl.Cm.P2", "c1.cm.P2", "INVALID_VOT", "P99"})
+    void shouldReturn400IfInvalidVtrValueProvided(String invalidVtr)
+            throws JsonProcessingException,
+                    InvalidKeySpecException,
+                    NoSuchAlgorithmException,
+                    JOSEException,
+                    ParseException,
+                    JarValidationException {
+        // Arrange
+        var invalidVtrClaimsBuilder = getValidClaimsBuilder();
+        invalidVtrClaimsBuilder.claim(VTR, List.of(invalidVtr));
+        var invalidVtrSignedJwt = getSignedJWT(invalidVtrClaimsBuilder);
+        when(mockJarValidator.validateRequestJwt(any(), any()))
+                .thenReturn(invalidVtrSignedJwt.getJWTClaimsSet());
+
+        // Act
+        APIGatewayProxyResponseEvent response =
+                initialiseIpvSessionHandler.handleRequest(validEvent, mockContext);
+
+        // Assert
+        Map<String, Object> responseBody =
+                OBJECT_MAPPER.readValue(response.getBody(), new TypeReference<>() {});
+
+        assertEquals(HttpStatusCode.BAD_REQUEST, response.getStatusCode());
+        assertEquals(ErrorResponse.INVALID_VTR_CLAIM.getCode(), responseBody.get("code"));
+        assertEquals(ErrorResponse.INVALID_VTR_CLAIM.getMessage(), responseBody.get("message"));
     }
 
     @ParameterizedTest

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/Vot.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/enums/Vot.java
@@ -4,7 +4,9 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile;
 import uk.gov.di.ipv.core.library.helpers.CollectionHelper;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @ExcludeFromGeneratedCoverageReport
 public enum Vot {
@@ -12,6 +14,7 @@ public enum Vot {
     P1(List.of(Gpg45Profile.L1A)),
     P2(List.of(Gpg45Profile.M1A, Gpg45Profile.M1B, Gpg45Profile.M2B, Gpg45Profile.M1C)),
     P3(List.of(Gpg45Profile.H1A));
+
     public static final List<Vot> SUPPORTED_VOTS_BY_DESCENDING_STRENGTH =
             List.of(Vot.P3, Vot.P2, Vot.P1);
 
@@ -34,5 +37,14 @@ public enum Vot {
         return SUPPORTED_VOTS_BY_DESCENDING_STRENGTH.stream()
                 .filter(vot -> vot.getSupportedGpg45Profiles(false).contains(profile))
                 .collect(CollectionHelper.toSingleton());
+    }
+
+    public static Optional<Vot> parse(String value) {
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(values())
+                .filter(vot -> vot.name().equalsIgnoreCase(value.trim()))
+                .findFirst();
     }
 }

--- a/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/enums/VotTest.java
+++ b/libs/common-services/src/test/java/uk/gov/di/ipv/core/library/enums/VotTest.java
@@ -4,12 +4,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.L1A;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1A;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1B;
@@ -42,5 +45,35 @@ class VotTest {
 
         // Assert
         assertEquals("List size is not 1", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"P0", "P1", "P2", "P3", "p1", " p2 ", "P3 "})
+    void parseShouldReturnCorrectVotForValidStrings(String input) {
+        // Act
+        Optional<Vot> result = Vot.parse(input);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(input.trim().toUpperCase(), result.get().name());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invalid", "Cl.Cm.P2", "c1.cm.P2", "", "   "})
+    void parseShouldReturnEmptyForInvalidStrings(String input) {
+        // Act
+        Optional<Vot> result = Vot.parse(input);
+
+        // Assert
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void parseShouldReturnEmptyForNullInput() {
+        // Act
+        Optional<Vot> result = Vot.parse(null);
+
+        // Assert
+        assertTrue(result.isEmpty());
     }
 }


### PR DESCRIPTION


## Proposed changes
### What changed

- Add Vot.parse(String) helper to safely convert VTR strings into Vot enum values without throwing unhandled IllegalArgumentExceptions 
- Add input validation in InitialiseIpvSessionHandler to check incoming vtr claim values against supported Vots. Throw 400 if invalid

Before:
<img width="400" height="350" alt="Screenshot 2026-08-24 at 13 50 18" src="https://github.com/user-attachments/assets/4e060d4e-2906-428f-bd9e-4e5749cdd5a6" />

After:
<img width="400" height="350" alt="Screenshot 2026-08-24 at 13 48 58" src="https://github.com/user-attachments/assets/4500a6c5-1ee2-4101-b583-060de5ba049a" />

Before:
<img width="300" height="350" alt="Screenshot 2026-08-25 at 11 22 09" src="https://github.com/user-attachments/assets/08ec7f11-5515-40ed-a437-6d70b871c005" />

After:
<img width="500" height="250" alt="Screenshot 2026-08-25 at 11 18 32" src="https://github.com/user-attachments/assets/4d449c83-0595-48d0-88a2-c183b95ad345" />

### Why did it change

- Prevent downstream IllegalArgumentExceptions by validating the VTR claim in the authorize request during session initialisation.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9208](https://govukverify.atlassian.net/browse/PYIC-9208)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9208]: https://govukverify.atlassian.net/browse/PYIC-9208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ