### PR TITLE
PYIC-9068: Pin device identificaiton drop off page to correct page.

### DIFF
--- a/api-tests/features/fraud-mitigation/p2-mitigation.feature
+++ b/api-tests/features/fraud-mitigation/p2-mitigation.feature
@@ -1012,13 +1012,13 @@ Feature: P2 Fraud mitigation
         | Context    | Value |
         | deviceType | dad   |
       When I submit a 'neither' event
-      Then I get a 'app-passport-prove-identity' page response
+      Then I get a 'need-smartphone-prove-identity-app' page response
       When I submit a 'back' event
       Then I get an 'pyi-triage-select-smartphone' page response and pageContext
         | Context    | Value |
         | deviceType | dad   |
       When I submit a 'neither' event
-      Then I get a 'app-passport-prove-identity' page response
+      Then I get a 'need-smartphone-prove-identity-app' page response
       When I submit a 'useApp' event
       Then I get an 'identify-device' page response
       When I submit an 'appTriage' event

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/strategic-app-triage.yaml
@@ -568,7 +568,7 @@ nestedJourneyStates:
         targetState: DAD_SELECT_SMARTPHONE_EXIT_BUFFER
         checkMitigation:
           liveness-likeness:
-            targetState: MITIGATION_APP_PASSPORT_PROVE_IDENTITY
+            targetState: MITIGATION_NEED_SMARTPHONE_PROVE_IDENTITY_APP
         checkJourneyContext:
           internationalAddress:
             targetState: DAD_SELECT_SMARTPHONE_NEED_APP


### PR DESCRIPTION
## Proposed changes
### What changed

- Changed drop off page for device identification route during Fraud mitigation from  app-passport-prove-identity to need-smartphone-prove-identity-app
- Fixed API test

### Why did it change

Pinned to app-passport-prove-identity instead of need-smartphone-prove-identity-app

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9068](https://govukverify.atlassian.net/browse/PYIC-9068)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9068]: https://govukverify.atlassian.net/browse/PYIC-9068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ