### PR TITLE
Pyic 9212 auth check events

### DIFF
--- a/api-tests/data/audit-events/alternate-doc-app-mitigation-journey.json
+++ b/api-tests/data/audit-events/alternate-doc-app-mitigation-journey.json
@@ -1,0 +1,229 @@
+[
+  {
+    "event_name": "IPV_JOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "vtr": ["P2"]
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_SUBJOURNEY_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "journey_type": "NEW_P2_IDENTITY"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "cri": "dcmawAsync",
+      "type": "pending"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_APP_HANDOFF_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_ASYNC_CRI_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": null
+    },
+    "extensions": {
+      "iss": "https://dcmaw-async.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "checkDetails": [
+            {
+              "checkMethod": "vcrypt",
+              "identityCheckPolicy": "published"
+            },
+            {
+              "biometricVerificationProcessLevel": 3,
+              "checkMethod": "bvr"
+            }
+          ],
+          "strengthScore": 3,
+          "type": "IdentityCheck",
+          "validityScore": 2
+        }
+      ],
+      "successful": true,
+      "isUkIssued": true,
+      "age": "type[number]",
+      "credential_issuer_id": "dcmawAsync"
+    }
+  },
+  {
+    "event_name": "IPV_ASYNC_CRI_VC_CONSUMED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": null
+    },
+    "extensions": {
+      "iss": "https://dcmaw-async.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "checkDetails": [
+            {
+              "checkMethod": "vcrypt",
+              "identityCheckPolicy": "published"
+            },
+            {
+              "biometricVerificationProcessLevel": 3,
+              "checkMethod": "bvr"
+            }
+          ],
+          "strengthScore": 3,
+          "type": "IdentityCheck",
+          "validityScore": 2
+        }
+      ],
+      "successful": true,
+      "isUkIssued": true,
+      "age": "type[number]",
+      "credential_issuer_id": "dcmawAsync"
+    },
+    "restricted": {
+      "name": [
+        {
+          "nameParts": [
+            {
+              "type": "GivenName",
+              "value": "Kenneth"
+            },
+            {
+              "type": "FamilyName",
+              "value": "Decerqueira"
+            }
+          ]
+        }
+      ],
+      "docExpiryDate": "2026-09-25"
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_VC_RECEIVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "iss": "https://driving-licence-cri.stubs.account.gov.uk",
+      "evidence": [
+        {
+          "activityHistoryScore": 0,
+          "ci": ["NEEDS-ALTERNATE-DOC"],
+          "failedCheckDetails": [
+            {
+              "checkMethod": "data",
+              "identityCheckPolicy": "published"
+            }
+          ],
+          "strengthScore": 3,
+          "type": "IdentityCheck",
+          "validityScore": 0
+        }
+      ],
+      "successful": false,
+      "isUkIssued": true,
+      "age": "type[number]"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_CORE_CRI_RESOURCE_RETRIEVED",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "cri": "drivingLicence",
+      "type": "vc"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_MITIGATION_START",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "extensions": {
+      "mitigation_type": "invalid-dl"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  },
+  {
+    "event_name": "IPV_REDIRECT_TO_CRI",
+    "component_id": "https://identity.local.account.gov.uk",
+    "user": {
+      "user_id": "type[string]",
+      "session_id": "type[string]",
+      "govuk_signin_journey_id": "type[string]"
+    },
+    "restricted": {
+      "device_information": {}
+    }
+  }
+]

--- a/api-tests/data/audit-events/alternate-doc-app-mitigation-journey.json
+++ b/api-tests/data/audit-events/alternate-doc-app-mitigation-journey.json
@@ -70,8 +70,7 @@
         {
           "checkDetails": [
             {
-              "checkMethod": "vcrypt",
-              "identityCheckPolicy": "published"
+              "checkMethod": "vri"
             },
             {
               "biometricVerificationProcessLevel": 3,
@@ -102,8 +101,7 @@
         {
           "checkDetails": [
             {
-              "checkMethod": "vcrypt",
-              "identityCheckPolicy": "published"
+              "checkMethod": "vri"
             },
             {
               "biometricVerificationProcessLevel": 3,
@@ -126,16 +124,16 @@
           "nameParts": [
             {
               "type": "GivenName",
-              "value": "Kenneth"
+              "value": "KENNETH"
             },
             {
               "type": "FamilyName",
-              "value": "Decerqueira"
+              "value": "DECERQUEIRA"
             }
           ]
         }
       ],
-      "docExpiryDate": "2026-09-25"
+      "docExpiryDate": "2033-01-18"
     }
   },
   {

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -402,7 +402,7 @@ Feature: Audit Events
       | Context    | Value   |
       | smartphone | android |
       | isAppOnly  | false   |
-    When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
+    When the async DCMAW CRI produces a 'kenneth-driving-permit-valid' VC
     And I poll for async DCMAW credential receipt
     Then the poll returns a '201'
     When I submit the returned journey event

--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -384,6 +384,38 @@ Feature: Audit Events
     And audit events for 'alternate-doc-mitigation-journey' are recorded [local only]
 
   @QualityGateRegressionTest
+  Scenario: Alternate doc mitigation after app
+    Given I start a new 'medium-confidence' journey
+    Then I get a 'live-in-uk' page response
+    When I submit a 'uk' event
+    Then I get a 'page-ipv-identity-document-start' page response
+    When I submit an 'appTriage' event
+    Then I get an 'identify-device' page response
+    When I submit an 'appTriage' event
+    Then I get a 'pyi-triage-select-device' page response
+    When I submit a 'computer-or-tablet' event
+    Then I get a 'pyi-triage-select-smartphone' page response and pageContext
+      | Context    | Value |
+      | deviceType | dad   |
+    When I submit an 'android' event
+    Then I get a 'pyi-triage-desktop-download-app' page response and pageContext
+      | Context    | Value   |
+      | smartphone | android |
+      | isAppOnly  | false   |
+    When the async DCMAW CRI produces a 'kennethD' 'drivingPermit' 'success' VC
+    And I poll for async DCMAW credential receipt
+    Then the poll returns a '201'
+    When I submit the returned journey event
+    Then I get a 'drivingLicence' CRI response
+    When I submit 'kenneth-driving-permit-needs-alternate-doc' details with attributes to the CRI stub
+      | Attribute | Values          |
+      | context   | "check_details" |
+    Then I get a 'pyi-driving-licence-no-match-another-way' page response
+    When I submit a 'next' event
+    Then I get a 'ukPassport' CRI response
+    And audit events for 'alternate-doc-app-mitigation-journey' are recorded [local only]
+
+  @QualityGateRegressionTest
   Scenario: Reprove identity journey with AIS
     Given the subject already has the following credentials
       | CRI     | scenario                     |

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/StateMachine.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNullElse;
-import static uk.gov.di.ipv.core.library.collections.Merging.mergeLists;
-import static uk.gov.di.ipv.core.library.collections.Merging.mergeMaps;
 import static uk.gov.di.ipv.core.library.domain.JourneyState.JOURNEY_STATE_DELIMITER;
 
 public class StateMachine {
@@ -68,16 +66,9 @@ public class StateMachine {
                     result.state()
                             .transition(
                                     entryEvent, startState, eventResolveParameters, eventResolver);
-            // Add audit events and context from the outer event
-            return new TransitionResult(
-                    nestedResult.state(),
-                    mergeLists(result.auditEvents(), nestedResult.auditEvents()),
-                    mergeMaps(result.auditContext(), nestedResult.auditContext()),
-                    nestedResult.targetEntryEvent(),
-                    mergeLists(result.journeyContextsToSet(), nestedResult.journeyContextsToSet()),
-                    mergeLists(
-                            result.journeyContextsToUnset(),
-                            nestedResult.journeyContextsToUnset()));
+
+            // Merge in audit events and context from the outer event
+            return new TransitionResult(nestedResult, result);
         }
 
         return result;

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/TransitionResult.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/TransitionResult.java
@@ -7,6 +7,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static uk.gov.di.ipv.core.library.collections.Merging.mergeLists;
+import static uk.gov.di.ipv.core.library.collections.Merging.mergeMaps;
+
 public record TransitionResult(
         State state,
         List<AuditEventTypes> auditEvents,
@@ -16,5 +19,17 @@ public record TransitionResult(
         List<String> journeyContextsToUnset) {
     public TransitionResult(State state) {
         this(state, List.of(), Map.of(), null, Collections.emptyList(), Collections.emptyList());
+    }
+
+    // When entering a nested journey we need to keep any contexts or audit events from the outer
+    // transition response
+    public TransitionResult(TransitionResult result, TransitionResult outerResult) {
+        this(
+                result.state(),
+                mergeLists(outerResult.auditEvents(), result.auditEvents()),
+                mergeMaps(outerResult.auditContext(), result.auditContext()),
+                result.targetEntryEvent(),
+                mergeLists(outerResult.journeyContextsToSet(), result.journeyContextsToSet()),
+                mergeLists(outerResult.journeyContextsToUnset(), result.journeyContextsToUnset()));
     }
 }

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeState.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/states/NestedJourneyInvokeState.java
@@ -72,12 +72,16 @@ public class NestedJourneyInvokeState implements State {
 
         if (result.state() instanceof NestedJourneyInvokeState) {
             var entryEvent = requireNonNullElse(result.targetEntryEvent(), eventName);
-            return result.state()
-                    .transition(
-                            entryEvent,
-                            String.join(JOURNEY_STATE_DELIMITER, stateNameParts),
-                            eventResolveParameters,
-                            eventResolver);
+            var nestedResult =
+                    result.state()
+                            .transition(
+                                    entryEvent,
+                                    String.join(JOURNEY_STATE_DELIMITER, stateNameParts),
+                                    eventResolveParameters,
+                                    eventResolver);
+
+            // Merge in audit events and context from the outer event
+            return new TransitionResult(nestedResult, result);
         }
 
         return result;

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -177,6 +177,14 @@ states:
         targetState: PAGE_STATE
         auditEvents:
           - IPV_NO_PHOTO_ID_JOURNEY_START
+      exitEventTwo:
+        targetState: PAGE_STATE
+        checkIfDisabled:
+          openBanking:
+            targetState: STRATEGIC_APP_TRIAGE
+            targetEntryEvent: eventEight
+            auditEvents:
+              - IPV_NO_PHOTO_ID_JOURNEY_START
 
   STRATEGIC_APP_TRIAGE:
     nestedJourney: STRATEGIC_APP_TRIAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/initial-journey-selection.yaml
@@ -165,10 +165,18 @@ states:
     exitEvents:
       exitEventFromNestedStateOne:
         targetState: PAGE_STATE
+      exitEventFromNestedStateOneWithAuditLog:
+        targetState: PAGE_STATE
+        auditEvents:
+          - IPV_NO_PHOTO_ID_JOURNEY_START
       exitEventFromNestedStateTwo:
         targetState: ANOTHER_PAGE_STATE
       exitEventFromDoublyNestedInvokeState:
         targetState: ERROR_STATE
+      exitEventFromDoublyNestedInvokeStateWithAuditLog:
+        targetState: PAGE_STATE
+        auditEvents:
+          - IPV_NO_PHOTO_ID_JOURNEY_START
 
   STRATEGIC_APP_TRIAGE:
     nestedJourney: STRATEGIC_APP_TRIAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/doubly-nested-definition.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/doubly-nested-definition.yaml
@@ -19,3 +19,5 @@ nestedJourneyStates:
     events:
       eventOne:
         exitEventToEmit: exitEventFromDoublyNestedStateTwo
+      eventOneWithAuditLog:
+        exitEventToEmit: exitEventFromDoublyNestedStateTwoWithAuditLog

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/nested-journey-definition.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/nested-journey-definition.yaml
@@ -20,6 +20,8 @@ nestedJourneyStates:
             exitEventToEmit: exitEventFromNestedStateOne
       eventOneWithAuditLog:
         exitEventToEmit: exitEventFromNestedStateOneWithAuditLog
+      eventTwo:
+        exitEventToEmit: exitEventTwo
   NESTED_STATE_TWO:
     response:
       type: page

--- a/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/nested-journey-definition.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/test/nested-journeys/nested-journey-definition.yaml
@@ -18,6 +18,8 @@ nestedJourneyStates:
         checkMitigation:
           first-mitigation:
             exitEventToEmit: exitEventFromNestedStateOne
+      eventOneWithAuditLog:
+        exitEventToEmit: exitEventFromNestedStateOneWithAuditLog
   NESTED_STATE_TWO:
     response:
       type: page
@@ -33,3 +35,6 @@ nestedJourneyStates:
     exitEvents:
       exitEventFromDoublyNestedStateTwo:
         exitEventToEmit: exitEventFromDoublyNestedInvokeState
+      exitEventFromDoublyNestedStateTwoWithAuditLog:
+        exitEventToEmit: exitEventFromDoublyNestedInvokeStateWithAuditLog
+

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -1017,6 +1017,51 @@ class ProcessJourneyEventHandlerTest {
 
     @Test
     @Tag(SKIP_CHECK_AUDIT_EVENT_WAIT_TAG)
+    void shouldRecoredAuditEventWhenExitingAndEnteringNestedJourneys() throws Exception {
+        // Arrange
+        var inputToEnterNestedStates =
+                JourneyRequest.builder()
+                        .ipAddress(TEST_IP)
+                        .journey("eventTwo")
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .build();
+
+        mockIpvSessionItemAndTimeout("NESTED_JOURNEY_INVOKE_STATE/NESTED_STATE_ONE");
+        var ipvSession = mockIpvSessionService.getIpvSession("anyString");
+
+        ProcessJourneyEventHandler processJourneyEventHandler =
+                new ProcessJourneyEventHandler(
+                        mockAuditService,
+                        mockIpvSessionService,
+                        mockConfigService,
+                        mockClientOAuthSessionService,
+                        List.of(INITIAL_JOURNEY_SELECTION, TECHNICAL_ERROR),
+                        StateMachineInitializerMode.TEST,
+                        TEST_NESTED_JOURNEY_TYPES,
+                        mockCimitUtilityService,
+                        testPageContextValidator);
+
+        // Act
+        var nextResponse =
+                processJourneyEventHandler.handleRequest(inputToEnterNestedStates, mockContext);
+
+        // Assert
+        assertEquals("identify-device", nextResponse.get("page"));
+        assertEquals(
+                new JourneyState(INITIAL_JOURNEY_SELECTION, "STRATEGIC_APP_TRIAGE/IDENTIFY_DEVICE"),
+                ipvSession.getState());
+
+        InOrder auditInOrderOne = inOrder(mockAuditService);
+        auditInOrderOne.verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        auditInOrderOne.verify(mockAuditService).awaitAuditEvents();
+        auditInOrderOne.verifyNoMoreInteractions();
+
+        var auditEvent = auditEventCaptor.getValue();
+        assertEquals(IPV_NO_PHOTO_ID_JOURNEY_START, auditEvent.getEventName());
+    }
+
+    @Test
+    @Tag(SKIP_CHECK_AUDIT_EVENT_WAIT_TAG)
     void shouldUseBackEventDefinedOnStateIfExists() throws Exception {
         var inputToNextPageState =
                 JourneyRequest.builder()

--- a/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
+++ b/lambdas/process-journey-event/src/test/java/uk/gov/di/ipv/core/processjourneyevent/ProcessJourneyEventHandlerTest.java
@@ -379,9 +379,6 @@ class ProcessJourneyEventHandlerTest {
                         JOURNEY_EVENT_ONE_WITH_TEST_CURRENT_PAGE,
                         "/journey/cri/build-oauth-request/aCriId"),
                 Arguments.of(
-                        JOURNEY_EVENT_ONE_WITH_TEST_CURRENT_PAGE,
-                        "/journey/cri/build-oauth-request/aCriId"),
-                Arguments.of(
                         JOURNEY_TEST_WITH_CONTEXT_WITH_EMPTY_CURRENT_PAGE,
                         "/journey/cri/build-oauth-request/aCriId?context=test_context"));
     }
@@ -919,6 +916,95 @@ class ProcessJourneyEventHandlerTest {
                 new JourneyState(
                         INITIAL_JOURNEY_SELECTION, "NESTED_JOURNEY_INVOKE_STATE/NESTED_STATE_ONE"),
                 ipvSession.getState());
+
+        InOrder auditInOrderOne = inOrder(mockAuditService);
+        auditInOrderOne.verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        auditInOrderOne.verify(mockAuditService).awaitAuditEvents();
+        auditInOrderOne.verifyNoMoreInteractions();
+
+        var auditEvent = auditEventCaptor.getValue();
+        assertEquals(IPV_NO_PHOTO_ID_JOURNEY_START, auditEvent.getEventName());
+    }
+
+    @Test
+    @Tag(SKIP_CHECK_AUDIT_EVENT_WAIT_TAG)
+    void shouldRecoredAuditEventWhenExitingNestedJourney() throws Exception {
+        // Arrange
+        var inputToEnterNestedStates =
+                JourneyRequest.builder()
+                        .ipAddress(TEST_IP)
+                        .journey("eventOneWithAuditLog")
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .build();
+
+        mockIpvSessionItemAndTimeout("NESTED_JOURNEY_INVOKE_STATE/NESTED_STATE_ONE");
+        var ipvSession = mockIpvSessionService.getIpvSession("anyString");
+
+        ProcessJourneyEventHandler processJourneyEventHandler =
+                new ProcessJourneyEventHandler(
+                        mockAuditService,
+                        mockIpvSessionService,
+                        mockConfigService,
+                        mockClientOAuthSessionService,
+                        List.of(INITIAL_JOURNEY_SELECTION, TECHNICAL_ERROR),
+                        StateMachineInitializerMode.TEST,
+                        TEST_NESTED_JOURNEY_TYPES,
+                        mockCimitUtilityService,
+                        testPageContextValidator);
+
+        // Act
+        var nextResponse =
+                processJourneyEventHandler.handleRequest(inputToEnterNestedStates, mockContext);
+
+        // Assert
+        assertEquals("page-id-for-page-state", nextResponse.get("page"));
+        assertEquals(
+                new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), ipvSession.getState());
+
+        InOrder auditInOrderOne = inOrder(mockAuditService);
+        auditInOrderOne.verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());
+        auditInOrderOne.verify(mockAuditService).awaitAuditEvents();
+        auditInOrderOne.verifyNoMoreInteractions();
+
+        var auditEvent = auditEventCaptor.getValue();
+        assertEquals(IPV_NO_PHOTO_ID_JOURNEY_START, auditEvent.getEventName());
+    }
+
+    @Test
+    @Tag(SKIP_CHECK_AUDIT_EVENT_WAIT_TAG)
+    void shouldRecoredAuditEventWhenExitingDoublyNestedJourney() throws Exception {
+        // Arrange
+        var inputToEnterNestedStates =
+                JourneyRequest.builder()
+                        .ipAddress(TEST_IP)
+                        .journey("eventOneWithAuditLog")
+                        .ipvSessionId(TEST_SESSION_ID)
+                        .build();
+
+        mockIpvSessionItemAndTimeout(
+                "NESTED_JOURNEY_INVOKE_STATE/DOUBLY_NESTED_INVOKE_STATE/DOUBLY_NESTED_STATE_TWO");
+        var ipvSession = mockIpvSessionService.getIpvSession("anyString");
+
+        ProcessJourneyEventHandler processJourneyEventHandler =
+                new ProcessJourneyEventHandler(
+                        mockAuditService,
+                        mockIpvSessionService,
+                        mockConfigService,
+                        mockClientOAuthSessionService,
+                        List.of(INITIAL_JOURNEY_SELECTION, TECHNICAL_ERROR),
+                        StateMachineInitializerMode.TEST,
+                        TEST_NESTED_JOURNEY_TYPES,
+                        mockCimitUtilityService,
+                        testPageContextValidator);
+
+        // Act
+        var nextResponse =
+                processJourneyEventHandler.handleRequest(inputToEnterNestedStates, mockContext);
+
+        // Assert
+        assertEquals("page-id-for-page-state", nextResponse.get("page"));
+        assertEquals(
+                new JourneyState(INITIAL_JOURNEY_SELECTION, "PAGE_STATE"), ipvSession.getState());
 
         InOrder auditInOrderOne = inOrder(mockAuditService);
         auditInOrderOne.verify(mockAuditService).sendAuditEvent(auditEventCaptor.capture());


### PR DESCRIPTION
## Proposed changes
### What changed

Fix audit event generation when a journey transition goes from within a subjourney into a different subjourney

### Why did it change

Audit events weren't being raised when they should be

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9212](https://govukverify.atlassian.net/browse/PYIC-9212)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated

[PYIC-9212]: https://govukverify.atlassian.net/browse/PYIC-9212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ