### PR TITLE
BAU Clear CRI OAuth session to try and reduce duplicate CRI token requests

### DIFF
--- a/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
+++ b/lambdas/process-cri-callback/src/main/java/uk/gov/di/ipv/core/processcricallback/ProcessCriCallbackHandler.java
@@ -330,6 +330,10 @@ public class ProcessCriCallbackHandler
         }
         criCheckingService.validateCallbackRequest(callbackRequest, criOAuthSessionItem);
 
+        // Clear the CRI OAuth session so we don't process this callback again
+        ipvSessionItem.setCriOAuthSessionId(null);
+        ipvSessionService.updateIpvSession(ipvSessionItem);
+
         // Retrieve, store and check cri credentials
         var accessToken = criApiService.fetchAccessToken(callbackRequest, criOAuthSessionItem);
         var vcResponse =


### PR DESCRIPTION
## Proposed changes
### What changed

Clear criOAuthSessionId after callback validation and before token exchange, rather than waiting for the subsequent journey step. This shrinks the window in which a repeat CRI callback can pass OAuth state validation and trigger a second token request to the CRI. A second callback should now see the session is already cleared and will be routed to pyi-attempt-recovery where the user can get back on track.

### Why did it change

Trying this because we have seen a recent increase in repeat callbacks from CRIs, seemingly due to a possible iOS Safari bug causing duplicate requests. Note this is a best-effort mitigation - the clear is a non-atomic write and the session read is eventually consistent, so truly concurrent callbacks may still race.
