### PR TITLE
Setting Dynatrace to be disabled due to third party incident

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -144,7 +144,7 @@ Conditions:
   IsPerformanceSensitive: !Or
     - !Not [ !Condition IsDevelopment ]
     - !Condition IsDevPerf
-  UseDynatrace: false
+  UseDynatrace: false #also skipping canaries
 
 # The AWS Account Id is used in the following mapping section because we have
 # multiple developer environments and it is undesirable to have to keep this

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -144,7 +144,7 @@ Conditions:
   IsPerformanceSensitive: !Or
     - !Not [ !Condition IsDevelopment ]
     - !Condition IsDevPerf
-  UseDynatrace: !Condition IsPerformanceSensitive
+  UseDynatrace: false
 
 # The AWS Account Id is used in the following mapping section because we have
 # multiple developer environments and it is undesirable to have to keep this


### PR DESCRIPTION
## Proposed changes
### What changed

Temporarily disable dynatrace

-

### Why did it change

Issue with otel layer causing lambda timeouts during Dynatrace incident.


### Issue tracking


## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>
