### PR TITLE
INC0020182 Only use DT in dev-perf env for now

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -144,7 +144,7 @@ Conditions:
   IsPerformanceSensitive: !Or
     - !Not [ !Condition IsDevelopment ]
     - !Condition IsDevPerf
-  UseDynatrace: !Condition IsDevelopment #also skipping canaries
+  UseDynatrace: !Condition IsDevPerf # Not using DT in higher envs for now due to INC0020182
 
 # The AWS Account Id is used in the following mapping section because we have
 # multiple developer environments and it is undesirable to have to keep this


### PR DESCRIPTION
## Proposed changes
### What changed

- Only use DT in dev-perf env for now

### Why did it change

- During INC0020182 we stopped using the OTel layers in build-prod and instead pointed them at dev only. But we don't actually want to use them in dev other than the dev-perf env

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

INC0020182

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>
