### PR TITLE
PYIC-9011: Clean EVCS_API_UPDATES feature flag.

### DIFF
--- a/api-tests/README.md
+++ b/api-tests/README.md
@@ -61,6 +61,11 @@ To swap in a remote stub, update the relevant URLs, API keys, and signing/encryp
 - `CIMIT_INTERNAL_API_KEY` — Internal API key of the dev environment CIMIT stub
 - `MANAGEMENT_CIMIT_STUB_API_KEY` — External API key of the dev environment CIMIT stub
 
+If you want to run API tests against local running core-back instance, make sure it's connected to the same stub. You can adjust this settings in:
+
+- [core.local.params](../local-running/core.local.params.yaml)
+- [core.local.secrets](../local-running/core.local.secrets.yaml) (make sure you have copied and populated the template file)
+
 #### Finding Dev Environment API Keys in AWS
 
 1. Open the AWS Console and navigate to **API Gateway > API Keys**.

--- a/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
+++ b/lambdas/check-existing-identity/src/main/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandler.java
@@ -75,7 +75,6 @@ import java.util.Optional;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_NOT_FOUND;
 import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SIS_VERIFICATION;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
@@ -415,12 +414,7 @@ public class CheckExistingIdentityHandler
                                 .findFirst()
                                 .ifPresent(vcsForUpdate::add);
 
-                        if (configService.enabled(EVCS_API_UPDATES)) {
-                            evcsService.markHistoricInEvcsV2(
-                                    userId, govukSigninJourneyId, vcsForUpdate);
-                        } else {
-                            evcsService.markHistoricInEvcs(userId, vcsForUpdate);
-                        }
+                        evcsService.markHistoricInEvcs(userId, govukSigninJourneyId, vcsForUpdate);
 
                         vcsForUpdate.forEach(credentialBundle.credentials::remove);
 

--- a/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
+++ b/lambdas/check-existing-identity/src/test/java/uk/gov/di/ipv/core/checkexistingidentity/CheckExistingIdentityHandlerTest.java
@@ -108,7 +108,6 @@ import static uk.gov.di.ipv.core.library.ais.TestData.createNoInterventionAisSta
 import static uk.gov.di.ipv.core.library.ais.TestData.createReproveIdentityAisState;
 import static uk.gov.di.ipv.core.library.ais.TestData.createResetPasswordAisState;
 import static uk.gov.di.ipv.core.library.ais.TestData.createSuspendedIdentityAisState;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.SIS_VERIFICATION;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
@@ -1167,55 +1166,7 @@ class CheckExistingIdentityHandlerTest {
 
             assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM, journeyResponse);
             verify(mockEvcsService, times(1))
-                    .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
-
-            verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
-            var auditEvent = auditEventArgumentCaptor.getValue();
-            var extension = (AuditExtensionExpiredDcmawDlVcFound) auditEvent.getExtensions();
-            assertEquals(AuditEventTypes.IPV_EXPIRED_DCMAW_DL_VC_FOUND, auditEvent.getEventName());
-            assertEquals(
-                    1705986521000L, // 23/01/2024 timestamp in ms
-                    extension.vcIssueDate());
-            assertEquals(15552000000L, extension.vcExpiryPeriodMs()); // 180 days in ms
-        }
-
-        @Test
-        void shouldReturnNewIdentityResponseIfUserHasExpiredDcmawDrivingLicenceAndSendAuditEventV2()
-                throws Exception {
-
-            // Arrange
-            var testCredentialBundle =
-                    List.of(
-                            vcDcmawDrivingPermitDvaExpired(), // VC issue date is 23/01/2024
-                            vcWebDrivingPermitDvaExpired());
-            when(userIdentityService.areVcsCorrelated(any())).thenReturn(true);
-            when(mockEvcsService.fetchEvcsVerifiableCredentialsByState(
-                            TEST_USER_ID, EVCS_TEST_TOKEN, false, CURRENT, PENDING_RETURN))
-                    .thenReturn(Map.of(CURRENT, testCredentialBundle));
-            when(criResponseService.getAsyncResponseStatus(eq(TEST_USER_ID), any(), eq(false)))
-                    .thenReturn(emptyAsyncCriStatus);
-            when(mockVotMatcher.findStrongestMatches(List.of(P2), List.of(), List.of(), true))
-                    .thenReturn(
-                            new VotMatchingResult(
-                                    Optional.empty(),
-                                    Optional.empty(),
-                                    Gpg45Scores.builder().build()));
-            when(configService.getDcmawExpiredDlValidityPeriodDays()).thenReturn(180);
-            when(configService.enabled(EVCS_API_UPDATES)).thenReturn(true);
-
-            mockVcHelper
-                    .when(() -> VcHelper.isExpiredDrivingPermitVc(any(), eq(configService), any()))
-                    .thenReturn(true);
-
-            // Act
-            var result = checkExistingIdentityHandler.handleRequest(event, context);
-
-            // Assert
-            var journeyResponse = toResponseClass(result, JourneyResponse.class);
-
-            assertEquals(JOURNEY_REPROVE_IDENTITY_GPG45_MEDIUM, journeyResponse);
-            verify(mockEvcsService, times(1))
-                    .markHistoricInEvcsV2(TEST_USER_ID, TEST_JOURNEY_ID, testCredentialBundle);
+                    .markHistoricInEvcs(TEST_USER_ID, TEST_JOURNEY_ID, testCredentialBundle);
 
             verify(auditService, times(1)).sendAuditEvent(auditEventArgumentCaptor.capture());
             var auditEvent = auditEventArgumentCaptor.getValue();
@@ -1255,7 +1206,7 @@ class CheckExistingIdentityHandlerTest {
 
             assertEquals(JOURNEY_REUSE, journeyResponse);
             verify(mockEvcsService, times(0))
-                    .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
+                    .markHistoricInEvcs(TEST_USER_ID, TEST_JOURNEY_ID, testCredentialBundle);
         }
 
         @Test
@@ -1271,7 +1222,7 @@ class CheckExistingIdentityHandlerTest {
             checkExistingIdentityHandler.handleRequest(event, context);
 
             verify(mockEvcsService, times(0))
-                    .markHistoricInEvcs(TEST_USER_ID, testCredentialBundle);
+                    .markHistoricInEvcs(TEST_USER_ID, TEST_JOURNEY_ID, testCredentialBundle);
             verify(auditService, never())
                     .sendAuditEvent(
                             argThat(

--- a/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
+++ b/lambdas/process-async-cri-credential/src/main/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandler.java
@@ -47,7 +47,6 @@ import static software.amazon.awssdk.utils.CollectionUtils.isNullOrEmpty;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAudit;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getExtensionsForAuditWithCriId;
 import static uk.gov.di.ipv.core.library.auditing.helpers.AuditExtensionsHelper.getRestrictedAuditDataForAsync;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_CODE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_ERROR_DESCRIPTION;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_MESSAGE_DESCRIPTION;
@@ -229,11 +228,8 @@ public class ProcessAsyncCriCredentialHandler
 
             submitVcToCiStorage(vc, journeyId);
             postMitigatingVc(vc, journeyId);
-            if (configService.enabled(EVCS_API_UPDATES)) {
-                evcsService.storePendingVcV2(vc, journeyId);
-            } else {
-                evcsService.storePendingVc(vc);
-            }
+            evcsService.storePendingVc(vc, journeyId);
+
             sendIpvVcConsumedAuditEvent(auditEventUser, vc, cri, VcHelper.isSuccessfulVc(vc));
         }
     }

--- a/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
+++ b/lambdas/process-async-cri-credential/src/test/java/uk/gov/di/ipv/core/processasynccricredential/ProcessAsyncCriCredentialHandlerTest.java
@@ -55,7 +55,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.fixtures.TestFixtures.EC_PRIVATE_KEY_JWK;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcF2fPassportPhotoM1a;
@@ -134,35 +133,10 @@ class ProcessAsyncCriCredentialHandlerTest {
         verifyVerifiableCredentialJwtValidator();
         verifyCiStorageServicePutContraIndicators();
         verifyCiStorageServicePostMitigations();
-        verify(evcsService).storePendingVc(vcArgumentCaptor.capture());
+        verify(evcsService).storePendingVc(vcArgumentCaptor.capture(), eq(TEST_JOURNEY_ID));
         var storedVcs = vcArgumentCaptor.getAllValues();
         assertEquals(1, storedVcs.size());
-        assertEquals(F2F_VC, storedVcs.get(0));
-        verify(evcsService).storePendingVc(F2F_VC);
-        verifyAuditService();
-    }
-
-    @Test
-    void shouldProcessValidExpectedAsyncVerifiableCredentialSuccessfullyV2() throws Exception {
-        when(verifiableCredentialValidator.parseAndValidate(
-                        eq(TEST_USER_ID), eq(F2F), anyList(), any(), any()))
-                .thenReturn(List.of(F2F_VC));
-        when(criResponseService.getCriResponseItemWithState(TEST_USER_ID, TEST_OAUTH_STATE))
-                .thenReturn(Optional.of(TEST_CRI_RESPONSE_ITEM));
-        when(configService.enabled(EVCS_API_UPDATES)).thenReturn(true);
-        mockCredentialIssuerConfig();
-
-        var batchResponse = handler.handleRequest(createSuccessTestEvent(TEST_OAUTH_STATE), null);
-
-        assertEquals(0, batchResponse.getBatchItemFailures().size());
-
-        verifyVerifiableCredentialJwtValidator();
-        verifyCiStorageServicePutContraIndicators();
-        verifyCiStorageServicePostMitigations();
-        verify(evcsService).storePendingVcV2(vcArgumentCaptor.capture(), eq(TEST_JOURNEY_ID));
-        var storedVcs = vcArgumentCaptor.getAllValues();
-        assertEquals(1, storedVcs.size());
-        assertEquals(F2F_VC, storedVcs.get(0));
+        assertEquals(F2F_VC, storedVcs.getFirst());
         verifyAuditService();
     }
 
@@ -267,7 +241,7 @@ class ProcessAsyncCriCredentialHandlerTest {
         assertEquals(AuditEventTypes.IPV_F2F_CRI_VC_RECEIVED, auditEvents.get(0).getEventName());
         assertEquals(AuditEventTypes.IPV_ASYNC_CRI_VC_RECEIVED, auditEvents.get(1).getEventName());
 
-        verify(evcsService, never()).storePendingVc(any());
+        verify(evcsService, never()).storePendingVc(any(), any());
 
         verifyBatchResponseFailures(testEvent, batchResponse);
     }
@@ -294,7 +268,7 @@ class ProcessAsyncCriCredentialHandlerTest {
         verify(auditService, times(2))
                 .sendAuditEvent(ArgumentCaptor.forClass(AuditEvent.class).capture());
         verify(cimitService, times(1)).submitVC(any(), any(), any());
-        verify(evcsService, never()).storePendingVc(any());
+        verify(evcsService, never()).storePendingVc(any(), any());
 
         verifyBatchResponseFailures(testEvent, batchResponse);
     }
@@ -428,7 +402,7 @@ class ProcessAsyncCriCredentialHandlerTest {
     private void verifyVerifiableCredentialNotProcessedFurther() throws Exception {
         verify(auditService, never())
                 .sendAuditEvent(ArgumentCaptor.forClass(AuditEvent.class).capture());
-        verify(evcsService, never()).storePendingVc(any());
+        verify(evcsService, never()).storePendingVc(any(), any());
         verify(cimitService, never()).submitVC(any(), any(), any());
         verify(cimitService, never()).submitMitigatingVcList(any(), any(), any());
     }

--- a/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
+++ b/lambdas/process-candidate-identity/src/main/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityService.java
@@ -7,7 +7,6 @@ import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionCandidateIdentityType;
 import uk.gov.di.ipv.core.library.auditing.restricted.AuditRestrictedDeviceInformation;
-import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.CandidateIdentityType;
 import uk.gov.di.ipv.core.library.enums.Vot;
@@ -61,33 +60,22 @@ public class StoreIdentityService {
         var isPendingIdentity = identityType.equals(CandidateIdentityType.PENDING);
         var hasStoredSiObject = false;
 
-        if (configService.enabled(CoreFeatureFlag.EVCS_API_UPDATES)) {
-            hasStoredSiObject =
-                    storeIdentityUpdated(
-                            userId,
-                            govukSigninJourneyId,
-                            sessionCredentials,
-                            evcsVcs,
-                            achievedVot,
-                            strongestMatchedVot,
-                            isPendingIdentity);
-        } else {
-            hasStoredSiObject =
-                    storeIdentityLegacy(
-                            userId,
-                            sessionCredentials,
-                            evcsVcs,
-                            achievedVot,
-                            strongestMatchedVot,
-                            isPendingIdentity);
-        }
+        hasStoredSiObject =
+                storeIdentity(
+                        userId,
+                        govukSigninJourneyId,
+                        sessionCredentials,
+                        evcsVcs,
+                        achievedVot,
+                        strongestMatchedVot,
+                        isPendingIdentity);
 
         LOGGER.info(LogHelper.buildLogMessage("Identity successfully stored"));
         sendIdentityStoredEvent(
                 strongestMatchedVot, identityType, auditEventParameters, hasStoredSiObject);
     }
 
-    private boolean storeIdentityUpdated(
+    private boolean storeIdentity(
             String userId,
             String govukSigninJourneyId,
             List<VerifiableCredential> sessionCredentials,
@@ -99,7 +87,7 @@ public class StoreIdentityService {
 
         if (isPendingIdentity) {
             LOGGER.info(LogHelper.buildLogMessage("Storing user VCs with POST"));
-            evcsService.storePendingIdentityWithPostVcsV2(
+            evcsService.storePendingIdentityWithPostVcs(
                     userId, govukSigninJourneyId, sessionCredentials, evcsVcs);
             return false;
         }
@@ -117,41 +105,6 @@ public class StoreIdentityService {
                         achievedVot);
 
         return response.statusCode() == HttpStatusCode.ACCEPTED;
-    }
-
-    private boolean storeIdentityLegacy(
-            String userId,
-            List<VerifiableCredential> sessionCredentials,
-            List<EvcsGetUserVCDto> evcsVcs,
-            Vot achievedVot,
-            VotMatchingResult.VotAndProfile strongestMatchedVot,
-            boolean isPendingIdentity)
-            throws EvcsServiceException {
-
-        LOGGER.info(LogHelper.buildLogMessage("Storing user VCs with POST"));
-        evcsService.storeCompletedOrPendingIdentityWithPostVcs(
-                userId, sessionCredentials, evcsVcs, isPendingIdentity);
-
-        if (isPendingIdentity) {
-            return false;
-        }
-
-        try {
-            var response =
-                    evcsService.storeStoredIdentityRecord(
-                            userId, sessionCredentials, strongestMatchedVot, achievedVot);
-            return response.statusCode() == HttpStatusCode.ACCEPTED;
-        } catch (FailedToCreateStoredIdentityForEvcsException e) {
-            LOGGER.warn(
-                    LogHelper.buildLogMessage(
-                            "Failed to create stored identity record. Stored identity record was not saved to EVCS."));
-        } catch (EvcsServiceException e) {
-            LOGGER.warn(
-                    LogHelper.buildLogMessage(
-                            "Failed to store stored identity record to EVCS. Continuing user journey."));
-        }
-
-        return false;
     }
 
     private void sendIdentityStoredEvent(

--- a/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
+++ b/lambdas/process-candidate-identity/src/test/java/uk/gov/di/ipv/core/processcandidateidentity/service/StoreIdentityServiceTest.java
@@ -1,8 +1,6 @@
 package uk.gov.di.ipv.core.processcandidateidentity.service;
 
-import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,8 +16,6 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.core.library.auditing.AuditEvent;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.auditing.extension.AuditExtensionCandidateIdentityType;
-import uk.gov.di.ipv.core.library.config.CoreFeatureFlag;
-import uk.gov.di.ipv.core.library.domain.ErrorResponse;
 import uk.gov.di.ipv.core.library.domain.VerifiableCredential;
 import uk.gov.di.ipv.core.library.enums.CandidateIdentityType;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
@@ -32,27 +28,22 @@ import uk.gov.di.ipv.core.library.useridentity.service.VotMatchingResult;
 import uk.gov.di.ipv.core.processcandidateidentity.domain.SharedAuditEventParameters;
 
 import java.net.http.HttpResponse;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static com.nimbusds.oauth2.sdk.http.HTTPResponse.SC_SERVER_ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.auditing.AuditEventTypes.IPV_IDENTITY_STORED;
-import static uk.gov.di.ipv.core.library.domain.Cri.EXPERIAN_FRAUD;
-import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_AT_EVCS_HTTP_REQUEST_SEND;
 import static uk.gov.di.ipv.core.library.enums.Vot.P0;
 import static uk.gov.di.ipv.core.library.enums.Vot.P2;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcAddressM1a;
@@ -95,349 +86,128 @@ class StoreIdentityServiceTest {
                 new SharedAuditEventParameters(testAuditEventUser, DEVICE_INFORMATION);
     }
 
-    @Nested
-    class StoreIdentityServiceSuccessfulStoreTest {
-        @BeforeEach
-        void setUp() {
-            when(configService.getComponentId()).thenReturn("https://core-component.example");
-        }
-
-        @Test
-        void shouldSuccessfullyStoreIdentityWhenEvcsWriteEnabled() throws Exception {
-            // Arrange
-            when(evcsService.storeStoredIdentityRecord(any(), any(), any(), any()))
-                    .thenReturn(httpResponse);
-            when(httpResponse.statusCode()).thenReturn(HttpStatusCode.ACCEPTED);
-            VCS.forEach(
-                    credential -> {
-                        if (credential.getCri().equals(EXPERIAN_FRAUD)) {
-                            credential.setMigrated(null);
-                        } else {
-                            credential.setMigrated(Instant.now());
-                        }
-                    });
-
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P2,
-                    STRONGEST_MATCHED_VOT,
-                    CandidateIdentityType.NEW,
-                    sharedAuditEventParameters);
-
-            // Assert
-            verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
-        }
-
-        @Test
-        void shouldSendAuditEventWithVotExtensionWhenIdentityAchieved() throws Exception {
-            // Arrange
-            when(evcsService.storeStoredIdentityRecord(any(), any(), any(), any()))
-                    .thenReturn(httpResponse);
-            when(httpResponse.statusCode()).thenReturn(HttpStatusCode.ACCEPTED);
-            var testVcs =
-                    VCS.stream()
-                            .peek(
-                                    credential -> {
-                                        if (credential.getCri().equals(EXPERIAN_FRAUD)) {
-                                            credential.setMigrated(null);
-                                        } else {
-                                            credential.setMigrated(Instant.now());
-                                        }
-                                    })
-                            .toList();
-
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    testVcs,
-                    List.of(),
-                    P2,
-                    STRONGEST_MATCHED_VOT,
-                    CandidateIdentityType.NEW,
-                    sharedAuditEventParameters);
-
-            // Assert
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
-            var auditEvent = auditEventCaptor.getValue();
-
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertEquals(
-                    P2,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
-            assertEquals(
-                    CandidateIdentityType.NEW,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .identityType());
-            assertEquals(COMPONENT_ID, auditEvent.getComponentId());
-            assertEquals(testAuditEventUser, auditEvent.getUser());
-            verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPostVcs(any(), any(), any(), anyBoolean());
-        }
-
-        @Test
-        void shouldSendAuditEventWithVotAndIdentityTypeExtensionWhenIdentityUpdated()
-                throws Exception {
-            // Arrange
-            when(evcsService.storeStoredIdentityRecord(any(), any(), any(), any()))
-                    .thenReturn(httpResponse);
-            when(httpResponse.statusCode()).thenReturn(HttpStatusCode.ACCEPTED);
-
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P2,
-                    STRONGEST_MATCHED_VOT,
-                    CandidateIdentityType.UPDATE,
-                    sharedAuditEventParameters);
-
-            // Assert
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
-            var auditEvent = auditEventCaptor.getValue();
-
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertEquals(
-                    P2,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
-            assertEquals(
-                    CandidateIdentityType.UPDATE,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .identityType());
-            assertEquals(COMPONENT_ID, auditEvent.getComponentId());
-            assertEquals(testAuditEventUser, auditEvent.getUser());
-            verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPostVcs(any(), any(), any(), anyBoolean());
-        }
-
-        @Test
-        void shouldStoreIdentityInEvcsAndSendAuditEventForPendingVc() throws Exception {
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P0,
-                    null,
-                    CandidateIdentityType.PENDING,
-                    sharedAuditEventParameters);
-
-            // Assert
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
-            var auditEvent = auditEventCaptor.getValue();
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertNull(((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
-            assertEquals(
-                    CandidateIdentityType.PENDING,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .identityType());
-            assertEquals(COMPONENT_ID, auditEvent.getComponentId());
-            assertEquals(testAuditEventUser, auditEvent.getUser());
-
-            verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), true);
-        }
-
-        @Test
-        void
-                shouldSendAuditEventWithNullVotAndIdentityTypeExtensionWhenIdentityPendingWithFailedVot()
-                        throws Exception {
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P0,
-                    null,
-                    CandidateIdentityType.PENDING,
-                    sharedAuditEventParameters);
-
-            // Assert
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
-            var auditEvent = auditEventCaptor.getValue();
-
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertNull(((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
-            assertEquals(
-                    CandidateIdentityType.PENDING,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .identityType());
-            assertEquals(COMPONENT_ID, auditEvent.getComponentId());
-            assertEquals(testAuditEventUser, auditEvent.getUser());
-            verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPostVcs(any(), any(), any(), anyBoolean());
-        }
-    }
-
     @Test
-    void shouldThrowIfEvcsFailsToStorePendingIdentity() throws Exception {
+    void shouldSendAuditEventWithNullVotAndIdentityTypeExtensionWhenIdentityPendingWithFailedVot()
+            throws Exception {
         // Arrange
-        doThrow(
-                        new EvcsServiceException(
-                                HTTPResponse.SC_SERVER_ERROR, FAILED_AT_EVCS_HTTP_REQUEST_SEND))
-                .when(evcsService)
-                .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), true);
+        when(configService.getComponentId()).thenReturn("https://core-component.example");
+
+        // Act
+        storeIdentityService.storeIdentity(
+                USER_ID,
+                VCS,
+                List.of(),
+                P0,
+                null,
+                CandidateIdentityType.PENDING,
+                sharedAuditEventParameters);
 
         // Assert
-        assertThrows(
-                EvcsServiceException.class,
-                () ->
-                        storeIdentityService.storeIdentity(
-                                USER_ID,
-                                VCS,
-                                List.of(),
-                                P0,
-                                null,
-                                CandidateIdentityType.PENDING,
-                                sharedAuditEventParameters));
+        verify(auditService).sendAuditEvent(auditEventCaptor.capture());
+        var auditEvent = auditEventCaptor.getValue();
+
+        assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
+        assertNull(((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
+        assertEquals(
+                CandidateIdentityType.PENDING,
+                ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).identityType());
+        assertEquals(COMPONENT_ID, auditEvent.getComponentId());
+        assertEquals(testAuditEventUser, auditEvent.getUser());
+        verify(evcsService, times(1)).storePendingIdentityWithPostVcs(any(), any(), any(), any());
     }
 
-    @Nested
-    class PostIdentityEndpoint {
-        @Test
-        void shouldStoreStoredIdentityRecordForCompletedIdentity() throws Exception {
-            // Arrange
-            when(configService.getComponentId()).thenReturn("https://core-component.example");
-            when(evcsService.storeStoredIdentityRecord(any(), any(), any(), any()))
-                    .thenReturn(httpResponse);
-            when(httpResponse.statusCode()).thenReturn(HttpStatusCode.ACCEPTED);
+    private static Stream<Arguments> identityTypes() {
+        return Stream.of(
+                Arguments.of(CandidateIdentityType.NEW),
+                Arguments.of(CandidateIdentityType.UPDATE),
+                Arguments.of(CandidateIdentityType.EXISTING));
+    }
 
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P2,
-                    STRONGEST_MATCHED_VOT,
-                    CandidateIdentityType.NEW,
-                    sharedAuditEventParameters);
+    @ParameterizedTest
+    @MethodSource("identityTypes")
+    void shouldSuccessfullyStoreNewIdentityAndSiAndSendAuditEvent(
+            CandidateIdentityType candidateIdentityType) throws Exception {
+        // Arrange
+        when(evcsService.storeStoredIdentityRecordAndVcs(any(), any(), any(), any(), any(), any()))
+                .thenReturn(httpResponse);
+        when(httpResponse.statusCode()).thenReturn(HttpStatusCode.ACCEPTED);
+        when(configService.getComponentId()).thenReturn("https://core-component.example");
 
-            // Assert
-            verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
-            verify(evcsService, times(1))
-                    .storeStoredIdentityRecord(USER_ID, VCS, STRONGEST_MATCHED_VOT, P2);
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
+        // Act
+        storeIdentityService.storeIdentity(
+                USER_ID,
+                VCS,
+                List.of(),
+                P2,
+                STRONGEST_MATCHED_VOT,
+                candidateIdentityType,
+                sharedAuditEventParameters);
 
-            var auditEvent = auditEventCaptor.getValue();
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertTrue(
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .sisRecordCreated());
-        }
+        // Assert
+        verify(evcsService, times(1))
+                .storeStoredIdentityRecordAndVcs(
+                        USER_ID, GOVUK_JOURNEY_ID, VCS, List.of(), STRONGEST_MATCHED_VOT, P2);
 
-        @Test
-        void shouldNotStoreStoredIdentityRecordForPendingIdentity() throws Exception {
-            // Act
-            when(configService.getComponentId()).thenReturn("https://core-component.example");
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P2,
-                    STRONGEST_MATCHED_VOT,
-                    CandidateIdentityType.PENDING,
-                    sharedAuditEventParameters);
+        verify(auditService).sendAuditEvent(auditEventCaptor.capture());
+        var auditEvent = auditEventCaptor.getValue();
 
-            // Assert
-            verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), true);
-            verify(evcsService, times(0)).storeStoredIdentityRecord(any(), any(), any(), any());
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
-
-            var auditEvent = auditEventCaptor.getValue();
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertFalse(
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .sisRecordCreated());
-        }
-
-        private static Stream<Arguments> provideStoreStoredIdentityRecordExceptions() {
-            return Stream.of(
-                    Arguments.of(
-                            new FailedToCreateStoredIdentityForEvcsException(
-                                    "could not create si record")),
-                    Arguments.of(
-                            new EvcsServiceException(
-                                    SC_SERVER_ERROR,
-                                    ErrorResponse.FAILED_TO_PARSE_EVCS_REQUEST_BODY)));
-        }
-
-        @ParameterizedTest
-        @MethodSource("provideStoreStoredIdentityRecordExceptions")
-        void shouldContinueIfStoreStoredIdentityRecordFails(Throwable exception) throws Exception {
-            // Arrange
-            when(configService.getComponentId()).thenReturn("https://core-component.example");
-            when(evcsService.storeStoredIdentityRecord(any(), any(), any(), any()))
-                    .thenThrow(exception);
-
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P2,
-                    STRONGEST_MATCHED_VOT,
-                    CandidateIdentityType.NEW,
-                    sharedAuditEventParameters);
-
-            // Assert
-            verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
-
-            var auditEvent = auditEventCaptor.getValue();
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertFalse(
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .sisRecordCreated());
-        }
-
-        @Test
-        void
-                shouldSetSisRecordCreatedToFalseIfNonHttpResponseReturnedFromStoreStoredIdentityRecord()
-                        throws Exception {
-            // Arrange
-            when(configService.getComponentId()).thenReturn("https://core-component.example");
-            when(evcsService.storeStoredIdentityRecord(any(), any(), any(), any()))
-                    .thenReturn(httpResponse);
-            when(httpResponse.statusCode()).thenReturn(HttpStatusCode.FORBIDDEN);
-
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P2,
-                    STRONGEST_MATCHED_VOT,
-                    CandidateIdentityType.NEW,
-                    sharedAuditEventParameters);
-
-            // Assert
-            verify(evcsService, times(1))
-                    .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
-            verify(evcsService, times(1))
-                    .storeStoredIdentityRecord(USER_ID, VCS, STRONGEST_MATCHED_VOT, P2);
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
-
-            var auditEvent = auditEventCaptor.getValue();
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertFalse(
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .sisRecordCreated());
-        }
+        assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
+        assertEquals(
+                P2, ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
+        assertEquals(
+                candidateIdentityType,
+                ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).identityType());
+        assertTrue(
+                ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
+                        .sisRecordCreated());
+        assertEquals(COMPONENT_ID, auditEvent.getComponentId());
+        assertEquals(testAuditEventUser, auditEvent.getUser());
     }
 
     @Test
-    void shouldThrowIfStoreCompletedOrPendingIdentityWithPostMethodFails() throws Exception {
+    void shouldSuccessfullyStorePendingIdentityWithPostPatchEndpointAndNotStoreSiAndSendAuditEvent()
+            throws Exception {
+        // Arrange
+        when(configService.getComponentId()).thenReturn("https://core-component.example");
+
+        // Act
+        storeIdentityService.storeIdentity(
+                USER_ID,
+                VCS,
+                List.of(),
+                P2,
+                STRONGEST_MATCHED_VOT,
+                CandidateIdentityType.PENDING,
+                sharedAuditEventParameters);
+
+        // Assert
+        verify(evcsService, times(1))
+                .storePendingIdentityWithPostVcs(USER_ID, GOVUK_JOURNEY_ID, VCS, List.of());
+        verify(evcsService, never())
+                .storeStoredIdentityRecordAndVcs(any(), any(), any(), any(), any(), any());
+
+        verify(auditService).sendAuditEvent(auditEventCaptor.capture());
+        var auditEvent = auditEventCaptor.getValue();
+
+        assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
+        assertEquals(
+                P2, ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
+        assertEquals(
+                CandidateIdentityType.PENDING,
+                ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).identityType());
+        assertFalse(
+                ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
+                        .sisRecordCreated());
+        assertEquals(COMPONENT_ID, auditEvent.getComponentId());
+        assertEquals(testAuditEventUser, auditEvent.getUser());
+    }
+
+    @Test
+    void shouldThrowIfFailedToStoreVcsForPendingIdentity() throws Exception {
         // Arrange
         doThrow(EvcsServiceException.class)
                 .when(evcsService)
-                .storeCompletedOrPendingIdentityWithPostVcs(USER_ID, VCS, List.of(), false);
+                .storePendingIdentityWithPostVcs(USER_ID, GOVUK_JOURNEY_ID, VCS, List.of());
 
         // Act/Assert
         assertThrows(
@@ -449,153 +219,29 @@ class StoreIdentityServiceTest {
                                 List.of(),
                                 P2,
                                 STRONGEST_MATCHED_VOT,
-                                CandidateIdentityType.NEW,
+                                CandidateIdentityType.PENDING,
                                 sharedAuditEventParameters));
     }
 
-    @Nested
-    class StoreIdentityWithEvcsApiUpdates {
+    @Test
+    void shouldThrowIfFailedToStoreVcsAndSiObjectInOneTransaction() throws Exception {
+        // Arrange
+        doThrow(FailedToCreateStoredIdentityForEvcsException.class)
+                .when(evcsService)
+                .storeStoredIdentityRecordAndVcs(
+                        USER_ID, GOVUK_JOURNEY_ID, VCS, List.of(), STRONGEST_MATCHED_VOT, P2);
 
-        @BeforeEach
-        void setup() {
-            when(configService.enabled(CoreFeatureFlag.EVCS_API_UPDATES)).thenReturn(true);
-        }
-
-        private static Stream<Arguments> identityTypes() {
-            return Stream.of(
-                    Arguments.of(CandidateIdentityType.NEW),
-                    Arguments.of(CandidateIdentityType.UPDATE),
-                    Arguments.of(CandidateIdentityType.EXISTING));
-        }
-
-        @ParameterizedTest
-        @MethodSource("identityTypes")
-        void shouldSuccessfullyStoreNewIdentityAndSiAndSendAuditEvent(
-                CandidateIdentityType candidateIdentityType) throws Exception {
-            // Arrange
-            when(evcsService.storeStoredIdentityRecordAndVcs(
-                            any(), any(), any(), any(), any(), any()))
-                    .thenReturn(httpResponse);
-            when(httpResponse.statusCode()).thenReturn(HttpStatusCode.ACCEPTED);
-            when(configService.getComponentId()).thenReturn("https://core-component.example");
-
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P2,
-                    STRONGEST_MATCHED_VOT,
-                    candidateIdentityType,
-                    sharedAuditEventParameters);
-
-            // Assert
-            verify(evcsService, never())
-                    .storeCompletedOrPendingIdentityWithPostVcs(any(), any(), any(), anyBoolean());
-            verify(evcsService, times(1))
-                    .storeStoredIdentityRecordAndVcs(
-                            USER_ID, GOVUK_JOURNEY_ID, VCS, List.of(), STRONGEST_MATCHED_VOT, P2);
-
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
-            var auditEvent = auditEventCaptor.getValue();
-
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertEquals(
-                    P2,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
-            assertEquals(
-                    candidateIdentityType,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .identityType());
-            assertTrue(
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .sisRecordCreated());
-            assertEquals(COMPONENT_ID, auditEvent.getComponentId());
-            assertEquals(testAuditEventUser, auditEvent.getUser());
-        }
-
-        @Test
-        void
-                shouldSuccessfullyStorePendingIdentityWithPostPatchEndpointAndNotStoreSiAndSendAuditEvent()
-                        throws Exception {
-            // Arrange
-            when(configService.getComponentId()).thenReturn("https://core-component.example");
-
-            // Act
-            storeIdentityService.storeIdentity(
-                    USER_ID,
-                    VCS,
-                    List.of(),
-                    P2,
-                    STRONGEST_MATCHED_VOT,
-                    CandidateIdentityType.PENDING,
-                    sharedAuditEventParameters);
-
-            // Assert
-            verify(evcsService, times(1))
-                    .storePendingIdentityWithPostVcsV2(USER_ID, GOVUK_JOURNEY_ID, VCS, List.of());
-            verify(evcsService, never())
-                    .storeStoredIdentityRecordAndVcs(any(), any(), any(), any(), any(), any());
-
-            verify(auditService).sendAuditEvent(auditEventCaptor.capture());
-            var auditEvent = auditEventCaptor.getValue();
-
-            assertEquals(IPV_IDENTITY_STORED, auditEvent.getEventName());
-            assertEquals(
-                    P2,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions()).maxVot());
-            assertEquals(
-                    CandidateIdentityType.PENDING,
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .identityType());
-            assertFalse(
-                    ((AuditExtensionCandidateIdentityType) auditEvent.getExtensions())
-                            .sisRecordCreated());
-            assertEquals(COMPONENT_ID, auditEvent.getComponentId());
-            assertEquals(testAuditEventUser, auditEvent.getUser());
-        }
-
-        @Test
-        void shouldThrowIfFailedToStoreVcsForPendingIdentity() throws Exception {
-            // Arrange
-            doThrow(EvcsServiceException.class)
-                    .when(evcsService)
-                    .storePendingIdentityWithPostVcsV2(USER_ID, GOVUK_JOURNEY_ID, VCS, List.of());
-
-            // Act/Assert
-            assertThrows(
-                    EvcsServiceException.class,
-                    () ->
-                            storeIdentityService.storeIdentity(
-                                    USER_ID,
-                                    VCS,
-                                    List.of(),
-                                    P2,
-                                    STRONGEST_MATCHED_VOT,
-                                    CandidateIdentityType.PENDING,
-                                    sharedAuditEventParameters));
-        }
-
-        @Test
-        void shouldThrowIfFailedToStoreVcsAndSiObjectInOneTransaction() throws Exception {
-            // Arrange
-            doThrow(FailedToCreateStoredIdentityForEvcsException.class)
-                    .when(evcsService)
-                    .storeStoredIdentityRecordAndVcs(
-                            USER_ID, GOVUK_JOURNEY_ID, VCS, List.of(), STRONGEST_MATCHED_VOT, P2);
-
-            // Act/Assert
-            assertThrows(
-                    FailedToCreateStoredIdentityForEvcsException.class,
-                    () ->
-                            storeIdentityService.storeIdentity(
-                                    USER_ID,
-                                    VCS,
-                                    List.of(),
-                                    P2,
-                                    STRONGEST_MATCHED_VOT,
-                                    CandidateIdentityType.NEW,
-                                    sharedAuditEventParameters));
-        }
+        // Act/Assert
+        assertThrows(
+                FailedToCreateStoredIdentityForEvcsException.class,
+                () ->
+                        storeIdentityService.storeIdentity(
+                                USER_ID,
+                                VCS,
+                                List.of(),
+                                P2,
+                                STRONGEST_MATCHED_VOT,
+                                CandidateIdentityType.NEW,
+                                sharedAuditEventParameters));
     }
 }

--- a/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
+++ b/lambdas/reset-identity/src/main/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandler.java
@@ -35,7 +35,6 @@ import uk.gov.di.ipv.core.library.verifiablecredential.service.SessionCredential
 
 import java.util.Map;
 
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_TO_PARSE_ISSUED_CREDENTIALS;
@@ -206,14 +205,11 @@ public class ResetIdentityHandler implements RequestHandler<ProcessRequest, Map<
             throws EvcsServiceException {
         var userId = clientOAuthSessionItem.getUserId();
         criResponseService.deleteCriResponseItem(userId, asyncCri);
-        if (configService.enabled(EVCS_API_UPDATES)) {
-            evcsService.abandonPendingIdentityV2(
-                    userId,
-                    clientOAuthSessionItem.getEvcsAccessToken(),
-                    clientOAuthSessionItem.getGovukSigninJourneyId());
-        } else {
-            evcsService.abandonPendingIdentity(userId, clientOAuthSessionItem.getEvcsAccessToken());
-        }
+        evcsService.abandonPendingIdentity(
+                userId,
+                clientOAuthSessionItem.getEvcsAccessToken(),
+                clientOAuthSessionItem.getGovukSigninJourneyId());
+
         LOGGER.info(
                 LogHelper.buildLogMessage(
                         String.format("Reset done for %s pending identity.", asyncCri.getId())));

--- a/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
+++ b/lambdas/reset-identity/src/test/java/uk/gov/di/ipv/core/resetidentity/ResetIdentityHandlerTest.java
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.domain.Cri.DCMAW_ASYNC;
 import static uk.gov.di.ipv.core.library.domain.Cri.F2F;
 import static uk.gov.di.ipv.core.library.domain.ErrorResponse.FAILED_AT_EVCS_HTTP_REQUEST_SEND;
@@ -192,41 +191,8 @@ class ResetIdentityHandlerTest {
                 .deleteSessionCredentialsForResetType(
                         ipvSessionItem.getIpvSessionId(), PENDING_F2F_ALL);
         verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, F2F);
-        verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
-        verify(mockEvcsService).invalidateStoredIdentityRecord(TEST_USER_ID);
-
-        assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
-    }
-
-    @Test
-    void handleRequestShouldCleanupVcsAndReturnNext_forPendingF2fV2() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
-        var event =
-                ProcessRequest.processRequestBuilder()
-                        .ipvSessionId(TEST_SESSION_ID)
-                        .featureSet(TEST_FEATURE_SET)
-                        .lambdaInput(Map.of("resetType", PENDING_F2F_ALL.name()))
-                        .build();
-
-        // Act
-        var journeyResponse =
-                OBJECT_MAPPER.convertValue(
-                        resetIdentityHandler.handleRequest(event, mockContext),
-                        JourneyResponse.class);
-
-        // Assert
-        verifyVotSetToP0();
-
-        verify(mockSessionCredentialsService)
-                .deleteSessionCredentialsForResetType(
-                        ipvSessionItem.getIpvSessionId(), PENDING_F2F_ALL);
-        verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, F2F);
         verify(mockEvcsService)
-                .abandonPendingIdentityV2(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
+                .abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
         verify(mockEvcsService).invalidateStoredIdentityRecord(TEST_USER_ID);
 
         assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
@@ -242,7 +208,7 @@ class ResetIdentityHandlerTest {
                         new EvcsServiceException(
                                 HTTPResponse.SC_SERVER_ERROR, FAILED_AT_EVCS_HTTP_REQUEST_SEND))
                 .when(mockEvcsService)
-                .abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+                .abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
 
         var event =
                 ProcessRequest.processRequestBuilder()
@@ -261,7 +227,8 @@ class ResetIdentityHandlerTest {
                 .deleteSessionCredentialsForResetType(
                         ipvSessionItem.getIpvSessionId(), PENDING_F2F_ALL);
         verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, F2F);
-        verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
+        verify(mockEvcsService)
+                .abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
 
         assertEquals(JOURNEY_ERROR_PATH, journeyResponse.get("journey"));
         assertEquals(500, journeyResponse.get(STATUS_CODE));
@@ -295,45 +262,12 @@ class ResetIdentityHandlerTest {
                 .deleteSessionCredentialsForResetType(
                         ipvSessionItem.getIpvSessionId(), PENDING_DCMAW_ASYNC_ALL);
         verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, DCMAW_ASYNC);
-        verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
-
-        assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
-    }
-
-    @Test
-    void handleRequestShouldCleanupVcsAndReturnNextForPendingDcmawAsyncAllV2() throws Exception {
-        // Arrange
-        when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
-        var event =
-                ProcessRequest.processRequestBuilder()
-                        .ipvSessionId(TEST_SESSION_ID)
-                        .featureSet(TEST_FEATURE_SET)
-                        .lambdaInput(Map.of("resetType", PENDING_DCMAW_ASYNC_ALL.name()))
-                        .build();
-
-        // Act
-        var journeyResponse =
-                OBJECT_MAPPER.convertValue(
-                        resetIdentityHandler.handleRequest(event, mockContext),
-                        JourneyResponse.class);
-
-        // Assert
-        verifyVotSetToP0();
-
-        verify(mockSessionCredentialsService)
-                .deleteSessionCredentialsForResetType(
-                        ipvSessionItem.getIpvSessionId(), PENDING_DCMAW_ASYNC_ALL);
-        verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, DCMAW_ASYNC);
         verify(mockEvcsService)
-                .abandonPendingIdentityV2(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
+                .abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
 
         assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
     }
 
-    // Can be removed with EVCS_API_UPDATES feature flag removal ticket
     @Test
     void handleRequestShouldCleanupAsyncDcmawVcAndPendingRecordAndReturnNextForPendingDcmawAsync()
             throws Exception {
@@ -360,39 +294,8 @@ class ResetIdentityHandlerTest {
                 .deleteSessionCredentialsForResetType(
                         ipvSessionItem.getIpvSessionId(), PENDING_DCMAW_ASYNC);
         verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, DCMAW_ASYNC);
-        verify(mockEvcsService).abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN);
-        assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
-    }
-
-    @Test
-    void handleRequestShouldCleanupAsyncDcmawVcAndPendingRecordAndReturnNextForPendingDcmawAsyncV2()
-            throws Exception {
-        // Arrange
-        when(mockIpvSessionService.getIpvSession(TEST_SESSION_ID)).thenReturn(ipvSessionItem);
-        when(mockClientOAuthSessionDetailsService.getClientOAuthSession(any()))
-                .thenReturn(clientOAuthSessionItem);
-        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
-        var event =
-                ProcessRequest.processRequestBuilder()
-                        .ipvSessionId(TEST_SESSION_ID)
-                        .featureSet(TEST_FEATURE_SET)
-                        .lambdaInput(Map.of("resetType", PENDING_DCMAW_ASYNC.name()))
-                        .build();
-
-        // Act
-        var journeyResponse =
-                OBJECT_MAPPER.convertValue(
-                        resetIdentityHandler.handleRequest(event, mockContext),
-                        JourneyResponse.class);
-
-        // Assert
-        verifyVotSetToP0();
-        verify(mockSessionCredentialsService)
-                .deleteSessionCredentialsForResetType(
-                        ipvSessionItem.getIpvSessionId(), PENDING_DCMAW_ASYNC);
-        verify(mockCriResponseService).deleteCriResponseItem(TEST_USER_ID, DCMAW_ASYNC);
         verify(mockEvcsService)
-                .abandonPendingIdentityV2(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
+                .abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_TOKEN, TEST_JOURNEY_ID);
         assertEquals(JOURNEY_NEXT.getJourney(), journeyResponse.getJourney());
     }
 

--- a/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
+++ b/libs/common-services/src/main/java/uk/gov/di/ipv/core/library/config/CoreFeatureFlag.java
@@ -4,7 +4,6 @@ public enum CoreFeatureFlag implements FeatureFlag {
     UNUSED_PLACEHOLDER("unusedPlaceHolder"),
     DL_AUTH_SOURCE_CHECK("drivingLicenceAuthCheck"),
     SIS_VERIFICATION("sisVerificationEnabled"),
-    EVCS_API_UPDATES("evcsApiUpdatesEnabled"),
     MITIGATIONS_9020("mitigations9020Enabled");
 
     private final String name;

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClient.java
@@ -14,12 +14,10 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.core.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.core.library.config.ConfigurationVariable;
 import uk.gov.di.ipv.core.library.domain.ErrorResponse;
-import uk.gov.di.ipv.core.library.evcs.dto.EvcsCreateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsCreateUserVCsRequestBody;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsInvalidateStoredIdentityDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsPostIdentityDto;
-import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsRequestBody;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
@@ -47,7 +45,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.hc.core5.http.HttpHeaders.AUTHORIZATION;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_RESPONSE_MESSAGE;
 import static uk.gov.di.ipv.core.library.helpers.LogHelper.LogField.LOG_STATUS_CODE;
 
@@ -167,34 +164,6 @@ public class EvcsClient {
         }
     }
 
-    public HttpResponse<String> storeUserVCs(
-            String userId, List<EvcsCreateUserVCsDto> userVCsForEvcs) throws EvcsServiceException {
-        LOGGER.info(
-                LogHelper.buildLogMessage(
-                        "Preparing to store %d user VCs using POST /vcs endpoint"
-                                .formatted(userVCsForEvcs.size())));
-        try {
-            HttpRequest.Builder httpRequestBuilder =
-                    HttpRequest.newBuilder()
-                            .uri(getUri(VCS_SUB_PATH, userId, null))
-                            .POST(
-                                    HttpRequest.BodyPublishers.ofString(
-                                            OBJECT_MAPPER.writeValueAsString(userVCsForEvcs)))
-                            .header(
-                                    X_API_KEY_HEADER,
-                                    configService.getSecret(ConfigurationVariable.EVCS_API_KEY))
-                            .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
-
-            return sendHttpRequest(httpRequestBuilder.build());
-        } catch (URISyntaxException e) {
-            throw new EvcsServiceException(
-                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_CONSTRUCT_EVCS_URI);
-        } catch (JsonProcessingException e) {
-            throw new EvcsServiceException(
-                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_PARSE_EVCS_REQUEST_BODY);
-        }
-    }
-
     public HttpResponse<String> storeUserIdentity(EvcsPostIdentityDto evcsPostIdentity)
             throws EvcsServiceException {
         LOGGER.info(LogHelper.buildLogMessage("Preparing to store user's stored identity record"));
@@ -220,36 +189,7 @@ public class EvcsClient {
         }
     }
 
-    public HttpResponse<String> updateUserVCs(
-            String userId, List<EvcsUpdateUserVCsDto> evcsUserVCsToUpdate)
-            throws EvcsServiceException {
-        LOGGER.info(
-                LogHelper.buildLogMessage(
-                        "Preparing to update %d user VCs".formatted(evcsUserVCsToUpdate.size())));
-        try {
-            HttpRequest.Builder httpRequestBuilder =
-                    HttpRequest.newBuilder()
-                            .uri(getUri(VCS_SUB_PATH, userId, null))
-                            .method(
-                                    "PATCH",
-                                    HttpRequest.BodyPublishers.ofString(
-                                            OBJECT_MAPPER.writeValueAsString(evcsUserVCsToUpdate)))
-                            .header(
-                                    X_API_KEY_HEADER,
-                                    configService.getSecret(ConfigurationVariable.EVCS_API_KEY))
-                            .header(CONTENT_TYPE, ContentType.APPLICATION_JSON.toString());
-
-            return sendHttpRequest(httpRequestBuilder.build());
-        } catch (URISyntaxException e) {
-            throw new EvcsServiceException(
-                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_CONSTRUCT_EVCS_URI);
-        } catch (JsonProcessingException e) {
-            throw new EvcsServiceException(
-                    HTTPResponse.SC_SERVER_ERROR, ErrorResponse.FAILED_TO_PARSE_EVCS_REQUEST_BODY);
-        }
-    }
-
-    public HttpResponse<String> storeUserVcsV2(EvcsCreateUserVCsRequestBody requestBody)
+    public HttpResponse<String> storeUserVcs(EvcsCreateUserVCsRequestBody requestBody)
             throws EvcsServiceException {
         LOGGER.info(
                 LogHelper.buildLogMessage(
@@ -277,7 +217,7 @@ public class EvcsClient {
         }
     }
 
-    public HttpResponse<String> updateUserVcsV2(EvcsUpdateUserVCsRequestBody requestBody)
+    public HttpResponse<String> updateUserVcs(EvcsUpdateUserVCsRequestBody requestBody)
             throws EvcsServiceException {
         LOGGER.info(
                 LogHelper.buildLogMessage(
@@ -311,8 +251,7 @@ public class EvcsClient {
         LOGGER.info(
                 LogHelper.buildLogMessage("Preparing to invalidate user's stored identity record"));
 
-        var invalidateEndPoint =
-                configService.enabled(EVCS_API_UPDATES) ? "invalidate/si" : "invalidate";
+        var invalidateEndPoint = "invalidate/si";
 
         try {
             HttpRequest.Builder httpRequestBuilder =

--- a/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
+++ b/libs/evcs-service/src/main/java/uk/gov/di/ipv/core/library/evcs/service/EvcsService.java
@@ -141,17 +141,9 @@ public class EvcsService {
         return credentials;
     }
 
-    public void storePendingVc(VerifiableCredential credential) throws EvcsServiceException {
-        evcsClient.storeUserVCs(
-                credential.getUserId(),
-                List.of(
-                        new EvcsCreateUserVCsDto(
-                                credential.getVcString(), PENDING_RETURN, null, OFFLINE)));
-    }
-
-    public void storePendingVcV2(VerifiableCredential credential, String govukSigninJourneyId)
+    public void storePendingVc(VerifiableCredential credential, String govukSigninJourneyId)
             throws EvcsServiceException {
-        evcsClient.storeUserVcsV2(
+        evcsClient.storeUserVcs(
                 new EvcsCreateUserVCsRequestBody(
                         credential.getUserId(),
                         govukSigninJourneyId,
@@ -160,21 +152,7 @@ public class EvcsService {
                                         credential.getVcString(), PENDING_RETURN, null, OFFLINE))));
     }
 
-    public void abandonPendingIdentity(String userId, String evcsAccessToken)
-            throws EvcsServiceException {
-        List<EvcsUpdateUserVCsDto> vcsToUpdates =
-                getUserVCs(userId, evcsAccessToken, PENDING_RETURN).stream()
-                        .map(
-                                vc ->
-                                        new EvcsUpdateUserVCsDto(
-                                                getVcSignature(vc.vc()), ABANDONED, null))
-                        .toList();
-        if (!vcsToUpdates.isEmpty()) {
-            evcsClient.updateUserVCs(userId, vcsToUpdates);
-        }
-    }
-
-    public void abandonPendingIdentityV2(
+    public void abandonPendingIdentity(
             String userId, String evcsAccessToken, String govukSigninJourneyId)
             throws EvcsServiceException {
         List<EvcsUpdateUserVCsDto> vcsToUpdates =
@@ -185,7 +163,7 @@ public class EvcsService {
                                                 getVcSignature(vc.vc()), ABANDONED, null))
                         .toList();
         if (!vcsToUpdates.isEmpty()) {
-            evcsClient.updateUserVcsV2(
+            evcsClient.updateUserVcs(
                     new EvcsUpdateUserVCsRequestBody(userId, govukSigninJourneyId, vcsToUpdates));
         }
     }
@@ -196,35 +174,7 @@ public class EvcsService {
         return evcsClient.getUserVcs(userId, evcsAccessToken, List.of(states)).vcs();
     }
 
-    public void storeCompletedOrPendingIdentityWithPostVcs(
-            String userId,
-            List<VerifiableCredential> credentials,
-            List<EvcsGetUserVCDto> existingEvcsUserVCs,
-            boolean isPendingIdentity)
-            throws EvcsServiceException {
-
-        var evcsCreateUserVCsDtos =
-                mapNewVcsToEvcsCreateUserVCsDto(
-                        findNewUserVcs(credentials, existingEvcsUserVCs),
-                        isPendingIdentity ? PENDING_RETURN : CURRENT);
-
-        if (!CollectionUtils.isEmpty(existingEvcsUserVCs)) {
-            var existingVcsToUpdate =
-                    mapAndUpdateStateOfExistingUserVcs(
-                            credentials,
-                            existingEvcsUserVCs,
-                            this::mapExistingVcsToEvcsUpdateUserVCsDto,
-                            isPendingIdentity);
-            if (!existingVcsToUpdate.isEmpty()) {
-                evcsClient.updateUserVCs(userId, existingVcsToUpdate);
-            }
-        }
-        if (!evcsCreateUserVCsDtos.isEmpty()) {
-            evcsClient.storeUserVCs(userId, evcsCreateUserVCsDtos);
-        }
-    }
-
-    public void storePendingIdentityWithPostVcsV2(
+    public void storePendingIdentityWithPostVcs(
             String userId,
             String govukSigninJourneyId,
             List<VerifiableCredential> credentials,
@@ -243,35 +193,19 @@ public class EvcsService {
                             this::mapExistingVcsToEvcsUpdateUserVCsDto,
                             true);
             if (!existingVcsToUpdate.isEmpty()) {
-                evcsClient.updateUserVcsV2(
+                evcsClient.updateUserVcs(
                         new EvcsUpdateUserVCsRequestBody(
                                 userId, govukSigninJourneyId, existingVcsToUpdate));
             }
         }
         if (!evcsCreateUserVCsDtos.isEmpty()) {
-            evcsClient.storeUserVcsV2(
+            evcsClient.storeUserVcs(
                     new EvcsCreateUserVCsRequestBody(
                             userId, govukSigninJourneyId, evcsCreateUserVCsDtos));
         }
     }
 
-    public void markHistoricInEvcs(String userId, List<VerifiableCredential> vcs)
-            throws EvcsServiceException {
-        var vcsToUpdate =
-                vcs.stream()
-                        .map(
-                                vc ->
-                                        new EvcsUpdateUserVCsDto(
-                                                getVcSignature(vc.getVcString()),
-                                                EvcsVCState.HISTORIC,
-                                                null))
-                        .toList();
-        if (!vcsToUpdate.isEmpty()) {
-            evcsClient.updateUserVCs(userId, vcsToUpdate);
-        }
-    }
-
-    public void markHistoricInEvcsV2(
+    public void markHistoricInEvcs(
             String userId, String govukSigninJourneyId, List<VerifiableCredential> vcs)
             throws EvcsServiceException {
         var vcsToUpdate =
@@ -284,24 +218,9 @@ public class EvcsService {
                                                 null))
                         .toList();
         if (!vcsToUpdate.isEmpty()) {
-            evcsClient.updateUserVcsV2(
+            evcsClient.updateUserVcs(
                     new EvcsUpdateUserVCsRequestBody(userId, govukSigninJourneyId, vcsToUpdate));
         }
-    }
-
-    public HttpResponse<String> storeStoredIdentityRecord(
-            String userId,
-            List<VerifiableCredential> credentials,
-            VotMatchingResult.VotAndProfile strongestAchievedVot,
-            Vot achievedVot)
-            throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
-        var storedIdentityJwt =
-                storedIdentityService.getStoredIdentityForEvcs(
-                        userId, credentials, strongestAchievedVot, achievedVot);
-
-        var evcsStoreIdentityDto = new EvcsPostIdentityDto(userId, null, null, storedIdentityJwt);
-
-        return evcsClient.storeUserIdentity(evcsStoreIdentityDto);
     }
 
     public HttpResponse<String> storeStoredIdentityRecordAndVcs(

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/client/EvcsClientTest.java
@@ -60,7 +60,6 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.evcs.client.EvcsClient.AFTER_KEY_PARAM;
 import static uk.gov.di.ipv.core.library.evcs.client.EvcsClient.VC_STATE_PARAM;
 import static uk.gov.di.ipv.core.library.evcs.client.EvcsClient.X_API_KEY_HEADER;
@@ -142,7 +141,6 @@ class EvcsClientTest {
         when(mockConfigService.getConfiguration()).thenReturn(mockConfig);
         when(mockConfig.getEvcs()).thenReturn(mockEvcs);
         stubEvcsBaseUrl(EVCS_APPLICATION_URL);
-        lenient().when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(false);
         lenient()
                 .when(mockConfigService.getSecret(ConfigurationVariable.EVCS_API_KEY))
                 .thenReturn(EVCS_API_KEY);
@@ -331,7 +329,7 @@ class EvcsClientTest {
         verify(mockHttpClient, times(2)).send(httpRequestCaptor.capture(), any());
         var httpRequests = httpRequestCaptor.getAllValues();
 
-        var initialRequest = httpRequests.get(0);
+        var initialRequest = httpRequests.getFirst();
         var expectedInitialUri =
                 new URIBuilder(
                                 "%s/vcs/%s"
@@ -472,7 +470,10 @@ class EvcsClientTest {
         // Act
         try (MockedStatic<HttpRequest.BodyPublishers> mockedBodyPublishers =
                 mockStatic(HttpRequest.BodyPublishers.class, CALLS_REAL_METHODS)) {
-            evcsClient.storeUserVCs(TEST_USER_ID, EVCS_CREATE_USER_VCS_DTO);
+            var evcsRequestBody =
+                    new EvcsCreateUserVCsRequestBody(
+                            TEST_USER_ID, TEST_GOVUK_SIGNIN_JOURNEY_ID, EVCS_CREATE_USER_VCS_DTO);
+            evcsClient.storeUserVcs(evcsRequestBody);
 
             // Assert
             verify(mockHttpClient).send(httpRequestCaptor.capture(), any());
@@ -484,24 +485,13 @@ class EvcsClientTest {
 
             mockedBodyPublishers.verify(
                     () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
-            var userVCsForEvcs =
+            var requestBody =
                     OBJECT_MAPPER.readValue(
-                            stringCaptor.getAllValues().get(0),
-                            new TypeReference<List<EvcsCreateUserVCsDto>>() {});
+                            stringCaptor.getAllValues().getFirst(),
+                            EvcsCreateUserVCsRequestBody.class);
+            var userVCsForEvcs = requestBody.vcs();
             assertFalse(userVCsForEvcs.stream().anyMatch(dto -> !dto.state().equals(CURRENT)));
         }
-    }
-
-    @Test
-    void testCreateUserVCs_shouldThrowException_ifBadUrl() {
-        // Arrange
-        when(mockEvcs.getApplicationUrl()).thenReturn(badUri);
-        when(badUri.toString()).thenReturn("\\");
-        // Act
-        // Assert
-        assertThrows(
-                EvcsServiceException.class,
-                () -> evcsClient.storeUserVCs("user%^", EVCS_CREATE_USER_VCS_DTO));
     }
 
     @Test
@@ -512,7 +502,10 @@ class EvcsClientTest {
         // Act
         try (MockedStatic<HttpRequest.BodyPublishers> mockedBodyPublishers =
                 mockStatic(HttpRequest.BodyPublishers.class, CALLS_REAL_METHODS)) {
-            var res = evcsClient.updateUserVCs(TEST_USER_ID, EVCS_UPDATE_USER_VCS_DTO);
+            var evcsRequestBody =
+                    new EvcsUpdateUserVCsRequestBody(
+                            TEST_USER_ID, TEST_GOVUK_SIGNIN_JOURNEY_ID, EVCS_UPDATE_USER_VCS_DTO);
+            var res = evcsClient.updateUserVcs(evcsRequestBody);
 
             // Assert
             assertEquals(HttpStatusCode.ACCEPTED, res.statusCode());
@@ -525,24 +518,13 @@ class EvcsClientTest {
 
             mockedBodyPublishers.verify(
                     () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
-            var userVCsForEvcs =
+            var requestBody =
                     OBJECT_MAPPER.readValue(
-                            stringCaptor.getAllValues().get(0),
-                            new TypeReference<List<EvcsUpdateUserVCsDto>>() {});
+                            stringCaptor.getAllValues().getFirst(),
+                            EvcsUpdateUserVCsRequestBody.class);
+            var userVCsForEvcs = requestBody.vcs();
             assertFalse(userVCsForEvcs.stream().anyMatch(dto -> dto.state().equals(CURRENT)));
         }
-    }
-
-    @Test
-    void testUpdateUserVCs_shouldThrowException_ifBadUrl() {
-        // Arrange
-        when(mockEvcs.getApplicationUrl()).thenReturn(badUri);
-        when(badUri.toString()).thenReturn("\\");
-        // Act
-        // Assert
-        assertThrows(
-                EvcsServiceException.class,
-                () -> evcsClient.updateUserVCs("user%^", EVCS_UPDATE_USER_VCS_DTO));
     }
 
     @Test
@@ -612,7 +594,7 @@ class EvcsClientTest {
                     () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
             var evcsPostIdentityDto =
                     OBJECT_MAPPER.readValue(
-                            stringCaptor.getAllValues().get(0),
+                            stringCaptor.getAllValues().getFirst(),
                             new TypeReference<EvcsPostIdentityDto>() {});
             assertEquals("storedIdentityJwt", evcsPostIdentityDto.si().jwt());
             assertEquals(Vot.P2, evcsPostIdentityDto.si().vot());
@@ -644,7 +626,7 @@ class EvcsClientTest {
                     () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
             var evcsPostIdentityDto =
                     OBJECT_MAPPER.readValue(
-                            stringCaptor.getAllValues().get(0),
+                            stringCaptor.getAllValues().getFirst(),
                             new TypeReference<EvcsPostIdentityDto>() {});
             assertEquals("storedIdentityJwt", evcsPostIdentityDto.si().jwt());
             assertEquals(Vot.P2, evcsPostIdentityDto.si().vot());
@@ -656,42 +638,10 @@ class EvcsClientTest {
     }
 
     @Test
-    void invalidateStoredIdentityRecordShouldSuccessfullySendRequest() throws Exception {
+    void invalidateStoredIdentityRecordShouldSendRequest() throws Exception {
         // Arrange
         when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
         when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.NO_CONTENT);
-
-        // Act
-        try (MockedStatic<HttpRequest.BodyPublishers> mockedBodyPublishers =
-                mockStatic(HttpRequest.BodyPublishers.class, CALLS_REAL_METHODS)) {
-            var res = evcsClient.invalidateStoredIdentityRecord(TEST_USER_ID);
-
-            // Assert
-            assertEquals(HttpStatusCode.NO_CONTENT, res.statusCode());
-            verify(mockHttpClient).send(httpRequestCaptor.capture(), any());
-            HttpRequest httpRequest = httpRequestCaptor.getValue();
-            assertEquals("POST", httpRequest.method());
-            assertTrue(httpRequest.bodyPublisher().isPresent());
-            assertFalse(httpRequest.headers().map().containsKey(AUTHORIZATION));
-            assertTrue(httpRequest.headers().map().containsKey(X_API_KEY_HEADER));
-            assertEquals("/v1/identity/invalidate", httpRequest.uri().getPath());
-
-            mockedBodyPublishers.verify(
-                    () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
-            var evcsInvalidateSiDto =
-                    OBJECT_MAPPER.readValue(
-                            stringCaptor.getAllValues().get(0),
-                            new TypeReference<EvcsInvalidateStoredIdentityDto>() {});
-            assertEquals(TEST_USER_ID, evcsInvalidateSiDto.userId());
-        }
-    }
-
-    @Test
-    void invalidateStoredIdentityRecordShouldSendRequestToNewUrlIfFlagEnabled() throws Exception {
-        // Arrange
-        when(mockHttpClient.<String>send(any(), any())).thenReturn(mockHttpResponse);
-        when(mockHttpResponse.statusCode()).thenReturn(HttpStatusCode.NO_CONTENT);
-        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
 
         // Act
         try (MockedStatic<HttpRequest.BodyPublishers> mockedBodyPublishers =
@@ -712,7 +662,7 @@ class EvcsClientTest {
                     () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
             var evcsInvalidateSiDto =
                     OBJECT_MAPPER.readValue(
-                            stringCaptor.getAllValues().get(0),
+                            stringCaptor.getAllValues().getFirst(),
                             new TypeReference<EvcsInvalidateStoredIdentityDto>() {});
             assertEquals(TEST_USER_ID, evcsInvalidateSiDto.userId());
         }
@@ -749,7 +699,7 @@ class EvcsClientTest {
         // Act
         try (MockedStatic<HttpRequest.BodyPublishers> mockedBodyPublishers =
                 mockStatic(HttpRequest.BodyPublishers.class, CALLS_REAL_METHODS)) {
-            evcsClient.storeUserVcsV2(requestBody);
+            evcsClient.storeUserVcs(requestBody);
 
             // Assert
             verify(mockHttpClient).send(httpRequestCaptor.capture(), any());
@@ -764,7 +714,7 @@ class EvcsClientTest {
                     () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
             var sentBody =
                     OBJECT_MAPPER.readValue(
-                            stringCaptor.getAllValues().get(0),
+                            stringCaptor.getAllValues().getFirst(),
                             new TypeReference<EvcsCreateUserVCsRequestBody>() {});
             assertEquals(TEST_USER_ID, sentBody.userId());
             assertEquals(TEST_GOVUK_SIGNIN_JOURNEY_ID, sentBody.govuk_signin_journey_id());
@@ -773,7 +723,7 @@ class EvcsClientTest {
     }
 
     @Test
-    void testStoreUserVcsV2_shouldThrowException_ifBadUrl() {
+    void testStoreUserVcs_shouldThrowException_ifBadUrl() {
         // Arrange
         when(mockEvcs.getApplicationUrl()).thenReturn(badUri);
         when(badUri.toString()).thenReturn("\\");
@@ -782,7 +732,7 @@ class EvcsClientTest {
         assertThrows(
                 EvcsServiceException.class,
                 () ->
-                        evcsClient.storeUserVcsV2(
+                        evcsClient.storeUserVcs(
                                 new EvcsCreateUserVCsRequestBody(
                                         TEST_USER_ID,
                                         TEST_GOVUK_SIGNIN_JOURNEY_ID,
@@ -800,7 +750,7 @@ class EvcsClientTest {
         // Act
         try (MockedStatic<HttpRequest.BodyPublishers> mockedBodyPublishers =
                 mockStatic(HttpRequest.BodyPublishers.class, CALLS_REAL_METHODS)) {
-            var res = evcsClient.updateUserVcsV2(requestBody);
+            var res = evcsClient.updateUserVcs(requestBody);
 
             // Assert
             assertEquals(HttpStatusCode.ACCEPTED, res.statusCode());
@@ -816,7 +766,7 @@ class EvcsClientTest {
                     () -> HttpRequest.BodyPublishers.ofString(stringCaptor.capture()));
             var sentBody =
                     OBJECT_MAPPER.readValue(
-                            stringCaptor.getAllValues().get(0),
+                            stringCaptor.getAllValues().getFirst(),
                             new TypeReference<EvcsUpdateUserVCsRequestBody>() {});
             assertEquals(TEST_USER_ID, sentBody.userId());
             assertEquals(TEST_GOVUK_SIGNIN_JOURNEY_ID, sentBody.govuk_signin_journey_id());
@@ -825,7 +775,7 @@ class EvcsClientTest {
     }
 
     @Test
-    void testUpdateUserVcsV2_shouldThrowException_ifBadUrl() {
+    void testUpdateUserVcs_shouldThrowException_ifBadUrl() {
         // Arrange
         when(mockEvcs.getApplicationUrl()).thenReturn(badUri);
         when(badUri.toString()).thenReturn("\\");
@@ -834,7 +784,7 @@ class EvcsClientTest {
         assertThrows(
                 EvcsServiceException.class,
                 () ->
-                        evcsClient.updateUserVcsV2(
+                        evcsClient.updateUserVcs(
                                 new EvcsUpdateUserVCsRequestBody(
                                         TEST_USER_ID,
                                         TEST_GOVUK_SIGNIN_JOURNEY_ID,

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
@@ -888,8 +888,6 @@ class ContractTest {
                 });
     }
 
-    // POST /identity/invalidate/si tests
-    // PYIC-9011 Remove EVCS_API_UPDATES flag mocking after go-live cleanup
     @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
     public RequestResponsePact postIdentityInvalidateSiReturns204(PactDslWithProvider builder) {
         return builder.given("EVCS client exist")

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/pact/ContractTest.java
@@ -34,16 +34,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArray;
 import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
 import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.core.library.config.CoreFeatureFlag.EVCS_API_UPDATES;
 import static uk.gov.di.ipv.core.library.enums.Vot.P2;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.PENDING_RETURN;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVcProvenance.ONLINE;
@@ -269,266 +266,6 @@ class ContractTest {
                     evcsClient.getUserVcs(
                             INVALID_USER_ID, "invalid-access-token", VC_STATES_FOR_QUERY);
                 });
-    }
-
-    // PYIC-9011 Remove old /vcs/{userId} POST endpoint test after go-live cleanup
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact validCreateUserVcReturnsMessageIdWith202(
-            PactDslWithProvider builder) {
-        return builder.given("Brand new user")
-                .given("test-evcs-api-key is a valid API key")
-                .uponReceiving("A request to create EVCS user VCs")
-                .path("/vcs/" + TEST_USER_ID)
-                .method("POST")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(getRequestBodyForUserVC())
-                .willRespondWith()
-                .status(202)
-                .toPact();
-    }
-
-    private DslPart getRequestBodyForUserVC() {
-        return newJsonArray(
-                        array -> {
-                            array.object(
-                                    vcObject -> {
-                                        vcObject.stringType("vc", VC_STRING);
-                                        vcObject.stringType("state", "CURRENT");
-                                        vcObject.object(
-                                                "metadata",
-                                                metadata -> {
-                                                    metadata.stringType("reason", "testing");
-                                                    metadata.stringType(
-                                                            "timestampMs", "1711721297123");
-                                                    metadata.stringType(
-                                                            "txmaEventId", "txma-testing-event-id");
-                                                });
-                                        vcObject.stringType("provenance", "ONLINE");
-                                    });
-                        })
-                .build();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "validCreateUserVcReturnsMessageIdWith202")
-    void testCreateVcRequestReturnsUsersVcWith202(MockServer mockServer) throws Exception {
-        // Under Test
-        EvcsClient evcsClient = new EvcsClient(mockConfigService);
-        try {
-            evcsClient.storeUserVCs(TEST_USER_ID, EVCS_CREATE_USER_VCS_DTO);
-        } catch (EvcsServiceException e) {
-            fail("EvcsServiceException was thrown");
-        }
-    }
-
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact invalidCreateUserVcReturns400(PactDslWithProvider builder) {
-        return builder.given("test-evcs-api-key is a valid API key")
-                .uponReceiving("A request to create EVCS user VCs")
-                .path("/vcs/" + TEST_USER_ID)
-                .method("POST")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(invalidRequestBodyForUserVC())
-                .willRespondWith()
-                .status(400)
-                .toPact();
-    }
-
-    private DslPart invalidRequestBodyForUserVC() {
-        return newJsonArray(
-                        array -> {
-                            array.object(
-                                    vcObject -> {
-                                        vcObject.stringType("vc", "invalid-vc-string");
-                                        vcObject.stringType("state", "WRONG_STATE");
-                                    });
-                        })
-                .build();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "invalidCreateUserVcReturns400")
-    void testCreateUserVcRequestReturns400(MockServer mockServer) {
-        // Under Test
-        EvcsClient evcsClient = new EvcsClient(mockConfigService);
-        assertThrows(
-                EvcsServiceException.class,
-                () -> {
-                    evcsClient.storeUserVCs(TEST_USER_ID, INVALID_CREATE_USER_VCS_DTO);
-                });
-    }
-
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact createUserVcForExistingVcReturns409(PactDslWithProvider builder) {
-        return builder.given("Existing user")
-                .given("test-evcs-api-key is a valid API key")
-                .uponReceiving("A request to create EVCS user VCs")
-                .path("/vcs/" + TEST_USER_ID)
-                .method("POST")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(getRequestBodyForUserVC())
-                .willRespondWith()
-                .status(409)
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "createUserVcForExistingVcReturns409")
-    void testCreateUserVcRequestReturns409(MockServer mockServer) {
-        // Under Test
-        EvcsClient evcsClient = new EvcsClient(mockConfigService);
-        assertThrows(
-                EvcsServiceException.class,
-                () -> {
-                    evcsClient.storeUserVCs(TEST_USER_ID, EVCS_CREATE_USER_VCS_DTO);
-                });
-    }
-
-    // PYIC-9011 Remove old /vcs/{userId} PATCH endpoint test after go-live cleanup
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact validUpdateUserVcReturnsMessageIdWith204(
-            PactDslWithProvider builder) {
-        return builder.given("User has a valid VC")
-                .given("test-evcs-api-key is a valid API key")
-                .given("test-user-id has one PENDING_RETURN VC")
-                .uponReceiving("A request to update EVCS user VCs")
-                .path("/vcs/" + TEST_USER_ID)
-                .method("PATCH")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(getRequestBodyUpdateVC("CURRENT"))
-                .willRespondWith()
-                .status(204)
-                .toPact();
-    }
-
-    private DslPart getRequestBodyUpdateVC(String state) {
-        return newJsonArray(
-                        array -> {
-                            array.object(
-                                    vcObject -> {
-                                        vcObject.stringType("signature", VC_SIGNATURE);
-                                        vcObject.stringType("state", state);
-                                        vcObject.object(
-                                                "metadata",
-                                                metadata -> {
-                                                    metadata.stringType("reason", "testing");
-                                                    metadata.stringType(
-                                                            "timestampMs", "1711721297123");
-                                                    metadata.stringType(
-                                                            "txmaEventId", "txma-testing-event-id");
-                                                });
-                                    });
-                        })
-                .build();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "validUpdateUserVcReturnsMessageIdWith204")
-    void testUpdateVcRequestReturnsUsersVcWith204(MockServer mockServer) throws Exception {
-        // Under Test
-        EvcsClient evcsClient = new EvcsClient(mockConfigService);
-        try {
-            evcsClient.updateUserVCs(TEST_USER_ID, EVCS_UPDATE_USER_VCS_DTO);
-        } catch (EvcsServiceException e) {
-            fail("EvcsServiceException was thrown");
-        }
-    }
-
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact invalidUpdateUserVcReturns400(PactDslWithProvider builder) {
-        return builder.given("EVCS client exist")
-                .given("test-evcs-api-key is a valid API key")
-                .uponReceiving("A request to create EVCS user VCs")
-                .path("/vcs/" + INVALID_USER_ID)
-                .method("PATCH")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(getRequestBodyUpdateVC("INVALID_STATE"))
-                .willRespondWith()
-                .status(400)
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "invalidUpdateUserVcReturns400")
-    void testUpdateVcRequestReturns400(MockServer mockServer) {
-        // Under Test
-        EvcsClient evcsClient = new EvcsClient(mockConfigService);
-        assertThrows(
-                EvcsServiceException.class,
-                () -> {
-                    evcsClient.updateUserVCs(INVALID_USER_ID, EVCS_UPDATE_USER_VCS_DTO);
-                });
-    }
-
-    // PYIC-9011 Remove old POST /identity (without vcs/journey id) test after go-live cleanup
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact postIdentityReturns202(PactDslWithProvider builder) {
-        return builder.given("EVCS client exist")
-                .given("test-evcs-api-key is a valid API key")
-                .uponReceiving("A request to create a stored identity in EVCS.")
-                .path("/identity")
-                .method("POST")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(
-                        newJsonBody(
-                                        body -> {
-                                            body.stringType("userId", TEST_USER_ID);
-                                            body.object(
-                                                    "si",
-                                                    si -> {
-                                                        si.stringType("jwt", SI_JWT_STRING);
-                                                        si.stringType("vot", P2.toString());
-                                                    });
-                                        })
-                                .build())
-                .willRespondWith()
-                .status(202)
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "postIdentityReturns202")
-    void testPostIdentityReturns202(MockServer mockServer) throws EvcsServiceException {
-        // Arrange
-        var evcsPostIdentityDto =
-                new EvcsPostIdentityDto(TEST_USER_ID, null, null, EVCS_STORED_IDENTITY_DTO);
-        var underTest = new EvcsClient(mockConfigService);
-
-        // Act
-        var response = underTest.storeUserIdentity(evcsPostIdentityDto);
-
-        // Assert
-        assertEquals(202, response.statusCode());
     }
 
     @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
@@ -893,217 +630,6 @@ class ContractTest {
         assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getResponseCode());
     }
 
-    // PYIC-9011 Remove old /identity/invalidate endpoint tests after go-live cleanup
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact postIdentityInvalidateReturns204(PactDslWithProvider builder) {
-        return builder.given("EVCS client exist")
-                .given("test-evcs-api-key is a valid API key")
-                .given("test-user-id has a valid identity record")
-                .uponReceiving("A request to invalidate a EVCS user identity")
-                .path("/identity/invalidate")
-                .method("POST")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(
-                        newJsonBody(
-                                        body -> {
-                                            body.stringType("userId", TEST_USER_ID);
-                                        })
-                                .build())
-                .willRespondWith()
-                .status(204)
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "postIdentityInvalidateReturns204")
-    void testPostIdentityInvalidateReturns204(MockServer mockServer) throws EvcsServiceException {
-        // Arrange
-        var underTest = new EvcsClient(mockConfigService);
-
-        // Act
-        var response = underTest.invalidateStoredIdentityRecord(TEST_USER_ID);
-
-        // Assert
-        assertEquals(204, response.statusCode());
-    }
-
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact nullUserIdPostIdentityInvalidateReturns400(
-            PactDslWithProvider builder) {
-        // Null user id
-        return builder.given("EVCS client exist")
-                .given("test-evcs-api-key is a valid API key")
-                .given("test-user-id has a valid identity record")
-                .uponReceiving("A request to invalidate a EVCS user identity, with an null user id")
-                .path("/identity/invalidate")
-                .method("POST")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(newJsonBody(body -> body.nullValue("userId")).build())
-                .willRespondWith()
-                .status(400)
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "nullUserIdPostIdentityInvalidateReturns400")
-    void testNullUserIdPostIdentityInvalidateReturns400(MockServer mockServer) {
-        // Arrange
-        var underTest = new EvcsClient(mockConfigService);
-
-        // Act & Assert
-        var exception =
-                assertThrows(
-                        EvcsServiceException.class,
-                        () -> {
-                            underTest.invalidateStoredIdentityRecord(null);
-                        });
-        assertEquals(
-                ErrorResponse.RECEIVED_NON_200_RESPONSE_STATUS_CODE, exception.getErrorResponse());
-        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getResponseCode());
-    }
-
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact emptyUserIdPostIdentityInvalidateReturns400(
-            PactDslWithProvider builder) {
-        return builder.given("EVCS client exist")
-                .given("test-user-id has a valid identity record")
-                .given("test-evcs-api-key is a valid API key")
-                .uponReceiving(
-                        "A request to invalidate a EVCS user identity, with an empty user id")
-                .path("/identity/invalidate")
-                .method("POST")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(
-                        newJsonBody(
-                                        body -> {
-                                            body.stringType("userId", "");
-                                        })
-                                .build())
-                .willRespondWith()
-                .status(400)
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "emptyUserIdPostIdentityInvalidateReturns400")
-    void testEmptyUserIdPostIdentityInvalidateReturns400(MockServer mockServer) {
-        // Arrange
-        var underTest = new EvcsClient(mockConfigService);
-
-        // Act & Assert
-        var exception =
-                assertThrows(
-                        EvcsServiceException.class,
-                        () -> {
-                            underTest.invalidateStoredIdentityRecord("");
-                        });
-        assertEquals(
-                ErrorResponse.RECEIVED_NON_200_RESPONSE_STATUS_CODE, exception.getErrorResponse());
-        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getResponseCode());
-    }
-
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact forbiddenPostIdentityInvalidateReturns403(
-            PactDslWithProvider builder) {
-        return builder.given("EVCS client exist")
-                .given("test-user-id has a valid identity record")
-                .given("invalid-api-key is an invalid API key")
-                .uponReceiving("A request to invalidate a EVCS user identity")
-                .path("/identity/invalidate")
-                .method("POST")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_INVALID_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(
-                        newJsonBody(
-                                        body -> {
-                                            body.stringType("userId", TEST_USER_ID);
-                                        })
-                                .build())
-                .willRespondWith()
-                .status(403)
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "forbiddenPostIdentityInvalidateReturns403")
-    void testForbiddenPostIdentityInvalidateReturns403(MockServer mockServer) {
-        // Arrange
-        lenient()
-                .when(mockConfigService.getSecret(ConfigurationVariable.EVCS_API_KEY))
-                .thenReturn(EVCS_INVALID_API_KEY);
-        var underTest = new EvcsClient(mockConfigService);
-
-        // Act & Assert
-        var exception =
-                assertThrows(
-                        EvcsServiceException.class,
-                        () -> {
-                            underTest.invalidateStoredIdentityRecord(TEST_USER_ID);
-                        });
-        assertEquals(
-                ErrorResponse.RECEIVED_NON_200_RESPONSE_STATUS_CODE, exception.getErrorResponse());
-        assertEquals(HTTPResponse.SC_SERVER_ERROR, exception.getResponseCode());
-    }
-
-    @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
-    public RequestResponsePact notFoundPostIdentityInvalidateReturns404(
-            PactDslWithProvider builder) {
-        return builder.given("EVCS client exist")
-                .given("test-evcs-api-key is a valid API key")
-                .given("No user exists with id invalid-user-id")
-                .uponReceiving("A request to invalidate a EVCS user identity")
-                .path("/identity/invalidate")
-                .method("POST")
-                .headers(
-                        Map.of(
-                                "x-api-key",
-                                EVCS_API_KEY,
-                                CONTENT_TYPE,
-                                ContentType.APPLICATION_JSON.toString()))
-                .body(
-                        newJsonBody(
-                                        body -> {
-                                            body.stringType("userId", INVALID_USER_ID);
-                                        })
-                                .build())
-                .willRespondWith()
-                .status(404)
-                .toPact();
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "notFoundPostIdentityInvalidateReturns404")
-    void testNotFoundPostIdentityInvalidateReturns404(MockServer mockServer)
-            throws EvcsServiceException {
-        // Arrange
-        var underTest = new EvcsClient(mockConfigService);
-
-        // Act
-        var response = underTest.invalidateStoredIdentityRecord(TEST_USER_ID);
-
-        // Assert
-        assertEquals(404, response.statusCode());
-    }
-
     // POST /vcs with userId in body tests
     @Pact(provider = "EvcsProvider", consumer = "IpvCoreBack")
     public RequestResponsePact validCreateUserVcV2Returns202(PactDslWithProvider builder) {
@@ -1163,7 +689,7 @@ class ContractTest {
         EvcsClient evcsClient = new EvcsClient(mockConfigService);
         assertDoesNotThrow(
                 () ->
-                        evcsClient.storeUserVcsV2(
+                        evcsClient.storeUserVcs(
                                 new EvcsCreateUserVCsRequestBody(
                                         TEST_USER_ID,
                                         "test-govuk-signin-journey-id",
@@ -1216,7 +742,7 @@ class ContractTest {
         assertThrows(
                 EvcsServiceException.class,
                 () -> {
-                    evcsClient.storeUserVcsV2(
+                    evcsClient.storeUserVcs(
                             new EvcsCreateUserVCsRequestBody(
                                     TEST_USER_ID,
                                     "test-govuk-signin-journey-id",
@@ -1252,7 +778,7 @@ class ContractTest {
         assertThrows(
                 EvcsServiceException.class,
                 () -> {
-                    evcsClient.storeUserVcsV2(
+                    evcsClient.storeUserVcs(
                             new EvcsCreateUserVCsRequestBody(
                                     TEST_USER_ID,
                                     "test-govuk-signin-journey-id",
@@ -1319,7 +845,7 @@ class ContractTest {
         EvcsClient evcsClient = new EvcsClient(mockConfigService);
         assertDoesNotThrow(
                 () ->
-                        evcsClient.updateUserVcsV2(
+                        evcsClient.updateUserVcs(
                                 new EvcsUpdateUserVCsRequestBody(
                                         TEST_USER_ID,
                                         "test-govuk-signin-journey-id",
@@ -1354,7 +880,7 @@ class ContractTest {
         assertThrows(
                 EvcsServiceException.class,
                 () -> {
-                    evcsClient.updateUserVcsV2(
+                    evcsClient.updateUserVcs(
                             new EvcsUpdateUserVCsRequestBody(
                                     INVALID_USER_ID,
                                     "test-govuk-signin-journey-id",
@@ -1393,7 +919,6 @@ class ContractTest {
     @PactTestFor(pactMethod = "postIdentityInvalidateSiReturns204")
     void testPostIdentityInvalidateSiReturns204(MockServer mockServer) throws EvcsServiceException {
         // Arrange
-        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act
@@ -1429,7 +954,6 @@ class ContractTest {
     @PactTestFor(pactMethod = "nullUserIdPostIdentityInvalidateSiReturns400")
     void testNullUserIdPostIdentityInvalidateSiReturns400(MockServer mockServer) {
         // Arrange
-        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act & Assert
@@ -1476,7 +1000,6 @@ class ContractTest {
     @PactTestFor(pactMethod = "emptyUserIdPostIdentityInvalidateSiReturns400")
     void testEmptyUserIdPostIdentityInvalidateSiReturns400(MockServer mockServer) {
         // Arrange
-        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act & Assert
@@ -1521,7 +1044,6 @@ class ContractTest {
     @PactTestFor(pactMethod = "forbiddenPostIdentityInvalidateSiReturns403")
     void testForbiddenPostIdentityInvalidateSiReturns403(MockServer mockServer) {
         // Arrange
-        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
         lenient()
                 .when(mockConfigService.getSecret(ConfigurationVariable.EVCS_API_KEY))
                 .thenReturn(EVCS_INVALID_API_KEY);
@@ -1570,7 +1092,6 @@ class ContractTest {
     void testNotFoundPostIdentityInvalidateSiReturns404(MockServer mockServer)
             throws EvcsServiceException {
         // Arrange
-        when(mockConfigService.enabled(EVCS_API_UPDATES)).thenReturn(true);
         var underTest = new EvcsClient(mockConfigService);
 
         // Act

--- a/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
+++ b/libs/evcs-service/src/test/java/uk/gov/di/ipv/core/library/evcs/service/EvcsServiceTest.java
@@ -19,7 +19,6 @@ import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsGetUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsPostIdentityDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsStoredIdentityDto;
-import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsDto;
 import uk.gov.di.ipv.core.library.evcs.dto.EvcsUpdateUserVCsRequestBody;
 import uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState;
 import uk.gov.di.ipv.core.library.evcs.exception.EvcsServiceException;
@@ -34,15 +33,18 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.core.library.enums.Vot.P0;
 import static uk.gov.di.ipv.core.library.enums.Vot.P1;
+import static uk.gov.di.ipv.core.library.enums.Vot.P2;
+import static uk.gov.di.ipv.core.library.enums.Vot.P3;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.ABANDONED;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.CURRENT;
 import static uk.gov.di.ipv.core.library.evcs.enums.EvcsVCState.HISTORIC;
@@ -59,6 +61,7 @@ import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcWebDrivingPermitD
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcWebDrivingPermitDvlaValid;
 import static uk.gov.di.ipv.core.library.fixtures.VcFixtures.vcWebPassportSuccessful;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.L1A;
+import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1A;
 
 @ExtendWith(MockitoExtension.class)
 class EvcsServiceTest {
@@ -81,6 +84,7 @@ class EvcsServiceTest {
     private static final String TEST_GOVUK_SIGNIN_JOURNEY_ID = "test-govuk-signin-journey-id";
 
     private static final String TEST_EVCS_ACCESS_TOKEN = "TEST_EVCS_ACCESS_TOKEN";
+    public static final String TEST_SI_JWT = "test.si.jwt";
     private static final List<EvcsGetUserVCDto> EVCS_GET_USER_VC_DTO =
             List.of(
                     new EvcsGetUserVCDto(
@@ -107,14 +111,13 @@ class EvcsServiceTest {
 
     private static final VotMatchingResult.VotAndProfile STRONGEST_MATCHED_VOT =
             new VotMatchingResult.VotAndProfile(P1, Optional.of(L1A));
+    private static final VotMatchingResult.VotAndProfile STRONGEST_MATCHED_VOT_P3 =
+            new VotMatchingResult.VotAndProfile(P2, Optional.of(M1A));
     private static final Vot ACHIEVED_VOT = P1;
 
-    @Captor ArgumentCaptor<List<EvcsCreateUserVCsDto>> evcsCreateUserVCsDtosCaptor;
-    @Captor ArgumentCaptor<List<EvcsUpdateUserVCsDto>> evcsUpdateUserVCsDtosCaptor;
     @Captor ArgumentCaptor<EvcsPostIdentityDto> evcsPostIdentityDtoCaptor;
     @Captor ArgumentCaptor<EvcsCreateUserVCsRequestBody> evcsCreateRequestBodyCaptor;
     @Captor ArgumentCaptor<EvcsUpdateUserVCsRequestBody> evcsUpdateRequestBodyCaptor;
-    @Captor ArgumentCaptor<String> stringArgumentCaptor;
 
     @Mock EvcsClient mockEvcsClient;
     @Mock ConfigService mockConfigService;
@@ -125,84 +128,46 @@ class EvcsServiceTest {
     class StoreIdentityWithPost {
         @Test
         void testStoreIdentity_whenNoExistingEvcsUserVCs() throws Exception {
+            // Arrange
+            when(mockStoredIdentityService.getStoredIdentityForEvcs(any(), any(), any(), any()))
+                    .thenReturn(new EvcsStoredIdentityDto(TEST_SI_JWT, P3));
+
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
-                    TEST_USER_ID, VERIFIABLE_CREDENTIALS, List.of(), false);
-
-            // Assert
-            InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-            mockOrderVerifier.verify(mockEvcsClient, times(0)).updateUserVCs(any(), any());
-            mockOrderVerifier
-                    .verify(mockEvcsClient)
-                    .storeUserVCs(any(), evcsCreateUserVCsDtosCaptor.capture());
-            var userVCsForEvcs = evcsCreateUserVCsDtosCaptor.getValue();
-            assertEquals(
-                    3,
-                    (userVCsForEvcs.stream()
-                            .filter(dto -> dto.state().equals(EvcsVCState.CURRENT))
-                            .count()));
-            assertFalse(
-                    userVCsForEvcs.stream()
-                            .anyMatch(dto -> !dto.state().equals(EvcsVCState.CURRENT)));
-            assertFalse(userVCsForEvcs.stream().anyMatch(dto -> !dto.provenance().equals(ONLINE)));
-        }
-
-        @Test
-        void testStorePendingIdentity_onSuccessfulJourney_for_incompleteF2F() throws Exception {
-            // Act
-            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
-                    TEST_USER_ID, VERIFIABLE_CREDENTIALS_ONE_EXIST_IN_EVCS, List.of(), true);
-
-            // Assert
-            InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-            mockOrderVerifier
-                    .verify(mockEvcsClient, times(0))
-                    .updateUserVCs(any(), evcsUpdateUserVCsDtosCaptor.capture());
-            mockOrderVerifier
-                    .verify(mockEvcsClient)
-                    .storeUserVCs(any(), evcsCreateUserVCsDtosCaptor.capture());
-            var userVCsForEvcs = evcsCreateUserVCsDtosCaptor.getValue();
-            assertFalse(
-                    userVCsForEvcs.stream()
-                            .anyMatch(dto -> !dto.state().equals(EvcsVCState.PENDING_RETURN)));
-        }
-
-        @Test
-        void testStoreIdentity_for_6MFCJourney() throws Exception {
-            // Act
-            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
+            evcsService.storeStoredIdentityRecordAndVcs(
                     TEST_USER_ID,
-                    VERIFIABLE_CREDENTIALS_ONE_EXIST_IN_EVCS,
-                    EVCS_GET_USER_VC_DTO,
-                    false);
+                    TEST_GOVUK_SIGNIN_JOURNEY_ID,
+                    VERIFIABLE_CREDENTIALS,
+                    List.of(),
+                    STRONGEST_MATCHED_VOT_P3,
+                    P2);
 
             // Assert
-            InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-            mockOrderVerifier
-                    .verify(mockEvcsClient)
-                    .updateUserVCs(any(), evcsUpdateUserVCsDtosCaptor.capture());
-            mockOrderVerifier
-                    .verify(mockEvcsClient)
-                    .storeUserVCs(any(), evcsCreateUserVCsDtosCaptor.capture());
-
-            var evcsUserVCsToUpdate = evcsUpdateUserVCsDtosCaptor.getValue();
-            assertEquals(
-                    1,
-                    (evcsUserVCsToUpdate.stream()
-                            .filter(dto -> dto.state().equals(EvcsVCState.HISTORIC))
-                            .count()));
-            var userVCsForEvcs = evcsCreateUserVCsDtosCaptor.getValue();
+            verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
+            var evcsPostIdentityDto = evcsPostIdentityDtoCaptor.getValue();
             assertEquals(
                     3,
-                    (userVCsForEvcs.stream()
-                            .filter(dto -> dto.state().equals(EvcsVCState.CURRENT))
+                    (evcsPostIdentityDto.vcs().stream()
+                            .filter(vc -> vc.state().equals(EvcsVCState.CURRENT))
                             .count()));
+            assertFalse(
+                    evcsPostIdentityDto.vcs().stream()
+                            .anyMatch(vc -> !vc.state().equals(EvcsVCState.CURRENT)));
+            assertFalse(
+                    evcsPostIdentityDto.vcs().stream()
+                            .anyMatch(dto -> !dto.provenance().equals(ONLINE)));
+            assertEquals(TEST_SI_JWT, evcsPostIdentityDto.si().jwt());
+            assertEquals(P3, evcsPostIdentityDto.si().vot());
+            assertEquals(TEST_USER_ID, evcsPostIdentityDto.userId());
+            assertEquals(
+                    TEST_GOVUK_SIGNIN_JOURNEY_ID, evcsPostIdentityDto.govuk_signin_journey_id());
         }
 
         @Test
         void testStoreCompleteIdentity_whenAllVCsExistInEvcs_withCurrentState() throws Exception {
             // Arrange
-            List<EvcsGetUserVCDto> evcsGetUserVcsWithCurrentStateAllExistingDto =
+            when(mockStoredIdentityService.getStoredIdentityForEvcs(any(), any(), any(), any()))
+                    .thenReturn(new EvcsStoredIdentityDto(TEST_SI_JWT, P3));
+            var evcsGetUserVcsWithCurrentStateAllExistingDto =
                     List.of(
                             new EvcsGetUserVCDto(
                                     VC_ADDRESS_TEST.getVcString(),
@@ -216,23 +181,34 @@ class EvcsServiceTest {
                                     VC_F2F.getVcString(),
                                     EvcsVCState.CURRENT,
                                     Map.of("reason", "testing")));
+
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
+            evcsService.storeStoredIdentityRecordAndVcs(
                     TEST_USER_ID,
+                    TEST_GOVUK_SIGNIN_JOURNEY_ID,
                     VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS,
                     evcsGetUserVcsWithCurrentStateAllExistingDto,
-                    false);
+                    STRONGEST_MATCHED_VOT_P3,
+                    P2);
 
             // Assert
-            InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-            mockOrderVerifier.verify(mockEvcsClient, times(0)).updateUserVCs(any(), any());
-            mockOrderVerifier.verify(mockEvcsClient, times(0)).storeUserVCs(any(), any());
+            verify(mockEvcsClient, times(1)).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
+            var evcsPostIdentityDto = evcsPostIdentityDtoCaptor.getValue();
+            // We are passing null to omit vcs field
+            // If VCs are present, EVCS expect at least 1 VC to be present in the list
+            assertNull(evcsPostIdentityDto.vcs());
+            assertEquals(TEST_SI_JWT, evcsPostIdentityDto.si().jwt());
+            assertEquals(P3, evcsPostIdentityDto.si().vot());
+            assertEquals(TEST_USER_ID, evcsPostIdentityDto.userId());
+            assertNull(evcsPostIdentityDto.govuk_signin_journey_id());
         }
 
         @Test
         void testStoreCompleteIdentity_whenAllVCsExistInEvcs_inSession_withPendingReturnState()
                 throws Exception {
             // Arrange
+            when(mockStoredIdentityService.getStoredIdentityForEvcs(any(), any(), any(), any()))
+                    .thenReturn(new EvcsStoredIdentityDto(TEST_SI_JWT, P3));
             List<EvcsGetUserVCDto> evcsGetUserVcsWithPendingAllExistingDto =
                     List.of(
                             new EvcsGetUserVCDto(
@@ -248,30 +224,35 @@ class EvcsServiceTest {
                                     EvcsVCState.PENDING_RETURN,
                                     Map.of("reason", "testing")));
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
+            evcsService.storeStoredIdentityRecordAndVcs(
                     TEST_USER_ID,
+                    TEST_GOVUK_SIGNIN_JOURNEY_ID,
                     VERIFIABLE_CREDENTIALS_ALL_EXIST_IN_EVCS,
                     evcsGetUserVcsWithPendingAllExistingDto,
-                    false);
+                    STRONGEST_MATCHED_VOT_P3,
+                    P2);
 
             // Assert
-            InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-            mockOrderVerifier
-                    .verify(mockEvcsClient, times(1))
-                    .updateUserVCs(any(), evcsUpdateUserVCsDtosCaptor.capture());
-            var userVCsToUpdate = evcsUpdateUserVCsDtosCaptor.getValue();
+            verify(mockEvcsClient, times(1)).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
+            var evcsPostIdentityDto = evcsPostIdentityDtoCaptor.getValue();
             assertEquals(
                     3,
-                    (userVCsToUpdate.stream()
-                            .filter(dto -> dto.state().equals(EvcsVCState.CURRENT))
+                    (evcsPostIdentityDto.vcs().stream()
+                            .filter(vc -> vc.state().equals(EvcsVCState.CURRENT))
                             .count()));
-            mockOrderVerifier.verify(mockEvcsClient, times(0)).storeUserVCs(any(), any());
+            assertEquals(TEST_SI_JWT, evcsPostIdentityDto.si().jwt());
+            assertEquals(P3, evcsPostIdentityDto.si().vot());
+            assertEquals(TEST_USER_ID, evcsPostIdentityDto.userId());
+            assertEquals(
+                    TEST_GOVUK_SIGNIN_JOURNEY_ID, evcsPostIdentityDto.govuk_signin_journey_id());
         }
 
         @Test
         void testStoreCompleteIdentity_whenAllVCsExistInEvcs_notInSession_withPendingReturnState()
                 throws Exception {
             // Arrange
+            when(mockStoredIdentityService.getStoredIdentityForEvcs(any(), any(), any(), any()))
+                    .thenReturn(new EvcsStoredIdentityDto(TEST_SI_JWT, P0));
             List<EvcsGetUserVCDto> evcsGetUserVcsWithPendingAllExistingDto =
                     List.of(
                             new EvcsGetUserVCDto(
@@ -287,63 +268,54 @@ class EvcsServiceTest {
                                     EvcsVCState.PENDING_RETURN,
                                     Map.of("reason", "testing")));
             // Act
-            evcsService.storeCompletedOrPendingIdentityWithPostVcs(
-                    TEST_USER_ID, List.of(), evcsGetUserVcsWithPendingAllExistingDto, false);
+            evcsService.storeStoredIdentityRecordAndVcs(
+                    TEST_USER_ID,
+                    TEST_GOVUK_SIGNIN_JOURNEY_ID,
+                    List.of(),
+                    evcsGetUserVcsWithPendingAllExistingDto,
+                    null,
+                    P0);
 
             // Assert
-            InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-            mockOrderVerifier
-                    .verify(mockEvcsClient, times(1))
-                    .updateUserVCs(any(), evcsUpdateUserVCsDtosCaptor.capture());
-            var userVCsToUpdate = evcsUpdateUserVCsDtosCaptor.getValue();
+            verify(mockEvcsClient, times(1)).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
+            var evcsPostIdentityDto = evcsPostIdentityDtoCaptor.getValue();
             assertEquals(
                     3,
-                    (userVCsToUpdate.stream()
-                            .filter(dto -> dto.state().equals(EvcsVCState.ABANDONED))
+                    (evcsPostIdentityDto.vcs().stream()
+                            .filter(vc -> vc.state().equals(EvcsVCState.ABANDONED))
                             .count()));
-            mockOrderVerifier.verify(mockEvcsClient, times(0)).storeUserVCs(any(), any());
+            assertEquals(TEST_SI_JWT, evcsPostIdentityDto.si().jwt());
+            assertEquals(P0, evcsPostIdentityDto.si().vot());
+            assertEquals(TEST_USER_ID, evcsPostIdentityDto.userId());
+            assertEquals(
+                    TEST_GOVUK_SIGNIN_JOURNEY_ID, evcsPostIdentityDto.govuk_signin_journey_id());
         }
     }
 
     @Test
-    void testStorePendingIdentityV2_for_incompleteF2F() throws Exception {
+    void testStorePendingIdentity_for_incompleteF2F() throws Exception {
         // Act
-        evcsService.storePendingIdentityWithPostVcsV2(
+        evcsService.storePendingIdentityWithPostVcs(
                 TEST_USER_ID,
                 TEST_GOVUK_SIGNIN_JOURNEY_ID,
                 VERIFIABLE_CREDENTIALS_ONE_EXIST_IN_EVCS,
                 List.of());
 
         // Assert
-        verify(mockEvcsClient, never()).updateUserVcsV2(any());
-        verify(mockEvcsClient).storeUserVcsV2(evcsCreateRequestBodyCaptor.capture());
+        verify(mockEvcsClient, never()).updateUserVcs(any());
+        verify(mockEvcsClient).storeUserVcs(evcsCreateRequestBodyCaptor.capture());
         var requestBody = evcsCreateRequestBodyCaptor.getValue();
         assertFalse(
                 requestBody.vcs().stream().anyMatch(dto -> !dto.state().equals(PENDING_RETURN)));
     }
 
     @Test
-    void storeAsyncVcShouldStoreVcWithPendingReturnState() throws EvcsServiceException {
-        evcsService.storePendingVc(VC_ADDRESS_TEST);
-
-        verify(mockEvcsClient)
-                .storeUserVCs(
-                        stringArgumentCaptor.capture(), evcsCreateUserVCsDtosCaptor.capture());
-
-        assertEquals(VC_ADDRESS_TEST.getUserId(), stringArgumentCaptor.getValue());
-        assertEquals(
-                VC_ADDRESS_TEST.getVcString(), evcsCreateUserVCsDtosCaptor.getValue().get(0).vc());
-        assertEquals(PENDING_RETURN, evcsCreateUserVCsDtosCaptor.getValue().get(0).state());
-        assertEquals(OFFLINE, evcsCreateUserVCsDtosCaptor.getValue().get(0).provenance());
-    }
-
-    @Test
-    void storePendingVcV2ShouldStoreVcWithPendingReturnState() throws EvcsServiceException {
+    void storePendingVcShouldStoreVcWithPendingReturnState() throws EvcsServiceException {
         // Act
-        evcsService.storePendingVcV2(VC_ADDRESS_TEST, TEST_GOVUK_SIGNIN_JOURNEY_ID);
+        evcsService.storePendingVc(VC_ADDRESS_TEST, TEST_GOVUK_SIGNIN_JOURNEY_ID);
 
         // Assert
-        verify(mockEvcsClient).storeUserVcsV2(evcsCreateRequestBodyCaptor.capture());
+        verify(mockEvcsClient).storeUserVcs(evcsCreateRequestBodyCaptor.capture());
         var requestBody = evcsCreateRequestBodyCaptor.getValue();
         assertEquals(VC_ADDRESS_TEST.getUserId(), requestBody.userId());
         assertEquals(TEST_GOVUK_SIGNIN_JOURNEY_ID, requestBody.govuk_signin_journey_id());
@@ -354,42 +326,6 @@ class EvcsServiceTest {
 
     @Test
     void abandonPendingIdentityShouldUpdateStateToAbandoned() throws EvcsServiceException {
-        EvcsGetUserVCsDto evcsGetUserVcsWithPendingAllExistingDto =
-                new EvcsGetUserVCsDto(
-                        List.of(
-                                new EvcsGetUserVCDto(
-                                        VC_ADDRESS_TEST.getVcString(),
-                                        EvcsVCState.PENDING_RETURN,
-                                        Map.of("reason", "testing")),
-                                new EvcsGetUserVCDto(
-                                        vcExperianFraudM1a().getVcString(),
-                                        EvcsVCState.PENDING_RETURN,
-                                        Map.of("reason", "testing"))),
-                        null);
-        when(mockEvcsClient.getUserVcs(
-                        TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, List.of(PENDING_RETURN)))
-                .thenReturn(evcsGetUserVcsWithPendingAllExistingDto);
-        evcsService.abandonPendingIdentity(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN);
-
-        InOrder mockOrderVerifier = inOrder(mockEvcsClient);
-        mockOrderVerifier
-                .verify(mockEvcsClient)
-                .getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, List.of(PENDING_RETURN));
-        mockOrderVerifier
-                .verify(mockEvcsClient)
-                .updateUserVCs(
-                        stringArgumentCaptor.capture(), evcsUpdateUserVCsDtosCaptor.capture());
-
-        var userVCsToUpdate = evcsUpdateUserVCsDtosCaptor.getValue();
-        assertEquals(
-                2,
-                (userVCsToUpdate.stream()
-                        .filter(dto -> dto.state().equals(EvcsVCState.ABANDONED))
-                        .count()));
-    }
-
-    @Test
-    void abandonPendingIdentityV2ShouldUpdateStateToAbandoned() throws EvcsServiceException {
         // Arrange
         EvcsGetUserVCsDto evcsGetUserVcsWithPendingAllExistingDto =
                 new EvcsGetUserVCsDto(
@@ -408,7 +344,7 @@ class EvcsServiceTest {
                 .thenReturn(evcsGetUserVcsWithPendingAllExistingDto);
 
         // Act
-        evcsService.abandonPendingIdentityV2(
+        evcsService.abandonPendingIdentity(
                 TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, TEST_GOVUK_SIGNIN_JOURNEY_ID);
 
         // Assert
@@ -418,7 +354,7 @@ class EvcsServiceTest {
                 .getUserVcs(TEST_USER_ID, TEST_EVCS_ACCESS_TOKEN, List.of(PENDING_RETURN));
         mockOrderVerifier
                 .verify(mockEvcsClient)
-                .updateUserVcsV2(evcsUpdateRequestBodyCaptor.capture());
+                .updateUserVcs(evcsUpdateRequestBodyCaptor.capture());
         var requestBody = evcsUpdateRequestBodyCaptor.getValue();
         assertEquals(TEST_USER_ID, requestBody.userId());
         assertEquals(TEST_GOVUK_SIGNIN_JOURNEY_ID, requestBody.govuk_signin_journey_id());
@@ -596,30 +532,6 @@ class EvcsServiceTest {
                         .count()));
     }
 
-    @Test
-    void shouldStoreStoredIdentityRecord() throws Exception {
-        // Arrange
-        var testVcs = List.of(VC_ADDRESS_TEST);
-        var testSiJwt = "test.si.jwt";
-
-        when(mockStoredIdentityService.getStoredIdentityForEvcs(
-                        TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT))
-                .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
-
-        // Act
-        evcsService.storeStoredIdentityRecord(
-                TEST_USER_ID, testVcs, STRONGEST_MATCHED_VOT, ACHIEVED_VOT);
-
-        // Assert
-        verify(mockEvcsClient).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
-
-        assertEquals(testSiJwt, evcsPostIdentityDtoCaptor.getValue().si().jwt());
-        assertEquals(P1, evcsPostIdentityDtoCaptor.getValue().si().vot());
-
-        verify(mockEvcsClient, never()).updateUserVCs(any(), any());
-        verify(mockEvcsClient, never()).storeUserVCs(any(), any());
-    }
-
     private List<EvcsCreateUserVCsDto> extractVcsFromDto(
             EvcsVCState evcsVCState, EvcsPostIdentityDto evcsPostIdentityDto) {
         return evcsPostIdentityDto.vcs().stream()
@@ -628,15 +540,14 @@ class EvcsServiceTest {
     }
 
     @Test
-    void shouldStoreStoredIdentityRecordAndVcs()
+    void shouldStoreStoredIdentityRecordAndVcsAndUpdateStateOfExistingVcs()
             throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
         // Arrange
-        var testSiJwt = "test.si.jwt";
         var credentials = List.of(VC_ADDRESS_TEST);
 
         when(mockStoredIdentityService.getStoredIdentityForEvcs(
                         TEST_USER_ID, credentials, STRONGEST_MATCHED_VOT, ACHIEVED_VOT))
-                .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
+                .thenReturn(new EvcsStoredIdentityDto(TEST_SI_JWT, P1));
 
         // Act
         evcsService.storeStoredIdentityRecordAndVcs(
@@ -650,25 +561,28 @@ class EvcsServiceTest {
         // Assert
         verify(mockEvcsClient, times(1)).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
 
-        assertEquals(testSiJwt, evcsPostIdentityDtoCaptor.getValue().si().jwt());
+        assertEquals(TEST_SI_JWT, evcsPostIdentityDtoCaptor.getValue().si().jwt());
         assertEquals(P1, evcsPostIdentityDtoCaptor.getValue().si().vot());
         assertEquals(4, evcsPostIdentityDtoCaptor.getValue().vcs().size());
 
-        var extractVcsFromDto = evcsPostIdentityDtoCaptor.getValue();
-        var abandonedVcs = extractVcsFromDto(ABANDONED, extractVcsFromDto).size();
-        var historicVcs = extractVcsFromDto(HISTORIC, extractVcsFromDto).size();
-        var currentVcs = extractVcsFromDto(CURRENT, extractVcsFromDto).size();
+        var evcsPostIdentityDto = evcsPostIdentityDtoCaptor.getValue();
+        var abandonedVcsCount = extractVcsFromDto(ABANDONED, evcsPostIdentityDto).size();
+        var historicVcsCount = extractVcsFromDto(HISTORIC, evcsPostIdentityDto).size();
+        var currentVcsCount = extractVcsFromDto(CURRENT, evcsPostIdentityDto).size();
 
-        assertEquals(1, abandonedVcs);
-        assertEquals(2, historicVcs);
-        assertEquals(1, currentVcs);
+        assertEquals(1, abandonedVcsCount);
+        assertEquals(2, historicVcsCount);
+        assertEquals(1, currentVcsCount);
+        assertEquals(TEST_SI_JWT, evcsPostIdentityDto.si().jwt());
+        assertEquals(P1, evcsPostIdentityDto.si().vot());
+        assertEquals(TEST_USER_ID, evcsPostIdentityDto.userId());
+        assertEquals(TEST_GOVUK_SIGNIN_JOURNEY_ID, evcsPostIdentityDto.govuk_signin_journey_id());
     }
 
     @Test
     void shouldStoreStoredIdentityRecordAndPendingReturnVcsExistingInEvcs()
             throws FailedToCreateStoredIdentityForEvcsException, EvcsServiceException {
         // Arrange
-        var testSiJwt = "test.si.jwt";
         var credentials = List.of(VC_ADDRESS_TEST);
 
         var existingGetUserVcDto =
@@ -680,7 +594,7 @@ class EvcsServiceTest {
 
         when(mockStoredIdentityService.getStoredIdentityForEvcs(
                         TEST_USER_ID, credentials, STRONGEST_MATCHED_VOT, ACHIEVED_VOT))
-                .thenReturn(new EvcsStoredIdentityDto(testSiJwt, P1));
+                .thenReturn(new EvcsStoredIdentityDto(TEST_SI_JWT, P1));
 
         // Act
         evcsService.storeStoredIdentityRecordAndVcs(
@@ -695,7 +609,7 @@ class EvcsServiceTest {
         verify(mockEvcsClient, times(1)).storeUserIdentity(evcsPostIdentityDtoCaptor.capture());
         var extractVcsFromDto = evcsPostIdentityDtoCaptor.getValue();
 
-        assertEquals(testSiJwt, extractVcsFromDto.si().jwt());
+        assertEquals(TEST_SI_JWT, extractVcsFromDto.si().jwt());
         assertEquals(P1, extractVcsFromDto.si().vot());
         assertEquals(1, extractVcsFromDto.vcs().size());
         assertEquals(CURRENT, extractVcsFromDto.vcs().getFirst().state());
@@ -711,29 +625,13 @@ class EvcsServiceTest {
     }
 
     @Test
-    void markVcsAsHistoricInEvcsShouldUpdateEvcsWithHistoricVcs() throws Exception {
+    void markHistoricInEvcsShouldUpdateEvcsWithHistoricVcs() throws Exception {
         // Act
-        evcsService.markHistoricInEvcs(TEST_USER_ID, List.of(VC_DRIVING_PERMIT_TEST));
-
-        // Assert
-        verify(mockEvcsClient, times(1))
-                .updateUserVCs(eq(TEST_USER_ID), evcsUpdateUserVCsDtosCaptor.capture());
-        var evcsUserVCsToUpdate = evcsUpdateUserVCsDtosCaptor.getValue();
-        assertEquals(
-                1,
-                (evcsUserVCsToUpdate.stream()
-                        .filter(dto -> dto.state().equals(EvcsVCState.HISTORIC))
-                        .count()));
-    }
-
-    @Test
-    void markHistoricInEvcsV2ShouldUpdateEvcsWithHistoricVcs() throws Exception {
-        // Act
-        evcsService.markHistoricInEvcsV2(
+        evcsService.markHistoricInEvcs(
                 TEST_USER_ID, TEST_GOVUK_SIGNIN_JOURNEY_ID, List.of(VC_DRIVING_PERMIT_TEST));
 
         // Assert
-        verify(mockEvcsClient, times(1)).updateUserVcsV2(evcsUpdateRequestBodyCaptor.capture());
+        verify(mockEvcsClient, times(1)).updateUserVcs(evcsUpdateRequestBodyCaptor.capture());
         var requestBody = evcsUpdateRequestBodyCaptor.getValue();
         assertEquals(TEST_USER_ID, requestBody.userId());
         assertEquals(TEST_GOVUK_SIGNIN_JOURNEY_ID, requestBody.govuk_signin_journey_id());
@@ -742,20 +640,11 @@ class EvcsServiceTest {
     }
 
     @Test
-    void markVcsAsHistoricInEvcsShouldNotCallEvcsIfGivenEmptyList() throws Exception {
+    void markHistoricInEvcsShouldNotCallEvcsIfGivenEmptyList() throws Exception {
         // Act
-        evcsService.markHistoricInEvcs(TEST_USER_ID, List.of());
+        evcsService.markHistoricInEvcs(TEST_USER_ID, TEST_GOVUK_SIGNIN_JOURNEY_ID, List.of());
 
         // Assert
-        verify(mockEvcsClient, times(0)).updateUserVCs(eq(TEST_USER_ID), any());
-    }
-
-    @Test
-    void markHistoricInEvcsV2ShouldNotCallEvcsIfGivenEmptyList() throws Exception {
-        // Act
-        evcsService.markHistoricInEvcsV2(TEST_USER_ID, TEST_GOVUK_SIGNIN_JOURNEY_ID, List.of());
-
-        // Assert
-        verify(mockEvcsClient, never()).updateUserVcsV2(any());
+        verify(mockEvcsClient, never()).updateUserVcs(any());
     }
 }

--- a/local-running/core.local.params.yaml
+++ b/local-running/core.local.params.yaml
@@ -385,7 +385,6 @@ core:
   featureFlags:
     drivingLicenceAuthCheck: true
     sisVerificationEnabled: true
-    evcsApiUpdatesEnabled: true
     mitigations9020Enabled: false
 
   features:
@@ -403,9 +402,6 @@ core:
     mitigations9020Disabled:
       featureFlags:
         mitigations9020Enabled: false
-    evcsApiUpdates:
-        featureFlags:
-          evcsApiUpdatesEnabled: true
     zeroHourFraudVcExpiry:
       self:
         fraudCheckExpiryPeriodDays: 0


### PR DESCRIPTION
## Proposed changes
### What changed

- Removed EVCS_API_UPDATES feature flag from codebase.

### Why did it change

- It's already enabled in production for few weeks, we had time to observe and we can now remove old code.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9011](https://govukverify.atlassian.net/browse/PYIC-9011)

## Checklists

- [x] READMEs and documentation up-to-date
- [x] API/ unit/ contract tests have been written/ updated
- [x] No risk of exposure: PII, credentials, etc through logs/ code
- [x] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-9011]: https://govukverify.atlassian.net/browse/PYIC-9011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ