### PR TITLE
PYIC-8990: Bump Mockito dependency to 5.23.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 awsSdk = "2.54.7"
 jackson = "2.22.1"
 log4j = "2.26.1"
-mockito = "5.21.0"
+mockito = "5.23.0"
 pact = "4.7.3"
 powertools = "2.10.0"
 

--- a/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionGpg45ProfileMatchedTest.java
+++ b/libs/audit-service/src/test/java/uk/gov/di/ipv/core/library/auditing/extension/AuditExtensionGpg45ProfileMatchedTest.java
@@ -10,34 +10,29 @@ import uk.gov.di.ipv.core.library.auditing.AuditEventTypes;
 import uk.gov.di.ipv.core.library.auditing.AuditEventUser;
 import uk.gov.di.ipv.core.library.gpg45.Gpg45Scores;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.core.library.gpg45.enums.Gpg45Profile.M1A;
 
 class AuditExtensionGpg45ProfileMatchedTest {
 
     private static final ObjectMapper om = new ObjectMapper();
-    private static MockedStatic<Clock> clockMock;
+    private static MockedStatic<Instant> instantMock;
+    private static final Instant FIXED_INSTANT = Instant.ofEpochMilli(1666170506321L);
 
     @BeforeAll
     public static void setup() {
-        clockMock = mockStatic(Clock.class);
-        Clock spyClock = spy(Clock.class);
-        clockMock.when(Clock::systemUTC).thenReturn(spyClock);
-        Instant instantValue = Instant.ofEpochMilli(1666170506321L);
-        when(spyClock.instant()).thenReturn(instantValue);
-        when(spyClock.instant().now()).thenReturn(instantValue);
+        instantMock = mockStatic(Instant.class, CALLS_REAL_METHODS);
+        instantMock.when(Instant::now).thenReturn(FIXED_INSTANT);
     }
 
     @AfterAll
     public static void tearDown() {
-        clockMock.close();
+        instantMock.close();
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes
### What changed

- Bump Mockito dependency to 5.23.0
- Mock Instant.now() directly instead of chaining clock mocking, which previously leaked static Instant behavior under older Mockito versions and caused serialization assertion failures.

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-8990](https://govukverify.atlassian.net/browse/PYIC-8990)

## Checklists

- [ ] READMEs and documentation up-to-date
- [ ] API/ unit/ contract tests have been written/ updated
- [ ] No risk of exposure: PII, credentials, etc through logs/ code
- [ ] Production changes appropriately staged out
    <details>
        <summary>Canary deployment considerations</summary>
        We use Canary deployments in build and prod meaning for a period of time, we might
        be using different versions of our lambdas.
        <ul>
        <li> API calls within core-back (via the step function) uses a consistent set of lambdas
          e.g. the result of <code>process-candidate-identity</code> is passed to <code>process-journey-event</code>
          by the journey engine step function.</li>
        <li>API calls into core-back, such as from core-front, might use different versions e.g.
          core-front makes a call to <code>process-cri-callback</code> then will pass the result from that to
          <code>process-journey-event</code>.</li>
        </ul>
    </details>


[PYIC-8990]: https://govukverify.atlassian.net/browse/PYIC-8990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ