### PR TITLE
PYIC-9151: Use new page variant for DWP dropout

### DIFF
--- a/api-tests/features/audit-events.feature
+++ b/api-tests/features/audit-events.feature
@@ -773,7 +773,9 @@ Feature: Audit Events
       When I call the CRI stub with attributes and get an 'access_denied' OAuth error with error description 'user_abandoned'
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       And audit events for 'dwp-kbv-dropout-user-abandons-cri-no-open-banking' are recorded [local only]
 
   Rule: DWP KBV
@@ -843,5 +845,7 @@ Feature: Audit Events
       When I call the CRI stub with attributes and get an 'access_denied' OAuth error with error description 'user_abandoned'
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       And audit events for 'dwp-kbv-dropout-user-abandons-cri' are recorded [local only]

--- a/api-tests/features/dwp-kbv/p1-alternate-doc-mitigation.feature
+++ b/api-tests/features/dwp-kbv/p1-alternate-doc-mitigation.feature
@@ -76,7 +76,9 @@ Feature: P1 CIMIT - Alternate doc - DWP KBV
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
     Then I get a 'page-different-security-questions' page response
     When I submit a 'next' event
-    Then I get a 'page-pre-experian-kbv-transition' page response
+    Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+      | Context      | Value  |
+      | isDwpDropout | true   |
     When I submit a 'next' event
     Then I get a 'experianKbv' CRI response
     When I submit 'kenneth-score-1' details with attributes to the CRI stub

--- a/api-tests/features/dwp-kbv/p1-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p1-web-journey.feature
@@ -160,7 +160,9 @@ Feature: P1 Web Journeys - DWP KBV
       When I call the CRI stub with attributes and get an 'access_denied' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       When I submit a 'next' event
       Then I get a 'experianKbv' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub

--- a/api-tests/features/dwp-kbv/p1-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p1-web-journey.feature
@@ -69,7 +69,9 @@ Feature: P1 Web Journeys - DWP KBV
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
       Then I get a 'page-different-security-questions' page response
       When I submit a 'next' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       When I submit a 'next' event
       Then I get a 'experianKbv' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub

--- a/api-tests/features/dwp-kbv/p2-alternate-doc-mitigation.feature
+++ b/api-tests/features/dwp-kbv/p2-alternate-doc-mitigation.feature
@@ -102,7 +102,9 @@ Feature: P2 CIMIT - Alternate doc - DWP KBV
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
       Then I get a 'page-different-security-questions' page response
       When I submit a 'next' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       When I submit a 'next' event
       Then I get a 'experianKbv' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub
@@ -286,7 +288,9 @@ Feature: P2 CIMIT - Alternate doc - DWP KBV
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
       Then I get a 'page-different-security-questions' page response
       When I submit a 'next' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       When I submit a 'next' event
       Then I get a 'experianKbv' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub

--- a/api-tests/features/dwp-kbv/p2-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p2-web-journey.feature
@@ -300,7 +300,9 @@ Feature: P2 Web document journey - DWP KBV
       When I call the CRI stub with attributes and get an '<oauth_error>' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       When I submit a 'next' event
       Then I get a 'experianKbv' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub
@@ -609,7 +611,9 @@ Feature: P2 Web document journey - DWP KBV
       When I call the CRI stub with attributes and get an '<oauth_error>' OAuth error
         | Attribute          | Values                                          |
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       When I submit a 'next' event
       Then I get a 'experianKbv' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub

--- a/api-tests/features/dwp-kbv/p2-web-journey.feature
+++ b/api-tests/features/dwp-kbv/p2-web-journey.feature
@@ -252,7 +252,9 @@ Feature: P2 Web document journey - DWP KBV
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
       Then I get a 'page-different-security-questions' page response
       When I submit a 'next' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       When I submit a 'next' event
       Then I get a 'experianKbv' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub
@@ -575,7 +577,9 @@ Feature: P2 Web document journey - DWP KBV
         | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":2} |
       Then I get a 'page-different-security-questions' page response
       When I submit a 'next' event
-      Then I get a 'page-pre-experian-kbv-transition' page response
+      Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+        | Context      | Value  |
+        | isDwpDropout | true   |
       When I submit a 'next' event
       Then I get a 'experianKbv' CRI response
       When I submit 'kenneth-score-2' details with attributes to the CRI stub

--- a/api-tests/features/p1-no-photo-id.feature
+++ b/api-tests/features/p1-no-photo-id.feature
@@ -197,7 +197,9 @@ Feature: P1 No Photo Id Journey
     When I call the CRI stub with attributes and get an 'access_denied' OAuth error
       | Attribute          | Values                                          |
       | evidence_requested | {"scoringPolicy":"gpg45","verificationScore":1} |
-    Then I get a 'page-pre-experian-kbv-transition' page response
+    Then I get a 'page-pre-experian-kbv-transition' page response and pageContext
+      | Context      | Value  |
+      | isDwpDropout | true   |
     When I submit a 'next' event
     Then I get a 'experianKbv' CRI response
     When I submit 'kenneth-score-2' details with attributes to the CRI stub

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/AbstractPageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/AbstractPageContextValidator.java
@@ -15,6 +15,7 @@ public abstract class AbstractPageContextValidator implements IPageContextValida
     public static final String INVALID_DOC = "invalidDoc";
     public static final String REMOVE_F2F = "removeF2f";
     public static final String NINO_ONLY = "ninoOnly";
+    public static final String IS_DWP_DROPOUT = "isDwpDropout";
     public static final String IS_UNRECOVERABLE = "isUnrecoverable";
     public static final String SMARTPHONE = "smartphone";
     public static final String IS_APP_ONLY = "isAppOnly";

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -13,6 +13,7 @@ public class PageContextValidator extends AbstractPageContextValidator {
                     Map.entry("page-dcmaw-success", Set.of(NO_ADDRESS)),
                     Map.entry("page-ipv-success", Set.of(JOURNEY_TYPE)),
                     Map.entry("page-multiple-doc-check", Set.of(ALLOW_NINO)),
+                    Map.entry("page-pre-experian-kbv-transition", Set.of(IS_DWP_DROPOUT)),
                     Map.entry("page-update-name", Set.of(JOURNEY_TYPE)),
                     Map.entry("photo-id-web-find-another-way", Set.of(REASON)),
                     Map.entry("prove-identity-another-type-photo-id", Set.of(INVALID_DOC)),

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -100,4 +100,4 @@ nestedJourneyStates:
       pageId: page-different-security-questions
     events:
       next:
-        targetState: PRE_EXPERIAN_PAGE
+        targetState: DWP_DROPOUT_PAGE

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/nested-journeys/kbvs.yaml
@@ -26,9 +26,9 @@ nestedJourneyStates:
         auditEvents:
           - IPV_DWP_KBV_CRI_THIN_FILE_ENCOUNTERED
       access-denied:
-        targetState: PRE_EXPERIAN_PAGE
+        targetState: DWP_DROPOUT_PAGE
       error:
-        targetState: PRE_EXPERIAN_PAGE
+        targetState: DWP_DROPOUT_PAGE
       fail-with-ci:
         exitEventToEmit: fail-with-ci
   EXPERIAN_KBV_CRI:
@@ -64,6 +64,15 @@ nestedJourneyStates:
     response:
       type: page
       pageId: page-pre-experian-kbv-transition
+    events:
+      next:
+        targetState: EXPERIAN_KBV_CRI
+  DWP_DROPOUT_PAGE:
+    response:
+      type: page
+      pageId: page-pre-experian-kbv-transition
+      pageContext:
+        isDwpDropout: true
     events:
       next:
         targetState: EXPERIAN_KBV_CRI


### PR DESCRIPTION
DO NOT MERGE until QA review in dev env

## Proposed changes
### What changed

Use new DWP dropout page

### Why did it change

To improve UX

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9151](https://govukverify.atlassian.net/browse/PYIC-9151)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated

[PYIC-9151]: https://govukverify.atlassian.net/browse/PYIC-9151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ