### PR TITLE
PYIC-9248: Use new page variant for open banking

### DIFF
--- a/api-tests/features/p2-no-photo-id.feature
+++ b/api-tests/features/p2-no-photo-id.feature
@@ -584,7 +584,9 @@ Feature: P2 no photo id journey
       When I call the CRI stub with attributes and get an 'access_denied' OAuth error
         | Attribute          | Values                                      |
         | evidence_requested | {"scoringPolicy":"gpg45","strengthScore":2} |
-      Then I get a 'no-photo-id-abandon-find-another-way' page response
+      Then I get a 'no-photo-id-abandon-find-another-way' page response and pageContext
+        | Context        | Value |
+        | isOpenBanking  | true  |
 
     Scenario: P2 no photo id journey - Abandon - Strategic app
       Given I activate the 'strategicApp' feature set

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/AbstractPageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/AbstractPageContextValidator.java
@@ -22,6 +22,7 @@ public abstract class AbstractPageContextValidator implements IPageContextValida
     public static final String IS_EXISTING_IDENTITY_VALID = "isExistingIdentityValid";
     public static final String IS_EXISTING_IDENTITY_INVALID = "isExistingIdentityInvalid";
     public static final String IS_FROM_STRATEGIC_APP = "isFromStrategicApp";
+    public static final String IS_OPEN_BANKING = "isOpenBanking";
     public static final String PHOTO_ID = "photoId";
 
     @Override

--- a/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
+++ b/lambdas/process-journey-event/src/main/java/uk/gov/di/ipv/core/processjourneyevent/statemachine/validators/PageContextValidator.java
@@ -10,6 +10,7 @@ public class PageContextValidator extends AbstractPageContextValidator {
                     Map.entry("delete-handover", Set.of(JOURNEY_TYPE)),
                     Map.entry("need-more-information-confirm-change-details", Set.of(JOURNEY_TYPE)),
                     Map.entry("no-photo-id-web-find-another-way", Set.of(REASON)),
+                    Map.entry("no-photo-id-abandon-find-another-way", Set.of(IS_OPEN_BANKING)),
                     Map.entry("page-dcmaw-success", Set.of(NO_ADDRESS)),
                     Map.entry("page-ipv-success", Set.of(JOURNEY_TYPE)),
                     Map.entry("page-multiple-doc-check", Set.of(ALLOW_NINO)),

--- a/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
+++ b/lambdas/process-journey-event/src/main/resources/statemachine/journey-maps/new-p2-identity.yaml
@@ -792,7 +792,7 @@ states:
       next:
         targetState: ADDRESS_AND_FRAUD_NO_PHOTO_ID_OPEN_BANKING
       access-denied:
-        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID
+        targetState: PYI_ESCAPE_ABANDON_NO_PHOTO_ID_OPEN_BANKING
       fail-with-ci:
         targetJourney: FAILED
         targetState: FAILED_NINO
@@ -956,6 +956,31 @@ states:
     response:
       type: page
       pageId: no-photo-id-abandon-find-another-way
+    events:
+      mobileApp:
+        targetState: STRATEGIC_APP_TRIAGE
+        targetEntryEvent: appTriage
+        checkIfDisabled:
+          dcmawAsync:
+            targetJourney: TECHNICAL_ERROR
+            targetState: ERROR
+      passport:
+        targetState: WEB_DL_OR_PASSPORT
+        targetEntryEvent: ukPassport
+      drivingLicence:
+        targetState: WEB_DL_OR_PASSPORT
+      postOffice:
+        targetState: CRI_CLAIMED_IDENTITY_J4
+      relyingParty:
+        targetJourney: INELIGIBLE
+        targetState: INELIGIBLE_SKIP_MESSAGE
+
+  PYI_ESCAPE_ABANDON_NO_PHOTO_ID_OPEN_BANKING:
+    response:
+      type: page
+      pageId: no-photo-id-abandon-find-another-way
+      pageContext:
+        isOpenBanking: true
     events:
       mobileApp:
         targetState: STRATEGIC_APP_TRIAGE


### PR DESCRIPTION
DO NOT MERGE until https://github.com/govuk-one-login/ipv-core-front/pull/3050 is merged and deployed

## Proposed changes
### What changed

New wording for Open Banking NINO drop out

### Why did it change

To improve UX

### Issue tracking
<!-- Jira ticket & other docs, like RFCs -->

- [PYIC-9248](https://govukverify.atlassian.net/browse/PYIC-9248)

## Checklists

- [x] API/ unit/ contract tests have been written/ updated


[PYIC-9248]: https://govukverify.atlassian.net/browse/PYIC-9248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ